### PR TITLE
feat: US 1.3 - Agent Status Management API

### DIFF
--- a/src/AIAgentPlatform.API/Controllers/AgentsController.cs
+++ b/src/AIAgentPlatform.API/Controllers/AgentsController.cs
@@ -106,4 +106,43 @@ public sealed class AgentsController : ControllerBase
         await _sender.Send(command, cancellationToken);
         return NoContent();
     }
+
+    /// <summary>
+    /// Activate an agent (change status to Active)
+    /// </summary>
+    [HttpPost("{id:guid}/activate")]
+    [ProducesResponseType(typeof(AgentDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AgentDto>> Activate(Guid id, CancellationToken cancellationToken)
+    {
+        var command = new ActivateAgentCommand { Id = id };
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Pause an agent (change status to Paused)
+    /// </summary>
+    [HttpPost("{id:guid}/pause")]
+    [ProducesResponseType(typeof(AgentDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AgentDto>> Pause(Guid id, CancellationToken cancellationToken)
+    {
+        var command = new PauseAgentCommand { Id = id };
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Archive an agent (change status to Archived - soft delete)
+    /// </summary>
+    [HttpPost("{id:guid}/archive")]
+    [ProducesResponseType(typeof(AgentDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<AgentDto>> Archive(Guid id, CancellationToken cancellationToken)
+    {
+        var command = new ArchiveAgentCommand { Id = id };
+        var result = await _sender.Send(command, cancellationToken);
+        return Ok(result);
+    }
 }

--- a/src/AIAgentPlatform.Application/Agents/Commands/ActivateAgentCommand.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/ActivateAgentCommand.cs
@@ -1,0 +1,12 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Command to activate an agent
+/// </summary>
+public sealed record ActivateAgentCommand : IRequest<AgentDto>
+{
+    public Guid Id { get; init; }
+}

--- a/src/AIAgentPlatform.Application/Agents/Commands/ActivateAgentCommandHandler.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/ActivateAgentCommandHandler.cs
@@ -1,0 +1,48 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using AIAgentPlatform.Domain.Exceptions;
+using AIAgentPlatform.Domain.Interfaces;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Handler for ActivateAgentCommand
+/// </summary>
+public sealed class ActivateAgentCommandHandler : IRequestHandler<ActivateAgentCommand, AgentDto>
+{
+    private readonly IAgentRepository _agentRepository;
+
+    public ActivateAgentCommandHandler(IAgentRepository agentRepository)
+    {
+        _agentRepository = agentRepository;
+    }
+
+    public async Task<AgentDto> Handle(ActivateAgentCommand request, CancellationToken cancellationToken)
+    {
+        // Get existing agent
+        var agent = await _agentRepository.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new AgentNotFoundException(request.Id);
+
+        // Activate agent
+        agent.Activate();
+
+        // Persist changes
+        await _agentRepository.UpdateAsync(agent, cancellationToken);
+
+        // Map to DTO
+        return new AgentDto
+        {
+            Id = agent.Id,
+            UserId = agent.UserId,
+            Name = agent.Name,
+            Description = agent.Description,
+            Instructions = agent.Instructions,
+            Model = agent.Model.Value,
+            Temperature = agent.Temperature,
+            MaxTokens = agent.MaxTokens,
+            Status = agent.Status.Value,
+            CreatedAt = agent.CreatedAt,
+            UpdatedAt = agent.UpdatedAt
+        };
+    }
+}

--- a/src/AIAgentPlatform.Application/Agents/Commands/ArchiveAgentCommand.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/ArchiveAgentCommand.cs
@@ -1,0 +1,12 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Command to archive an agent (soft delete alternative)
+/// </summary>
+public sealed record ArchiveAgentCommand : IRequest<AgentDto>
+{
+    public Guid Id { get; init; }
+}

--- a/src/AIAgentPlatform.Application/Agents/Commands/ArchiveAgentCommandHandler.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/ArchiveAgentCommandHandler.cs
@@ -1,0 +1,48 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using AIAgentPlatform.Domain.Exceptions;
+using AIAgentPlatform.Domain.Interfaces;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Handler for ArchiveAgentCommand
+/// </summary>
+public sealed class ArchiveAgentCommandHandler : IRequestHandler<ArchiveAgentCommand, AgentDto>
+{
+    private readonly IAgentRepository _agentRepository;
+
+    public ArchiveAgentCommandHandler(IAgentRepository agentRepository)
+    {
+        _agentRepository = agentRepository;
+    }
+
+    public async Task<AgentDto> Handle(ArchiveAgentCommand request, CancellationToken cancellationToken)
+    {
+        // Get existing agent
+        var agent = await _agentRepository.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new AgentNotFoundException(request.Id);
+
+        // Archive agent
+        agent.Archive();
+
+        // Persist changes
+        await _agentRepository.UpdateAsync(agent, cancellationToken);
+
+        // Map to DTO
+        return new AgentDto
+        {
+            Id = agent.Id,
+            UserId = agent.UserId,
+            Name = agent.Name,
+            Description = agent.Description,
+            Instructions = agent.Instructions,
+            Model = agent.Model.Value,
+            Temperature = agent.Temperature,
+            MaxTokens = agent.MaxTokens,
+            Status = agent.Status.Value,
+            CreatedAt = agent.CreatedAt,
+            UpdatedAt = agent.UpdatedAt
+        };
+    }
+}

--- a/src/AIAgentPlatform.Application/Agents/Commands/PauseAgentCommand.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/PauseAgentCommand.cs
@@ -1,0 +1,12 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Command to pause an agent
+/// </summary>
+public sealed record PauseAgentCommand : IRequest<AgentDto>
+{
+    public Guid Id { get; init; }
+}

--- a/src/AIAgentPlatform.Application/Agents/Commands/PauseAgentCommandHandler.cs
+++ b/src/AIAgentPlatform.Application/Agents/Commands/PauseAgentCommandHandler.cs
@@ -1,0 +1,48 @@
+using AIAgentPlatform.Application.Agents.DTOs;
+using AIAgentPlatform.Domain.Exceptions;
+using AIAgentPlatform.Domain.Interfaces;
+using MediatR;
+
+namespace AIAgentPlatform.Application.Agents.Commands;
+
+/// <summary>
+/// Handler for PauseAgentCommand
+/// </summary>
+public sealed class PauseAgentCommandHandler : IRequestHandler<PauseAgentCommand, AgentDto>
+{
+    private readonly IAgentRepository _agentRepository;
+
+    public PauseAgentCommandHandler(IAgentRepository agentRepository)
+    {
+        _agentRepository = agentRepository;
+    }
+
+    public async Task<AgentDto> Handle(PauseAgentCommand request, CancellationToken cancellationToken)
+    {
+        // Get existing agent
+        var agent = await _agentRepository.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new AgentNotFoundException(request.Id);
+
+        // Pause agent
+        agent.Pause();
+
+        // Persist changes
+        await _agentRepository.UpdateAsync(agent, cancellationToken);
+
+        // Map to DTO
+        return new AgentDto
+        {
+            Id = agent.Id,
+            UserId = agent.UserId,
+            Name = agent.Name,
+            Description = agent.Description,
+            Instructions = agent.Instructions,
+            Model = agent.Model.Value,
+            Temperature = agent.Temperature,
+            MaxTokens = agent.MaxTokens,
+            Status = agent.Status.Value,
+            CreatedAt = agent.CreatedAt,
+            UpdatedAt = agent.UpdatedAt
+        };
+    }
+}

--- a/tests/AIAgentPlatform.UnitTests/Application/Commands/AgentStatusCommandTests.cs
+++ b/tests/AIAgentPlatform.UnitTests/Application/Commands/AgentStatusCommandTests.cs
@@ -1,0 +1,210 @@
+using AIAgentPlatform.Application.Agents.Commands;
+using AIAgentPlatform.Domain.Entities;
+using AIAgentPlatform.Domain.Exceptions;
+using AIAgentPlatform.Domain.Interfaces;
+using AIAgentPlatform.Domain.ValueObjects;
+using FluentAssertions;
+using Moq;
+
+namespace AIAgentPlatform.UnitTests.Application.Commands;
+
+public sealed class AgentStatusCommandTests
+{
+    private readonly Mock<IAgentRepository> _mockRepository;
+
+    public AgentStatusCommandTests()
+    {
+        _mockRepository = new Mock<IAgentRepository>();
+    }
+
+    [Fact]
+    public async Task ActivateAgent_WithValidId_ShouldActivateAgent()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+        var agent = Agent.Create(
+            Guid.NewGuid(),
+            "Test Agent",
+            "Test instructions",
+            LLMModel.GPT4o
+        );
+        agent.Pause(); // Start with paused status
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var handler = new ActivateAgentCommandHandler(_mockRepository.Object);
+        var command = new ActivateAgentCommand { Id = agentId };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("active");
+        _mockRepository.Verify(x => x.UpdateAsync(agent, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ActivateAgent_WithNonExistentId_ShouldThrowAgentNotFoundException()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Agent?)null);
+
+        var handler = new ActivateAgentCommandHandler(_mockRepository.Object);
+        var command = new ActivateAgentCommand { Id = agentId };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AgentNotFoundException>(() =>
+            handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task PauseAgent_WithValidId_ShouldPauseAgent()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+        var agent = Agent.Create(
+            Guid.NewGuid(),
+            "Test Agent",
+            "Test instructions",
+            LLMModel.GPT4o
+        );
+        // Agent is active by default
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var handler = new PauseAgentCommandHandler(_mockRepository.Object);
+        var command = new PauseAgentCommand { Id = agentId };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("paused");
+        _mockRepository.Verify(x => x.UpdateAsync(agent, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PauseAgent_WithNonExistentId_ShouldThrowAgentNotFoundException()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Agent?)null);
+
+        var handler = new PauseAgentCommandHandler(_mockRepository.Object);
+        var command = new PauseAgentCommand { Id = agentId };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AgentNotFoundException>(() =>
+            handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ArchiveAgent_WithValidId_ShouldArchiveAgent()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+        var agent = Agent.Create(
+            Guid.NewGuid(),
+            "Test Agent",
+            "Test instructions",
+            LLMModel.GPT4o
+        );
+        // Agent is active by default
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var handler = new ArchiveAgentCommandHandler(_mockRepository.Object);
+        var command = new ArchiveAgentCommand { Id = agentId };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("archived");
+        _mockRepository.Verify(x => x.UpdateAsync(agent, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ArchiveAgent_WithNonExistentId_ShouldThrowAgentNotFoundException()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Agent?)null);
+
+        var handler = new ArchiveAgentCommandHandler(_mockRepository.Object);
+        var command = new ArchiveAgentCommand { Id = agentId };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AgentNotFoundException>(() =>
+            handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ActivateAgent_WhenAlreadyActive_ShouldRemainActive()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+        var agent = Agent.Create(
+            Guid.NewGuid(),
+            "Test Agent",
+            "Test instructions",
+            LLMModel.GPT4o
+        );
+        // Agent is active by default
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var handler = new ActivateAgentCommandHandler(_mockRepository.Object);
+        var command = new ActivateAgentCommand { Id = agentId };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("active");
+        _mockRepository.Verify(x => x.UpdateAsync(agent, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task PauseAgent_WhenAlreadyPaused_ShouldRemainPaused()
+    {
+        // Arrange
+        var agentId = Guid.NewGuid();
+        var agent = Agent.Create(
+            Guid.NewGuid(),
+            "Test Agent",
+            "Test instructions",
+            LLMModel.GPT4o
+        );
+        agent.Pause();
+
+        _mockRepository.Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var handler = new PauseAgentCommandHandler(_mockRepository.Object);
+        var command = new PauseAgentCommand { Id = agentId };
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be("paused");
+        _mockRepository.Verify(x => x.UpdateAsync(agent, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## 摘要
實作 User Story 1.3 - Agent 狀態管理 API,新增 Agent 狀態轉換的 REST API endpoints。

## 變更內容

### 新增功能
- **Agent 狀態管理 API**: 新增 3 個 POST endpoints
  - `POST /api/agents/{id}/activate` - 啟用 Agent
  - `POST /api/agents/{id}/pause` - 暫停 Agent  
  - `POST /api/agents/{id}/archive` - 封存 Agent (軟刪除)

### 技術實作
**Application Layer** (6 個新檔案):
- `ActivateAgentCommand.cs` + `ActivateAgentCommandHandler.cs`
- `PauseAgentCommand.cs` + `PauseAgentCommandHandler.cs`
- `ArchiveAgentCommand.cs` + `ArchiveAgentCommandHandler.cs`

**API Layer** (1 個修改):
- `AgentsController.cs` - 新增 3 個狀態管理 endpoints

**Tests** (1 個新檔案):
- `AgentStatusCommandTests.cs` - 8 個單元測試
  - 涵蓋正常流程、錯誤處理、冪等性測試

### 測試結果
- 測試數總計: 85 (77 原有 + 8 新增)
- 通過率: 100%
- 測試時間: 1.78 秒

### 架構遵循
- ✅ Clean Architecture 四層分離
- ✅ CQRS 模式使用 MediatR
- ✅ Repository 模式資料存取
- ✅ 領域邏輯封裝
- ✅ 完整單元測試覆蓋

## 檔案變更
- 新增: 7 個檔案 (6 個實作 + 1 個測試)
- 修改: 1 個檔案 (AgentsController.cs)
- 總計: 8 個檔案, 429 行新增

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>