### PR TITLE
chore(docs, sprint-55-1): bookkeeping [x] marks for closeout completion

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,6 +10,11 @@
 # BUSINESS_DOMAIN_MODE flag + BusinessServiceFactory). Header touch here
 # triggers backend-ci required check for docs-only closeout PR.
 #
+# Sprint 55.1 checklist bookkeeping (2026-05-04, post-closeout): commit
+# 32-line [x] marks for §4.6/4.7/4.8 (PR #82/#83 actual work landed via
+# closeout PR #83 but checklist `[x]` marks were never pushed back). Header
+# touch here applies the paths-filter workaround for this docs-only PR.
+#
 # Sprint 53.2.5 closeout sync (2026-05-03): SITUATION-V2-SESSION-START.md +
 # CLAUDE.md updated to reflect V2 14/22 progress + Solo-dev policy + Paths
 # filter workaround. Header touch here applies the workaround itself.

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,3 +1,4 @@
+# Sprint 55.1 checklist bookkeeping PR #84 — docs-only post-closeout `[x]` mark commit; touch to satisfy paths-filter (AD-CI-5).
 # Sprint 55.1 closeout PR — docs-only sync (V2 21/22 = 95%); touch to satisfy paths-filter (AD-CI-5).
 # Sprint 55.1 PR #82 — backend-only business-domain production service layer; touch to fire workflow per AD-CI-5 paths-filter workaround (backend-only PRs need this to satisfy required Frontend E2E check).
 # Sprint 54.2 closeout PR — docs-only sync; touch to satisfy paths-filter (AD-CI-5).

--- a/docs/03-implementation/agent-harness-planning/phase-55-production/sprint-55-1-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-55-production/sprint-55-1-checklist.md
@@ -220,19 +220,19 @@ Per AD-Plan-1 (53.7) + feedback_day0_must_grep_plan_assumptions.md — grep each
 - [x] **LLM SDK leak** ✅ 0
 - [x] **alembic upgrade head** ✅ migration 0012 applied earlier Day 1; cycle verified
 
-### 4.6 Open PR + CI green + solo-dev merge
-- [ ] **Push final commit + open PR** (next)
-- [ ] **Wait CI green** (5 active checks: backend-ci / V2 Lint / E2E Backend / E2E Summary / Frontend E2E chromium headless)
-- [ ] **Solo-dev normal merge to main**
+### 4.6 Open PR + CI green + solo-dev merge ✅
+- [x] **Push final commit + open PR** ✅ PR #82 opened
+- [x] **Wait CI green** ✅ 5/5 required checks green (1 isort fix commit `a1ad19c6` + 1 paths-filter workaround `8dbb8a56`)
+- [x] **Solo-dev normal merge to main** ✅ PR #82 squash-merged main `798176d5`
 
-### 4.7 Closeout PR
-- [ ] **Branch `chore/sprint-55-1-closeout`**
-- [ ] **Update SITUATION-V2-SESSION-START.md** §8 + §9 (V2 21/22 = 95%)
-- [ ] **Update CLAUDE.md** L48-50 V2 progress + main HEAD
-- [ ] **Touch backend-ci.yml header** + playwright-e2e.yml header (paths-filter workarounds)
-- [ ] **Open closeout PR + merge**
+### 4.7 Closeout PR ✅
+- [x] **Branch `chore/sprint-55-1-closeout`** ✅
+- [x] **Update SITUATION-V2-SESSION-START.md** §9 milestones row + Last Updated + Update history ✅
+- [x] **Update CLAUDE.md** L71-75 V2 progress + main HEAD + L559-562 footer ✅
+- [x] **Touch backend-ci.yml header + playwright-e2e.yml header** (paths-filter workarounds) ✅
+- [x] **Open closeout PR + merge** ✅ PR #83 merged main `7ef94d30`
 
-### 4.8 Memory update + final push
-- [ ] **Create `memory/project_phase55_1_business_services.md`**
-- [ ] **Update `memory/MEMORY.md`** index
-- [ ] **Verify main HEAD + working tree clean + delete merged branches**
+### 4.8 Memory update + final push ✅
+- [x] **Create `memory/project_phase55_1_business_services.md`** ✅
+- [x] **Update `memory/MEMORY.md`** index ✅ entry added
+- [x] **Verify main HEAD + working tree clean + delete merged branches** ✅ main `7ef94d30` clean; both branches deleted via `gh pr merge --delete-branch`


### PR DESCRIPTION
## Summary

Post-closeout housekeeping commit for Sprint 55.1. The 32-line `[x]` marks for §4.6 / 4.7 / 4.8 were never pushed back to the planning branch even though the actual work landed via:
- PR #82 → main \`798176d5\` (Sprint 55.1 main work)
- PR #83 → main \`7ef94d30\` (Sprint 55.1 closeout)

This PR commits the checklist `[x]` marks so the historical record matches the actual completion state.

## Changes

- `sprint-55-1-checklist.md` — 32-line `[x]` marks for §4.6 (Open PR + CI green + merge) / §4.7 (Closeout PR) / §4.8 (Memory update + final push)
- `backend-ci.yml` — header comment for paths-filter workaround (docs-only PR)

## Test plan

- [x] No code changes — bookkeeping only
- [ ] CI 5 active checks green
- [ ] Solo-dev normal merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)