### PR TITLE
[CHAOS TEST DO NOT MERGE] AI-22 enforce_admins verification

### DIFF
--- a/backend/tests/unit/test_chaos_dummy_53_7.py
+++ b/backend/tests/unit/test_chaos_dummy_53_7.py
@@ -1,0 +1,15 @@
+"""
+File: backend/tests/unit/test_chaos_dummy_53_7.py
+Purpose: AI-22 chaos test — intentional fail to verify enforce_admins blocks
+    admin merge of red-CI PR. NEVER MERGE; this branch + PR will be deleted
+    after the chaos test result is documented.
+Category: Tests / Chaos verification
+Scope: Sprint 53.7 US-3 / closes AI-22
+
+Created: 2026-05-04
+"""
+
+
+def test_intentional_fail_for_chaos_verification() -> None:
+    """Intentional assert False to fail CI; goal: verify branch protection blocks merge."""
+    assert 1 == 2, "Sprint 53.7 AI-22 chaos test: this fail is intentional."


### PR DESCRIPTION
## Purpose
Sprint 53.7 US-3 / AI-22 chaos test — verify `enforce_admins=true` blocks
admin merge of a PR with red required CI checks.

**THIS PR MUST NEVER BE MERGED.** Will be closed + branch deleted immediately
after chaos test result documented.

## Expected Outcome
1. CI runs → at least 1 required check fails (Backend CI's pytest job will
   pick up `test_chaos_dummy_53_7.py::test_intentional_fail_for_chaos_verification`).
2. `gh pr merge --merge` (admin) → expected: GitHub API rejects with
   `failedStatusChecks` error because `enforce_admins=true` + 5 required
   contexts must be green.
3. Result captured to
   `docs/03-implementation/agent-harness-execution/phase-53-7-audit-cleanup-cat9-quickwins/sprint-53-7-audit-cleanup-cat9-quickwins/chaos-test-enforce-admins.md`.

## Cleanup
After documentation:
- `gh pr close <num> --delete-branch`
- Memory updated AI-22 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)