### PR TITLE
Sprint 57.4 — Phase 57+ SaaS Frontend 3/N: Admin Tenants Console list bundle

### DIFF
--- a/backend/src/api/v1/admin/tenants.py
+++ b/backend/src/api/v1/admin/tenants.py
@@ -46,7 +46,7 @@ Created: 2026-05-06 (Sprint 56.1 Day 1)
 Last Modified: 2026-05-07
 
 Modification History:
-    - 2026-05-07: Sprint 57.4 Day 1 — add GET "" list endpoint + TenantListItem + TenantListResponse (US-1 closes D1)
+    - 2026-05-07: Sprint 57.4 — add GET "" list endpoint (US-1 closes D1)
     - 2026-05-07: Sprint 57.3 Day 2 — add PATCH /{id} + TenantUpdateRequest + audit chain (US-2)
     - 2026-05-07: Sprint 57.3 Day 1 — add GET /{tenant_id} + TenantResponse (US-1 closes D1)
     - 2026-05-06: Sprint 56.2 Day 1 — RBAC dep replaces token stub (closes AD-AdminAuth-1)

--- a/backend/src/api/v1/admin/tenants.py
+++ b/backend/src/api/v1/admin/tenants.py
@@ -46,6 +46,7 @@ Created: 2026-05-06 (Sprint 56.1 Day 1)
 Last Modified: 2026-05-07
 
 Modification History:
+    - 2026-05-07: Sprint 57.4 Day 1 — add GET "" list endpoint + TenantListItem + TenantListResponse (US-1 closes D1)
     - 2026-05-07: Sprint 57.3 Day 2 — add PATCH /{id} + TenantUpdateRequest + audit chain (US-2)
     - 2026-05-07: Sprint 57.3 Day 1 — add GET /{tenant_id} + TenantResponse (US-1 closes D1)
     - 2026-05-06: Sprint 56.2 Day 1 — RBAC dep replaces token stub (closes AD-AdminAuth-1)
@@ -68,9 +69,9 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from infrastructure.db.audit_helper import append_audit
@@ -148,6 +149,91 @@ async def create_tenant(
         code=tenant.code,
         state=tenant.state,
         estimated_ready_in_seconds=60,
+    )
+
+
+# ---------------------------------------------------------------------
+# Sprint 57.4 (US-1): List endpoint with filter + pagination
+# ---------------------------------------------------------------------
+
+
+class TenantListItem(BaseModel):
+    """Lightweight subset of Tenant ORM for paginated list responses.
+
+    Excludes provisioning_progress / onboarding_progress / meta_data
+    JSONB fields to keep list payload small; clients fetch full detail
+    via GET /{tenant_id} (Sprint 57.3).
+    """
+
+    id: UUID
+    code: str
+    display_name: str
+    state: TenantState
+    plan: TenantPlan
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TenantListResponse(BaseModel):
+    """Paginated list response wrapper (Sprint 57.4 US-1)."""
+
+    items: list[TenantListItem]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.get(
+    "",
+    response_model=TenantListResponse,
+    dependencies=[Depends(require_admin_platform_role)],
+)
+async def list_tenants(
+    state: TenantState | None = Query(None),
+    plan: TenantPlan | None = Query(None),
+    search: str | None = Query(None, max_length=128),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db_session),
+) -> TenantListResponse:
+    """List tenants with optional filter by state / plan + ILIKE search.
+
+    Sprint 57.4 (US-1) — closes plan-time D1 RED finding (backend was
+    missing a list endpoint at the entity prefix). Powers the Admin
+    Tenants Console frontend page (US-2..US-5).
+
+    Auth: super-admin only via require_admin_platform_role.
+    Order: created_at DESC (newest first).
+    """
+    base_stmt = select(Tenant)
+    if state is not None:
+        base_stmt = base_stmt.where(Tenant.state == state)
+    if plan is not None:
+        base_stmt = base_stmt.where(Tenant.plan == plan)
+    if search is not None:
+        like = f"%{search}%"
+        base_stmt = base_stmt.where(
+            or_(Tenant.code.ilike(like), Tenant.display_name.ilike(like))
+        )
+
+    count_stmt = select(func.count()).select_from(base_stmt.subquery())
+    total_raw = (await db.execute(count_stmt)).scalar()
+    total = int(total_raw or 0)
+
+    page_stmt = (
+        base_stmt.order_by(Tenant.created_at.desc(), Tenant.id.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await db.execute(page_stmt)).scalars().all()
+
+    return TenantListResponse(
+        items=[TenantListItem.model_validate(t) for t in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/backend/src/api/v1/admin/tenants.py
+++ b/backend/src/api/v1/admin/tenants.py
@@ -214,18 +214,14 @@ async def list_tenants(
         base_stmt = base_stmt.where(Tenant.plan == plan)
     if search is not None:
         like = f"%{search}%"
-        base_stmt = base_stmt.where(
-            or_(Tenant.code.ilike(like), Tenant.display_name.ilike(like))
-        )
+        base_stmt = base_stmt.where(or_(Tenant.code.ilike(like), Tenant.display_name.ilike(like)))
 
     count_stmt = select(func.count()).select_from(base_stmt.subquery())
     total_raw = (await db.execute(count_stmt)).scalar()
     total = int(total_raw or 0)
 
     page_stmt = (
-        base_stmt.order_by(Tenant.created_at.desc(), Tenant.id.desc())
-        .limit(limit)
-        .offset(offset)
+        base_stmt.order_by(Tenant.created_at.desc(), Tenant.id.desc()).limit(limit).offset(offset)
     )
     rows = (await db.execute(page_stmt)).scalars().all()
 

--- a/backend/tests/integration/api/test_admin_tenant_list.py
+++ b/backend/tests/integration/api/test_admin_tenant_list.py
@@ -1,0 +1,251 @@
+"""
+File: backend/tests/integration/api/test_admin_tenant_list.py
+Purpose: Integration tests — GET /admin/tenants list endpoint (Sprint 57.4 US-1).
+Category: Tests / Integration / API (Phase 57+ SaaS Frontend 3/N)
+Scope: Sprint 57.4 / Day 1 / US-1 (closes plan-time D1 RED finding)
+
+Description:
+    Verifies the GET /admin/tenants list endpoint:
+    - 401 when no JWT context (no X-Test-User header)
+    - 403 when role is not admin/platform_admin
+    - 200 happy path with default pagination (50 / 0)
+    - 200 filter by state — only matching tenants returned
+    - 200 filter by plan — only matching tenants returned
+    - 200 search by ILIKE on code substring
+    - 200 pagination limit + offset behavior
+    - 200 empty result for non-matching search
+    - Response shape matches TenantListResponse
+
+    Mirrors test_admin_tenant_get.py + test_admin_tenant_patch.py
+    patterns (FastAPI test app with X-Test-User / X-Test-Roles
+    middleware + dependency_overrides for db_session +
+    require_admin_platform_role).
+
+Created: 2026-05-07 (Sprint 57.4 Day 1)
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import FastAPI, Request, Response
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.v1.admin.tenants import router as admin_tenants_router
+from infrastructure.db.models.identity import Tenant, TenantPlan, TenantState
+from infrastructure.db.session import get_db_session
+from platform_layer.identity.auth import require_admin_platform_role
+
+pytestmark = pytest.mark.asyncio
+
+
+def _build_app(db_session: AsyncSession | None = None) -> FastAPI:
+    """Build app with admin tenants router + role middleware + DB override."""
+    app = FastAPI()
+    app.include_router(admin_tenants_router, prefix="/api/v1")
+
+    @app.middleware("http")
+    async def _populate_test_state(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        user_header = request.headers.get("X-Test-User")
+        roles_header = request.headers.get("X-Test-Roles")
+        request.state.user_id = UUID(user_header) if user_header else None
+        request.state.roles = json.loads(roles_header) if roles_header else None
+        return await call_next(request)
+
+    if db_session is not None:
+
+        async def _override_session() -> AsyncIterator[AsyncSession]:
+            yield db_session
+
+        async def _override_admin() -> UUID:
+            return UUID("00000000-0000-0000-0000-000000000001")
+
+        app.dependency_overrides[get_db_session] = _override_session
+        app.dependency_overrides[require_admin_platform_role] = _override_admin
+
+    return app
+
+
+async def _seed_tenant_with(
+    session: AsyncSession,
+    *,
+    code: str,
+    display_name: str | None = None,
+    state: TenantState = TenantState.REQUESTED,
+    plan: TenantPlan = TenantPlan.ENTERPRISE,
+) -> Tenant:
+    """Create + flush a Tenant with explicit state + plan for filter tests.
+
+    Note: Phase 56+ Stage 1 only ships TenantPlan.ENTERPRISE; STANDARD lands
+    in Stage 2. Plan filter test therefore exercises the filter parameter
+    parsing path rather than exclusion.
+    """
+    t = Tenant(
+        code=code,
+        display_name=display_name or f"Tenant {code}",
+        state=state,
+        plan=plan,
+    )
+    session.add(t)
+    await session.flush()
+    await session.refresh(t)
+    return t
+
+
+async def test_list_tenants_401_without_auth() -> None:
+    """No X-Test-User header → require_admin_platform_role 401."""
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants")
+    assert resp.status_code == 401
+
+
+async def test_list_tenants_403_wrong_role() -> None:
+    """tenant_admin role insufficient → 403."""
+    app = _build_app()
+    user_id = uuid4()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/api/v1/admin/tenants",
+            headers={
+                "X-Test-User": str(user_id),
+                "X-Test-Roles": json.dumps(["tenant_admin"]),
+            },
+        )
+    assert resp.status_code == 403
+
+
+async def test_list_tenants_happy_no_filter(db_session: AsyncSession) -> None:
+    """Admin auth + seeded tenants → 200 + items + total >= 1 + correct shape."""
+    await _seed_tenant_with(db_session, code="LIST_T1", display_name="Tenant One")
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "items" in body and "total" in body and "limit" in body and "offset" in body
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert body["total"] >= 1
+    # Each item should have the 7 TenantListItem fields (no progress/meta_data).
+    sample = body["items"][0]
+    expected = {"id", "code", "display_name", "state", "plan", "created_at", "updated_at"}
+    assert expected.issubset(set(sample.keys()))
+    assert "meta_data" not in sample
+    assert "provisioning_progress" not in sample
+    assert "onboarding_progress" not in sample
+
+
+async def test_list_tenants_filter_by_state(db_session: AsyncSession) -> None:
+    """Filter state=active returns only ACTIVE tenants (excludes REQUESTED)."""
+    await _seed_tenant_with(db_session, code="STATE_ACT", state=TenantState.ACTIVE)
+    await _seed_tenant_with(db_session, code="STATE_REQ", state=TenantState.REQUESTED)
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants?state=active")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert all(item["state"] == "active" for item in body["items"])
+    assert any(item["code"] == "STATE_ACT" for item in body["items"])
+    assert all(item["code"] != "STATE_REQ" for item in body["items"])
+
+
+async def test_list_tenants_filter_by_plan(db_session: AsyncSession) -> None:
+    """Filter plan=enterprise parses + returns matching tenants.
+
+    Phase 56+ Stage 1 only ships TenantPlan.ENTERPRISE — exclusion test
+    requires Stage 2 STANDARD to be added. This test verifies the filter
+    parameter parses and the response items all have plan=enterprise.
+    """
+    await _seed_tenant_with(db_session, code="PLAN_ENT", plan=TenantPlan.ENTERPRISE)
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants?plan=enterprise")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert all(item["plan"] == "enterprise" for item in body["items"])
+    assert any(item["code"] == "PLAN_ENT" for item in body["items"])
+
+
+async def test_list_tenants_search_by_code(db_session: AsyncSession) -> None:
+    """Search ILIKE matches code substring."""
+    await _seed_tenant_with(db_session, code="ACME_CORP", display_name="Acme Corp")
+    await _seed_tenant_with(db_session, code="OTHER_CO", display_name="Other Co")
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants?search=ACME")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    codes = [item["code"] for item in body["items"]]
+    assert "ACME_CORP" in codes
+    assert "OTHER_CO" not in codes
+
+
+async def test_list_tenants_pagination(db_session: AsyncSession) -> None:
+    """limit + offset return distinct paginated slices.
+
+    Uses ILIKE search to isolate the 3 seeded PAGE_* tenants so the test
+    is independent of any other tenants seeded by sibling fixtures.
+    Endpoint orders by (created_at DESC, id DESC) for deterministic
+    pagination even when tenants share the same created_at timestamp.
+    """
+    for i in range(3):
+        await _seed_tenant_with(db_session, code=f"PAGE_{i}")
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        page1 = await ac.get(
+            "/api/v1/admin/tenants?search=PAGE_&limit=2&offset=0"
+        )
+        page2 = await ac.get(
+            "/api/v1/admin/tenants?search=PAGE_&limit=2&offset=2"
+        )
+    assert page1.status_code == 200 and page2.status_code == 200
+    body1 = page1.json()
+    body2 = page2.json()
+    assert body1["limit"] == 2 and body1["offset"] == 0
+    assert body2["limit"] == 2 and body2["offset"] == 2
+    assert body1["total"] == 3 and body2["total"] == 3
+    assert len(body1["items"]) == 2
+    assert len(body2["items"]) == 1
+    # Pages must not overlap.
+    ids1 = {item["id"] for item in body1["items"]}
+    ids2 = {item["id"] for item in body2["items"]}
+    assert ids1.isdisjoint(ids2)
+
+
+async def test_list_tenants_empty_filter(db_session: AsyncSession) -> None:
+    """Search with no match → items=[] + total=0."""
+    await _seed_tenant_with(db_session, code="EXISTING_CODE")
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/api/v1/admin/tenants?search=NONEXISTENT_TENANT_99999"
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+
+
+async def test_list_tenants_invalid_query_limit(db_session: AsyncSession) -> None:
+    """limit > 200 → 422 Unprocessable Entity (Pydantic Query validation)."""
+    app = _build_app(db_session=db_session)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/tenants?limit=500")
+    assert resp.status_code == 422

--- a/backend/tests/integration/api/test_admin_tenant_list.py
+++ b/backend/tests/integration/api/test_admin_tenant_list.py
@@ -207,12 +207,8 @@ async def test_list_tenants_pagination(db_session: AsyncSession) -> None:
     app = _build_app(db_session=db_session)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        page1 = await ac.get(
-            "/api/v1/admin/tenants?search=PAGE_&limit=2&offset=0"
-        )
-        page2 = await ac.get(
-            "/api/v1/admin/tenants?search=PAGE_&limit=2&offset=2"
-        )
+        page1 = await ac.get("/api/v1/admin/tenants?search=PAGE_&limit=2&offset=0")
+        page2 = await ac.get("/api/v1/admin/tenants?search=PAGE_&limit=2&offset=2")
     assert page1.status_code == 200 and page2.status_code == 200
     body1 = page1.json()
     body2 = page2.json()
@@ -233,9 +229,7 @@ async def test_list_tenants_empty_filter(db_session: AsyncSession) -> None:
     app = _build_app(db_session=db_session)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        resp = await ac.get(
-            "/api/v1/admin/tenants?search=NONEXISTENT_TENANT_99999"
-        )
+        resp = await ac.get("/api/v1/admin/tenants?search=NONEXISTENT_TENANT_99999")
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["items"] == []

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/progress.md
@@ -83,12 +83,67 @@
 
 ---
 
-## Day 1 — TBD (US-1 Backend GET list endpoint)
+## Day 1 — 2026-05-07 (US-1 Backend GET list endpoint)
 
-(In progress — see Day 1 commit logs)
+- ✅ TenantListItem (7 fields) + TenantListResponse Pydantic added to tenants.py
+- ✅ `@router.get("")` endpoint with state/plan/search/limit/offset Query params
+- ✅ ORDER BY (created_at DESC, id DESC) for deterministic pagination (D9 fix)
+- ✅ 9 integration tests in `test_admin_tenant_list.py` (401/403/happy/state/plan/search/pagination/empty/422)
+- ✅ pytest 1589 → 1598 (+9, 150% of plan target +6)
+- ✅ mypy --strict 0 errors in tenants.py / 8 V2 lints 8/8
+- Commit: `a749e4c0`
+- Actual: ~45 min (vs ~2 hr est)
+
+## Day 2 — 2026-05-07 (US-2 Frontend Infra)
+
+- ✅ `features/admin-tenants/{components,services,store}` skeleton created
+- ✅ types.ts re-exports TenantState + TenantPlan from tenant-settings (no duplicate enum per AP-11)
+- ✅ adminTenantsService.ts with `buildListSearchParams` helper (omit undefined filters) + listTenants
+- ✅ adminTenantsStore.ts Zustand store (query/items/total/loading/error + setFilter resets offset / setPagination / loadData / reset)
+- ✅ 7 Vitest unit tests (4 service + 3 store)
+- ✅ Vitest 23 → 30 (+7, 117% of plan target +6 for US-2)
+- Commit: `cb061505`
+- Actual: ~30 min (vs ~1.5 hr est)
+
+## Day 3 — 2026-05-07 (US-3 + US-4 Components + Page)
+
+- ✅ TenantListTable.tsx (rows + state/plan badges + View button + empty state + loading skeleton)
+- ✅ TenantListFilters.tsx (state/plan dropdowns + search + Apply/Reset; no debounce per AP-6 → AD-AdminTenants-DebouncedSearch deferred)
+- ✅ TenantListPagination.tsx (Prev/Next + range indicator + edge-disable)
+- ✅ pages/admin-tenants/index.tsx (Filters + Table + Pagination layout + auto-load on mount + error retry; URL query sync deferred → AD-AdminTenants-URL-QuerySync)
+- ✅ 5 Vitest tests (2 Table + 1 Filters + 2 Pagination)
+- ✅ Vitest 30 → 35 (+5, hits plan target +5)
+- Commit: (Day 3 commit)
+- Actual: ~50 min (vs ~2.5 hr est)
+
+## Day 4 — 2026-05-07 (US-5 Routing + Playwright + Closeout)
+
+- ✅ App.tsx import AdminTenantsPage + Route `/admin-tenants` + Home Link + status text update + MHist line
+- ✅ Playwright e2e `admin_tenants_list.spec.ts` 4 cases (happy / filter / click-row / empty)
+- ✅ D14 Playwright strict-mode selector fix (mid-test) — `getByText("active")` 2 matches → `.locator("td span").filter()` + `getByRole("heading")`
+- ✅ Vite build 69 → **75 modules** / 203.02 → **209.11 kB** (+6.09 kB, admin-tenants wired)
+- ✅ Playwright 19 → 23 (+4)
+- ✅ retrospective.md (6 必答 + AD-Sprint-Plan-6 logged + Phase 57.x candidates Q5)
+- ✅ Memory snapshot + MEMORY.md index updated
+- Actual: ~30 min (vs ~2 hr est)
 
 ---
 
 ## Sprint Summary
 
-(To be filled at Day 4 retrospective)
+| Metric | Baseline | After 57.4 | Delta | vs Plan |
+|--------|----------|------------|-------|---------|
+| Backend pytest | 1589 | **1598** | +9 | 150% of +6 |
+| Backend mypy --strict | 0/295 | 0/295 (unchanged) | 0 | ✅ |
+| 8 V2 lints | 8/8 | 8/8 | 0 | ✅ |
+| LLM SDK leak | 0 | 0 | 0 | ✅ |
+| Vitest | 23 / 8 files | 35 / 13 files | +12 | 200% of +6 |
+| Playwright e2e | 19 (chromium) | 23 (chromium) | +4 | ✅ |
+| Vite build modules | 69 | 75 | +6 | wire-up |
+| Vite build size | 203.02 kB | 209.11 kB | +6.09 kB | wire-up |
+
+**Calibration**: `mixed` 0.60 4th app actual ~3.5 hr / committed 8.4 hr → ratio **0.42** ⬇️ below band by 0.43; 4-data-point window mean **0.79** dropped below band — pattern reuse acceleration evidence. **AD-Sprint-Plan-6** logged proposing scope-class refinement (mixed-greenfield 0.60 vs mixed-pattern-reuse ~0.40).
+
+**D-findings**: 8 catalogued (1 RED + 5 GREEN + 2 YELLOW); D1 RED closed pre-Day-1 via Option A pre-emptive bundle; D9 + D14 mid-sprint fixes (pagination stability + Playwright selectors).
+
+See [retrospective.md](./retrospective.md) for 6 必答 details + carryover AD list + Phase 57.x next-sprint candidates.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/progress.md
@@ -1,0 +1,94 @@
+# Sprint 57.4 Progress — Phase 57+ SaaS Frontend 3/N: Admin Tenants Console list bundle
+
+> **Sprint Plan**: [sprint-57-4-plan.md](../../../agent-harness-planning/phase-57-frontend-saas/sprint-57-4-plan.md)
+> **Sprint Checklist**: [sprint-57-4-checklist.md](../../../agent-harness-planning/phase-57-frontend-saas/sprint-57-4-checklist.md)
+> **Branch**: `feature/sprint-57-4-admin-tenants-list-bundle`
+> **Base**: main `a558f98b` (Sprint 57.3 closeout)
+
+---
+
+## Day 0 — 2026-05-07
+
+### 0.1 Branch + plan + checklist commit
+
+- ✅ Branch created from main(`a558f98b`):`feature/sprint-57-4-admin-tenants-list-bundle`
+- ✅ Plan + checklist committed (`a7f0e9f5`):904 insertions across 2 files
+
+### 0.2 Day-0 三-prong 探勘 v3 (second fully-applied sprint)
+
+**Prong 1 Path Verify** (per AD-Plan-2):
+- ✅ `frontend/src/features/admin-tenants/**` 不存在 (Glob 0 matches — expect for NEW US-2/3/4)
+- ✅ `frontend/src/pages/admin-tenants/**` 不存在 (Glob 0 matches — expect for NEW US-4)
+- ✅ `backend/tests/integration/api/test_admin_tenant_list.py` 不存在 (Glob 0 matches — expect for NEW US-1)
+- ✅ `backend/src/api/v1/admin/tenants.py` 已存在 (will MODIFY for US-1)
+- ✅ `backend/src/platform_layer/identity/auth.py` `require_admin_platform_role` 已存在 (56.2 reuse)
+- ✅ `backend/src/infrastructure/db/models/identity.py` Tenant ORM + TenantState/TenantPlan enums 已存在 (56.1 reuse)
+
+**Prong 2 Content Verify** (per AD-Plan-3 promoted):
+- 🔴 **D1 (already caught at plan-time)** — `tenants.py` 既有 5 endpoints (POST `""`, GET `/{id}/onboarding-status`, POST `/{id}/onboarding/{step}`, GET `/{id}`, PATCH `/{id}`) **無 GET `""` list endpoint**;**Closed** by user-confirmed Option A pre-emptive bundle 2026-05-07
+- ✅ `class TenantState(str, Enum)` at `identity.py:73` confirmed
+- ✅ `class TenantPlan(str, Enum)` at `identity.py:88` confirmed
+- ✅ Tenant ORM `code: Mapped[str]` + `display_name: Mapped[str]` at `identity.py:113-114` (ILIKE-able for US-1 search)
+- ✅ `from sqlalchemy import or_/func` 在 56.x usage 已有(`cost_ledger.py`, `feature_flag.py`, memory layers — 5 existing usages)
+- ✅ 0 new wrong-content drift (D1 RED already user-approved Option A)
+
+**Prong 3 Schema Verify** (per AD-Plan-4-Schema-Grep promoted):
+- ✅ N/A this sprint (no new DB schema/migration);**attempt 完成** per fold-in spirit
+- ✅ Migration head:`0016_sla_and_cost_ledger.py` (last;0017 available but not used this sprint)
+- ✅ Tenant ORM 7+ fields all reusable for list query (id/code/display_name/state/plan/created_at/updated_at)
+
+### 0.3 Calibration multiplier pre-read
+
+- ✅ `mixed` 0.60 mid-band 4th application; 3-data-point window mean **0.92 ✅** (53.7=1.01 + 56.2=1.17 + 57.3=0.57)
+- Bottom-up est ~14 hr × **0.60** = **~8 hr** committed
+- Day 4 retro Q2 will verify ratio in [0.85, 1.20] band
+
+### 0.4 Pre-flight verify — main green baseline
+
+| Baseline | Expected | Actual | Status |
+|----------|----------|--------|--------|
+| Backend pytest | 1589 | **1589** collected in 1.72s | ✅ |
+| Backend mypy --strict | 0/295 | **0/295** source files | ✅ |
+| 8 V2 lints | 8/8 green | **8/8** in 0.87s | ✅ |
+| LLM SDK leak (effective) | 0 | 5 docstring mentions, 0 real imports | ✅ |
+| Frontend Vite build | 69 modules / 203.02 kB | **69 / 203.02 kB** in 597ms | ✅ |
+| Vitest unit | 23 / 8 files | **23 / 8 files** in 1.32s | ✅ |
+| Playwright e2e | 15 | (will verify on Day 4 final) | — |
+
+### 0.5 D-findings catalogue
+
+| ID | Severity | Finding | Resolution |
+|----|----------|---------|------------|
+| D1 | 🔴 RED | backend admin tenants.py 缺 GET `""` list endpoint | **Closed** — Option A pre-emptive bundle 2026-05-07; +US-1 backend scope 3-4 hr; mixed 0.60 |
+| D2 | 🟢 GREEN | `require_admin_platform_role` (56.2) reusable | OK — US-1 reuse |
+| D3 | 🟢 GREEN | Tenant ORM `code`/`display_name` ILIKE-able | OK — US-1 search 用 `or_` + `ilike` |
+| D4 | 🟢 GREEN | TenantState/TenantPlan enum 已定義 + 57.3 frontend re-export | OK — US-2 types.ts re-export |
+| D5 | 🟢 GREEN | TenantResponse + GET `/{id}` 既有 (57.3) | OK — US-3 click-row → /tenant-settings/{id} 直接 functional |
+| D6 | 🟠 YELLOW | tenants 表無 RLS policy (它就是 tenant) | OK — RBAC 雙重 check (super-admin role + JWT) |
+| D7 | 🟢 GREEN | 57.3 tenantSettingsStore pattern reusable | OK — US-2 store ~30-40 min pattern reuse |
+| D8 | 🟠 YELLOW | URL query string sync 需 React Router useSearchParams or window.history | Day 3 first thing verify React Router version |
+
+### 0.6 Day 0 三-prong ROI evidence (second fully-applied sprint)
+
+- Prong 2 D1 catch at plan-time: ~30 min cost prevented 8-12 hr Day 1+ rework (類比 57.3 D1 catch)
+- ROI ≈ 16-24× this sprint (matches 57.3 first application)
+- Total Day 0 探勘 time: ~40 min (Path 8 checks + Content 6 checks + Schema attempt + baselines)
+- Cumulative AD-Plan-3 evidence: 4 fully-applied sprints (55.5 + 55.6 + 57.3 + 57.4) all caught D1-class wrong-content drift before Day 1 code
+
+### 0.7 Scope shift verdict
+
+- Cumulative scope shift: +backend 3-4 hr (US-1 list endpoint) = **+25-30%** vs naive medium-frontend baseline
+- < 50% threshold per AD-Plan-1 → continue Day 1+ without plan re-version
+- User-approved Option A 2026-05-07 — no re-confirm needed
+
+---
+
+## Day 1 — TBD (US-1 Backend GET list endpoint)
+
+(In progress — see Day 1 commit logs)
+
+---
+
+## Sprint Summary
+
+(To be filled at Day 4 retrospective)

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/retrospective.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/retrospective.md
@@ -1,0 +1,100 @@
+# Sprint 57.4 Retrospective — Phase 57+ SaaS Frontend 3/N: Admin Tenants Console list bundle
+
+> **Sprint Plan**: [sprint-57-4-plan.md](../../../agent-harness-planning/phase-57-frontend-saas/sprint-57-4-plan.md)
+> **Sprint Checklist**: [sprint-57-4-checklist.md](../../../agent-harness-planning/phase-57-frontend-saas/sprint-57-4-checklist.md)
+> **Branch**: `feature/sprint-57-4-admin-tenants-list-bundle`
+> **Date**: 2026-05-07
+
+---
+
+## Q1 — What went well
+
+- **Plan-time Prong 2 catch saved ~8-12 hr Day 1 rework** — the missing GET `""` list endpoint was identified at plan-time before any frontend code started. Option A pre-emptive bundle delivered in the same calibrated commit envelope (~8 hr) that a frontend-only naive plan would have spent rebuilding.
+- **57.3 pattern reuse acceleration** — types/service/store/page architecture mirrored 57.3 tenant-settings 1:1, including inline-style badge palette, `_handleResponse<T>` helper, Zustand store with reset action, and React Router / page wrapper conventions. Estimated 60-70% velocity boost vs greenfield 57.1 v2.
+- **5 Vitest unit tests + 4 Playwright e2e all green on first integrated run** (after 2 minor selector fixes from strict-mode violations). Pytest 9 new integration tests passed first run with only one pagination-stability fix (deterministic ORDER BY).
+- **D1 RED finding closed cleanly** — backend tenants.py R surface now includes both `GET /{id}` (57.3) AND `GET ""` (57.4 list); CRUD R complete for admin tenant entity.
+- **Day 0 三-prong second fully-applied sprint** — Path + Content + Schema all attempted; ROI ≈ 16-24× confirms 57.3 first application was not a fluke. Cumulative AD-Plan-3 evidence: 4 sprints (55.5/55.6/57.3/57.4) all caught D1-class drift before Day 1 code.
+
+## Q2 — What didn't go well + Calibration verdict
+
+### Calibration (AD-Sprint-Plan-4 `mixed` 0.60 mid-band 4th application)
+
+| Sprint | Multiplier | Bottom-up | Committed | Actual | Ratio |
+|--------|-----------|-----------|-----------|--------|-------|
+| 53.7 (1st app) | 0.55 | 13.5 hr | 7.4 hr | 7.5 hr | 1.01 ✅ |
+| 56.2 (2nd app) | 0.60 | 22 hr | 13.2 hr | 15.4 hr | 1.17 ✅ |
+| 57.3 (3rd app) | 0.60 | 17 hr | 10 hr | ~5.7 hr | 0.57 ⬇️ |
+| **57.4 (4th app)** | **0.60** | **14 hr** | **8.4 hr** | **~3.5 hr** | **0.42 ⬇️** |
+| **4-data-point mean** | | | | | **0.79 ⬇️** |
+
+**Verdict**: 4-data-point window mean 0.79 dropped below band lower edge [0.85, 1.20] by 0.06. The two recent low ratios (57.3 0.57 + 57.4 0.42) reflect a real *pattern reuse* effect — adding pages that mirror an established frontend feature folder (cost-dashboard / sla-dashboard / tenant-settings) compounds velocity beyond the multiplier's expected ratio.
+
+**Action**: Log **AD-Sprint-Plan-6** to consider scope-class refinement: split `mixed` into `mixed-greenfield` (0.60 retained) and `mixed-pattern-reuse` (proposed 0.40 starting baseline) for sprints that primarily extend an established frontend feature folder. Keep 0.60 for Sprint 57.5 if scope is novel; lower if it's clearly pattern-reuse continuation.
+
+### Other
+
+- **Playwright strict-mode selector fixes (D14)** — `getByText("active")` matched 2 elements (badge span + dropdown option text) on first run; fixed via `.locator("td span").filter({ hasText })` and `getByRole("heading")`. Cost ~5 min mid-Day-4. AD-Plan-3 process did not catch this because Playwright accessibility snapshots were not in scope for content-verify.
+- **Pagination test stability (D9)** — three tenants seeded in same flush share `created_at`; LIMIT/OFFSET ordering was non-deterministic. Fixed via secondary sort key `(created_at DESC, id DESC)` on the endpoint + ILIKE-search isolation in the test. Endpoint fix is a real correctness improvement (paginated APIs need deterministic ordering); test fix is hygiene.
+
+## Q3 — What we learned + Day 0 三-prong observations
+
+- **Pattern reuse compounds calibration drift faster than expected**. Sprint 57.3 already showed 0.57; Sprint 57.4 deepened to 0.42. Two consecutive sprints in the same lineage (tenant-settings → admin-tenants console) reveal that the multiplier matrix needs sub-classes for greenfield vs reuse, not just for scope size.
+- **AD-Plan-3 wrong-content drift catch is now a 4-sprint pattern**. ROI evidence consolidated: ~30 min Day-0 cost prevents 8-12 hr Day-1+ rework consistently. Recommend promoting Day-0 三-prong to a non-skippable rule line in `sprint-workflow.md` §Step 2.5 (already there as "Required" but de-facto enforcement evidence is now strong enough to remove the "first fully-applied sprint" framing — it's standard practice now).
+- **Schema-Grep (Prong 3) N/A is a valid verdict**, not a "skip". This sprint had no DB schema/migration scope and the Tenant ORM was reused as-is. Prong 3 attempt = re-confirming `class Tenant` field list + checking migrations head — under 5 min cost. Worth keeping the attempt habit even when verdict is N/A; it's free insurance against accidentally missing a schema dependency.
+- **Frontend bundle delta first-time observed** — Vite tree-shakes new feature folders aggressively until a route consumer imports them; build size only grew on Day 4 when App.tsx imported `AdminTenantsPage`. Result: 203.02 kB (Day 0-3) → **209.11 kB** (Day 4 wired). Future planning can rely on this: bundle-size impact is deferred until route wire-up.
+
+## Q4 — Audit Debt deferred (明確標 ID + target sprint)
+
+| AD ID | Description | Target |
+|-------|-------------|--------|
+| ⏸ **AD-Sprint-Plan-6** (NEW) | Split `mixed` multiplier into `mixed-greenfield` (0.60) vs `mixed-pattern-reuse` (~0.40). Evidence: 57.3 (0.57) + 57.4 (0.42) consecutive pattern-reuse sprints. Apply at next sprint plan §Workload header. | Sprint 57.5+ |
+| ⏸ **AD-AdminTenants-URL-QuerySync** (NEW) | Implement URL query string sync for filters/pagination (deferred this sprint per AP-6 — no real shareability need yet). When admin team raises actual share-URL request → next admin frontend sprint. | Phase 57.x or 58 |
+| ⏸ **AD-AdminTenants-DebouncedSearch** (NEW) | Add 300ms debounce to TenantListFilters search input (deferred this sprint per AP-6 — explicit Apply button is enough for current scale). When tenants count > ~500 in production search frequency tuning becomes real. | Phase 58+ |
+| ⏸ **AD-Cat10-VisualVerifier+Frontend-Panel** (carry from 55.5) | Phase 57.x Group F. | Phase 57.x |
+| ⏸ **AD-Cat11-Multiturn / SSEEvents / ParentCtx** (carry from 54.2) | Phase 56+ Cat 11 bundle. | Phase 56+ |
+| ⏸ **AD-CI-6** (carry from 55.6) | Production launch — needs Azure provisioning. | Phase 58 |
+| ⏸ **AD-Cat12-BusinessObs (real tracer)** (carry from 55.2) | Thread real tracer through chat router. | Phase 56.x |
+| ⏸ **AD-Cost-Ledger-Token-Split / Provider-Attribution / LoopMetricsAccumulator** (carry from 56.3) | Operational rollout / refactoring track. | Phase 56.x |
+
+## Q5 — Next steps (rolling planning)
+
+Sprint 57.5 candidates pending user approval (per `.claude/rules/sprint-workflow.md` rolling planning 紀律):
+
+1. **Onboarding self-serve wizard** — needs backend self-serve API design first; non-trivial ~12-15 hr × `large multi-domain` 0.55 = ~7-8 hr commit
+2. **Feature flags admin UI** (small-frontend ~5-6 hr × proposed `mixed-pattern-reuse` 0.40 = ~2-3 hr commit) — backend 56.1 ships full service + endpoint
+3. **Audit log frontend view** (small-frontend ~6-7 hr × `mixed-pattern-reuse` 0.40 = ~3 hr commit) — backend 53.5/53.6 ships full audit/log + verify-chain
+4. **Compliance partial GDPR** (medium-backend ~10-13 hr × 0.80 = ~8-10 hr commit)
+5. **DR + WAL streaming** (large multi-domain ~14-18 hr)
+6. **SaaS Stage 2 Stripe + 月結 + Status Page** (large multi-domain ~12-15 hr)
+7. **AD-Cat10-VisualVerifier + Frontend-Panel** (Phase 57.x Group F deferred)
+8. **AD-Cat11-Multiturn + SSEEvents + ParentCtx** (54.2 deferred bundle)
+9. **AD-CI-6** Phase 58 production launch (needs Azure provisioning)
+
+**Recommend**: continue frontend pattern-reuse momentum with **#2 Feature flags UI** or **#3 Audit log view** for fast ROI; OR pivot to **#1 Onboarding self-serve** for Stage 1 SaaS UX completeness (requires backend API design upfront).
+
+User approval required per rolling planning 紀律. Do not draft Sprint 57.5 plan/checklist before user picks direction.
+
+## Q6 — Solo-dev policy validation
+
+- ✅ `enforce_admins=true` permanent (PR cannot bypass CI via admin merge)
+- ✅ `required_approving_review_count = 0` permanent (solo dev unable to self-approve)
+- ✅ All 5 active CI checks expected green on PR (paths-filter retired since 55.6 — backend-ci.yml + playwright-e2e.yml always trigger)
+- ✅ No `--no-verify` / `--force` git operations used this sprint
+- ✅ Scope respected: backend list endpoint touched only `tenants.py`; frontend admin-tenants is new isolated folder; no cross-cutting ripple to V2 範疇 1-12
+
+---
+
+## Sprint Stats Summary
+
+| Metric | Baseline (Sprint 57.3 close) | After Sprint 57.4 | Delta | vs Plan |
+|--------|-------------------------------|-------------------|-------|---------|
+| Backend pytest | 1589 | **1598** | **+9** | 150% of +6 |
+| Backend mypy --strict | 0/295 source files | 0/295 (unchanged) | 0 | ✅ |
+| 8 V2 lints | 8/8 green | 8/8 green | 0 | ✅ |
+| LLM SDK leak | 0 (5 docstring mentions only) | 0 | 0 | ✅ |
+| Frontend Vitest | 23 / 8 files | **35 / 13 files** | **+12** | 200% of +6 |
+| Playwright e2e | 19 (chromium) | **23** (chromium) | **+4** | ✅ |
+| Vite build modules | 69 | **75** | +6 | wire-up |
+| Vite build size (kB) | 203.02 | **209.11** | +6.09 | wire-up |
+
+**Calibration**: `mixed` 0.60 4th app ratio **0.42** ⬇️ below band by 0.43; 4-data-point window mean **0.79** dropped below 60% in-band sustain. AD-Sprint-Plan-6 logged.

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-4-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-4-checklist.md
@@ -1,0 +1,314 @@
+# Sprint 57.4 — Checklist
+
+> [Sprint Plan](./sprint-57-4-plan.md)
+
+**Sprint Goal**: Open Phase 57+ SaaS Frontend 3/N — Admin Tenants Console list bundle(backend GET `""` list endpoint + frontend Admin Tenants Console page);closes plan-time D1 RED finding(57.4 Day 0 plan-time Prong 2 catch);4th application of `mixed` 0.60 multiplier。
+
+---
+
+## Day 0 — Setup + Day-0 三-prong 探勘 + Pre-flight Verify
+
+### 0.1 Branch + plan + checklist commit
+- [ ] **Branch from main(a558f98b)**
+  - DoD:`git checkout -b feature/sprint-57-4-admin-tenants-list-bundle`
+  - Verify:`git branch --show-current` → `feature/sprint-57-4-admin-tenants-list-bundle`
+- [ ] **Commit plan + checklist**
+  - DoD:both files staged + committed with conventional message `docs(plan, sprint-57-4): add plan + checklist for Admin Tenants Console list bundle`
+  - Verify:`git log --oneline -1` shows commit;`git status --short` clean
+
+### 0.2 Day-0 三-prong 探勘 v3(per AD-Plan-3 + AD-Plan-4 fold-in promoted;57.4 second fully-applied sprint)
+- [ ] **Prong 1 Path Verify**(per AD-Plan-2 path verify)
+  - `frontend/src/features/admin-tenants/` 不存在(expect — NEW US-2+US-3+US-4)
+  - `frontend/src/pages/admin-tenants/` 不存在(expect — NEW US-4)
+  - `frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts` 不存在(expect — NEW US-5)
+  - `backend/tests/integration/api/test_admin_tenant_list.py` 不存在(expect — NEW US-1)
+  - `backend/src/api/v1/admin/tenants.py` exists(expect — MODIFY US-1)
+  - `backend/src/platform_layer/identity/auth.py:140 require_admin_platform_role` exists(56.2 reuse)
+  - `backend/src/infrastructure/db/models/identity.py class Tenant` exists with code/display_name string columns(56.1 reuse)
+  - `frontend/src/features/tenant-settings/types.ts` exports TenantState + TenantPlan(57.3 re-export source)
+  - Verify:Glob + Grep results;0 unexpected drift(若有 → catalogue D9+)
+- [ ] **Prong 2 Content Verify**(per AD-Plan-3 content verify promoted)
+  - `tenants.py` GET `""` (no path param) list endpoint 不存在(D1 RED already caught — already user-confirmed Option A pre-emptive bundle)
+  - `tenants.py` 既有 5 endpoints(POST `""` / GET `/{id}/onboarding-status` / POST `/{id}/onboarding/{step}` / GET `/{id}` / PATCH `/{id}`)— grep 確認
+  - `TenantState` + `TenantPlan` enum 已定義 in `identity.py`(grep `class TenantState` + `class TenantPlan`)
+  - Tenant ORM `code` + `display_name` columns string 型別 ILIKE-able(grep `code:.*Mapped\[str\]` + `display_name:.*Mapped\[str\]`)
+  - `from sqlalchemy import or_` + `from sqlalchemy import func` 在 56.x usage 既有(grep verify import path)
+  - Pydantic v2 `Query(...)` + `ConfigDict(from_attributes=True)` 既有 56.x+57.3 慣例 grep verify
+  - Verify:0 new wrong-content drift(D1 RED catch already user-confirmed Option A pre-emptive bundle 2026-05-07)
+- [ ] **Prong 3 Schema Verify**(per AD-Plan-4-Schema-Grep promoted)
+  - 此 sprint 無新 DB schema/migration → Schema verify N/A
+  - **但 attempt 完成** per fold-in spirit:Grep `migrations/versions/0017_*.py` 不存在 confirm;Grep `class Tenant` ORM 7+ fields(id/code/display_name/state/plan/created_at/updated_at)全 verified for list query compatibility
+  - Verify:N/A verdict logged in progress.md;not skip silently
+
+### 0.3 Calibration multiplier pre-read
+- [ ] **`mixed` 0.60 mid-band 4th application**
+  - 3-data-point evidence:53.7 mixed 0.55 ratio 1.01(1st)+ 56.2 mixed 0.60 ratio 1.17(2nd)+ 57.3 mixed 0.60 ratio 0.57(3rd)= mean **0.92 ✅** in band → KEEP 0.60 mid-band per AD-Sprint-Plan-4 matrix discipline
+  - 此 sprint:bottom-up ~14 hr × 0.60 = **~8.4 hr** commit
+  - Day 4 retro Q2 verify:若 ratio in band → 4-data-point window opens;若 mean shift → AD-Sprint-Plan-N+1 logged
+
+### 0.4 Pre-flight verify(main green baseline)
+- [ ] **Backend baselines**
+  - `python -m pytest backend/tests/ -q --tb=no` → 1589 collected / 0 failures(Sprint 57.3 baseline)
+  - `python -m mypy backend/src --strict` → 0 errors / 295 source files
+  - `python scripts/lint/run_all.py` → 8 V2 lints 8/8 green
+  - `grep -rn "import openai\|import anthropic" backend/src/agent_harness/` → 0 results(LLM SDK leak)
+  - Verify:All 4 baselines documented in progress.md ✅ (1589 / 0/295 / 8/8 / 0)
+- [ ] **Frontend baselines**
+  - `cd frontend && npm run lint` → clean
+  - `cd frontend && npm run build` → success / 69 modules / 203.02 kB
+  - `cd frontend && npm run test` → 23 unit tests pass(57.3 baseline)
+  - Playwright e2e 15 tests baseline(57.3 closeout)
+  - Verify:All 4 baselines documented in progress.md ✅ (ESLint clean / Vite 69 modules 203.02 kB / Vitest 23/23 / Playwright 15)
+
+### 0.5 Day 0 progress.md commit + push
+- [ ] **Catalogue D-findings + cross-reference plan-time catch**
+  - D1 closed by user-confirmed Option A pre-emptive bundle 2026-05-07
+  - D2-D8 informational(per plan §Risks)
+  - Document Day 0 三-prong second fully-applied sprint attempt time + findings count
+  - Verify:`docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/progress.md` exists with Day 0 section ✅
+- [ ] **Day 0 commit + push**
+  - DoD:progress.md staged + committed `docs(progress, sprint-57-4): Day 0 三-prong 探勘 + pre-flight baseline verify`
+  - Verify:`git log --oneline -1` shows commit;remote up-to-date(branch pushed to origin)
+
+---
+
+## Day 1 — US-1 Backend GET list endpoint
+
+### 1.1 TenantListItem Pydantic model
+- [ ] **Add `class TenantListItem(BaseModel)` to tenants.py**
+  - 7 fields:id (UUID) / code (str) / display_name (str) / state (TenantState) / plan (TenantPlan) / created_at (datetime) / updated_at (datetime)
+  - **Non-include**:provisioning_progress / onboarding_progress / meta_data(reduce list payload size)
+  - `model_config = ConfigDict(from_attributes=True)` for ORM serialization
+  - File header MHist:`+ N+1 line: 2026-05-08: Sprint 57.4 — add TenantListItem + TenantListResponse + GET list endpoint (closes D1 RED)`
+  - Verify:`grep -n "class TenantListItem" backend/src/api/v1/admin/tenants.py` → 1 result
+
+### 1.2 TenantListResponse Pydantic wrapper
+- [ ] **Add `class TenantListResponse(BaseModel)` to tenants.py**
+  - 4 fields:`items: list[TenantListItem]` / `total: int` / `limit: int` / `offset: int`
+  - Verify:`grep -n "class TenantListResponse" backend/src/api/v1/admin/tenants.py` → 1 result
+
+### 1.3 GET `""` list endpoint with query params
+- [ ] **Add `@router.get("", response_model=TenantListResponse)` endpoint**
+  - Path:`""` (no path param) accepts query string
+  - Auth:`dependencies=[Depends(require_admin_platform_role)]` per 56.2 RBAC pattern
+  - Query params:`state: TenantState | None = Query(None)` / `plan: TenantPlan | None = Query(None)` / `search: str | None = Query(None, max_length=128)` / `limit: int = Query(50, ge=1, le=200)` / `offset: int = Query(0, ge=0)`
+  - Body:base_stmt = select(Tenant) + apply filters + count_stmt for total + page_stmt order_by created_at.desc().limit().offset() → return TenantListResponse
+  - Imports:`from sqlalchemy import or_, func` + `from fastapi import Query`
+  - Verify:`grep -n "@router.get(\"\"," backend/src/api/v1/admin/tenants.py` shows new entry + endpoint listed in Sprint 57.4 spec
+
+### 1.4 NEW test file test_admin_tenant_list.py
+- [ ] **Create `backend/tests/integration/api/test_admin_tenant_list.py`**(D9 path follows existing 56.x flat convention per 57.3)
+  - Test 1:`test_list_tenants_happy_no_filter` — admin user no query → 200 + total >= 1 + items array
+  - Test 2:`test_list_tenants_filter_by_state` — query `state=ACTIVE` → all items have state=ACTIVE
+  - Test 3:`test_list_tenants_filter_by_plan` — query `plan=ENTERPRISE` → all items have plan=ENTERPRISE
+  - Test 4:`test_list_tenants_search_by_code` — fixture seed tenant code="ACME_TEST" + query `search=ACME` → 1 match
+  - Test 5:`test_list_tenants_pagination` — seed 3 tenants + query `limit=2&offset=0` → 2 items + total=3+ + offset=0;then `offset=2` → 1+ items
+  - Test 6:`test_list_tenants_401_unauthenticated` — no Authorization header → 401
+  - Test 7:`test_list_tenants_403_wrong_role` — non-admin role JWT → 403
+  - Test 8:`test_list_tenants_response_shape` — assert response keys match TenantListResponse fields exactly
+  - Test 9 (optional):`test_list_tenants_empty_filter` — query `search=NONEXISTENT_TENANT_99999` → items=[] + total=0
+  - Verify:`python -m pytest backend/tests/integration/api/test_admin_tenant_list.py -v` → ≥6 pass / 0 fail
+
+### 1.5 Day 1 sanity checks
+- [ ] **Backend baselines verify**
+  - `python -m pytest backend/tests/ -q --tb=no` → 1595+ collected / 0 failures(+6)
+  - `python -m mypy backend/src/api/v1/admin/tenants.py --strict` → 0 errors
+  - `python scripts/lint/run_all.py` → 8 V2 lints 8/8 green
+  - `grep -rn "import openai\|import anthropic" backend/src/agent_harness/` → 0(LLM SDK leak)
+  - Verify:All 4 sanity checks pass + recorded in progress.md
+
+### 1.6 Day 1 commit + push + progress.md
+- [ ] **Commit US-1 + push**
+  - Commit message:`feat(api, sprint-57-4): add GET /admin/tenants list endpoint with TenantListItem + filters + pagination (US-1 closes D1)`
+  - Co-author:`Co-Authored-By: Claude <noreply@anthropic.com>`
+  - progress.md Day 1 section recorded(actual_hr / est_hr ratio note)
+  - Verify:`git log main..HEAD --oneline` shows new commit + previous Day 0;remote up-to-date
+
+---
+
+## Day 2 — US-2 Frontend Infra (types + service + store)
+
+### 2.1 features/admin-tenants/ skeleton
+- [ ] **Create folder structure**
+  - `frontend/src/features/admin-tenants/{components,services,store}/`
+  - Verify:`ls frontend/src/features/admin-tenants/` shows 3 subdirs
+
+### 2.2 types.ts mirror US-1 TenantListResponse
+- [ ] **Create `frontend/src/features/admin-tenants/types.ts`**
+  - Re-export `TenantState` + `TenantPlan` from `../tenant-settings/types`(no duplicate enum per 17.md spirit + AP-11)
+  - `interface TenantListItem { id / code / display_name / state / plan / created_at / updated_at }`
+  - `interface TenantListResponse { items / total / limit / offset }`
+  - `interface TenantListQuery { state? / plan? / search? / limit / offset }`
+  - File header docstring per file-header-convention.md
+  - Verify:`cat frontend/src/features/admin-tenants/types.ts` ≥ 30 lines
+
+### 2.3 adminTenantsService.ts plain fetch with URLSearchParams
+- [ ] **Create `services/adminTenantsService.ts`**
+  - Mirror tenant-settings `_handleResponse<T>` helper(per 57.3 D6)
+  - `listTenants(query: TenantListQuery)` 構建 URLSearchParams 並 fetch GET
+  - URLSearchParams logic:if state set → params.set("state", value);same for plan/search;always set limit+offset
+  - `API_BASE = "/api/v1/admin"` + `credentials: "include"` for auth cookie
+  - Verify:`npm run lint` clean for new file
+
+### 2.4 adminTenantsStore.ts Zustand
+- [ ] **Create `store/adminTenantsStore.ts`**
+  - State:`query` (TenantListQuery with defaults) / `items` (TenantListItem[]) / `total` / `loading` / `error`
+  - Actions:`setFilter` (resets offset to 0) / `setPagination` (changes limit/offset) / `loadData` (calls listTenants) / `reset`
+  - Default query:`{ state: undefined, plan: undefined, search: undefined, limit: 50, offset: 0 }`
+  - Mirror tenant-settings store pattern(57.3)
+  - Verify:`npm run build frontend/` clean(no TS errors)
+
+### 2.5 3 Vitest unit tests US-2
+- [ ] **Create `frontend/tests/unit/admin-tenants/adminTenantsService.test.ts`**
+  - Test 1:`listTenants` happy path with all filters → URLSearchParams string verified + fetch called with correct URL
+  - Test 2:`listTenants` happy with no filter → only limit+offset in URL
+  - Verify:`npm run test -- adminTenantsService` ≥ 2 pass
+
+- [ ] **Create `frontend/tests/unit/admin-tenants/adminTenantsStore.test.ts`**
+  - Test 3:store loadData success → items + total populated + loading=false
+  - Verify:`npm run test -- adminTenantsStore` ≥ 1 pass
+
+### 2.6 Day 2 sanity checks
+- [ ] **Frontend baselines verify**
+  - `cd frontend && npm run lint` clean
+  - `cd frontend && npm run build` success / 69 → 71+ modules
+  - `cd frontend && npm run test` → 23 → 26+ tests pass(+3)
+  - Verify:All 3 sanity checks recorded in progress.md
+
+### 2.7 Day 2 commit + push + progress.md
+- [ ] **Commit US-2 + push**
+  - Commit message:`feat(frontend, sprint-57-4): add admin-tenants infra (types/service/store + 3 Vitest) (US-2)`
+  - progress.md Day 2 section + actual_hr ratio note
+  - Verify:`git log main..HEAD --oneline` shows commit;remote up-to-date
+
+---
+
+## Day 3 — US-3 + US-4 Frontend Components + Page Layout
+
+### 3.1 TenantListTable component
+- [ ] **Create `components/TenantListTable.tsx`**
+  - Columns:Code (monospace) / Display Name / State (badge: ACTIVE green / PROVISIONING+REQUESTED amber / SUSPENDED+ARCHIVED gray) / Plan (badge: ENTERPRISE blue / STANDARD gray) / Created At (relative date or ISO) / View(button → navigate `/tenant-settings/{id}`)
+  - Empty state:items.length === 0 → "No tenants match current filter" + Reset Filters 按鈕(call store.reset + loadData)
+  - Loading skeleton:5 placeholder rows when `loading === true`
+  - Verify:File ≥ 100 lines + lint clean
+
+### 3.2 TenantListFilters component
+- [ ] **Create `components/TenantListFilters.tsx`**
+  - State dropdown(All / PROVISIONING / REQUESTED / ACTIVE / SUSPENDED / ARCHIVED)
+  - Plan dropdown(All / STANDARD / ENTERPRISE)
+  - Search input(maxLength=128;onChange + 300ms debounce → trigger setFilter)
+  - Apply button(triggers loadData immediately)
+  - Reset button(call store.reset → reloadData)
+  - Verify:File ≥ 80 lines + lint clean
+
+### 3.3 TenantListPagination component
+- [ ] **Create `components/TenantListPagination.tsx`**
+  - Prev button(disabled if offset === 0;onClick setPagination({ offset: offset - limit }) + loadData)
+  - Next button(disabled if offset + limit >= total;onClick setPagination({ offset: offset + limit }) + loadData)
+  - Page indicator: `"{offset+1}-{min(offset+limit,total)} of {total}"`
+  - Verify:File ≥ 50 lines + lint clean
+
+### 3.4 pages/admin-tenants/index.tsx page layout
+- [ ] **Create `pages/admin-tenants/index.tsx`**
+  - Layout:`<TenantListFilters />` 上 + `<TenantListTable />` 中 + `<TenantListPagination />` 下
+  - On mount(useEffect):解析 `window.location.search` URLSearchParams → set store filters → loadData
+  - On filter/pagination change(subscribe store):更新 URL via `window.history.replaceState` + state object
+  - Verify:File ≥ 60 lines + lint clean
+
+### 3.5 5 Vitest unit tests (3 US-3 + 2 US-4)
+- [ ] **Create `frontend/tests/unit/admin-tenants/TenantListTable.test.tsx`**
+  - Test 1:render with mock items(2 rows)→ assert rows + state badges + plan badges visible
+  - Test 2:render with empty items → assert empty state text + Reset Filters button visible
+  - Verify:`npm run test -- TenantListTable` ≥ 2 pass
+
+- [ ] **Create `frontend/tests/unit/admin-tenants/TenantListFilters.test.tsx`**
+  - Test 3:select state dropdown → assert setFilter called with state value
+  - Verify:`npm run test -- TenantListFilters` ≥ 1 pass
+
+- [ ] **Create `frontend/tests/unit/admin-tenants/AdminTenantsPage.test.tsx`**
+  - Test 4:page mount → loadData called(spyOn store)
+  - Test 5:Pagination next click → setPagination + loadData called
+  - Verify:`npm run test -- AdminTenantsPage` ≥ 2 pass
+
+### 3.6 Day 3 sanity checks
+- [ ] **Frontend baselines verify**
+  - `cd frontend && npm run lint` clean
+  - `cd frontend && npm run build` success / 71 → 76+ modules
+  - `cd frontend && npm run test` → 26 → 31+ tests pass(+5)
+  - Verify:All 3 sanity checks recorded in progress.md
+
+### 3.7 Day 3 commit + push + progress.md
+- [ ] **Commit US-3 + US-4 + push**
+  - Commit message:`feat(frontend, sprint-57-4): add admin-tenants components + page layout + 5 Vitest (US-3 + US-4)`
+  - progress.md Day 3 section + actual_hr ratio note
+  - Verify:`git log main..HEAD --oneline` shows commit;remote up-to-date
+
+---
+
+## Day 4 — US-5 Routing + Playwright E2E + Closeout Ceremony
+
+### 4.1 App.tsx route + Home nav Link
+- [ ] **Modify `frontend/src/App.tsx`**
+  - Add import: `import { AdminTenantsPage } from "./pages/admin-tenants";` (or direct path)
+  - Add Route: `<Route path="/admin-tenants" element={<AdminTenantsPage />} />`
+  - Add Home nav `<Link to="/admin-tenants">Admin Tenants Console</Link>`(always visible per 57.1 D10 Option C — backend 401/403 surfaces as Error UX)
+  - File header MHist:`+ N+1 line: 2026-05-08: Sprint 57.4 — wire /admin-tenants route + Home Link (US-5)`
+  - Verify:`grep -n "admin-tenants" frontend/src/App.tsx` shows Route + Link
+
+### 4.2 Playwright e2e admin_tenants_list.spec.ts (4 cases)
+- [ ] **Create `frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts`**
+  - Use `page.route()` browser-layer mock per 57.1 v2 D19 + 57.3 D13 pattern
+  - Test 1 (happy path):mock GET → render table → assert ≥1 row + code + state badge visible
+  - Test 2 (filter):click state dropdown → select ACTIVE → assert second mocked GET with `?state=ACTIVE` triggered
+  - Test 3 (click row navigation):mock GET → click View button → assert URL contains `/tenant-settings/`
+  - Test 4 (empty state):mock GET returns `items: [], total: 0` → assert "No tenants match" text + Reset button visible
+  - Verify:`cd frontend && npx playwright test admin_tenants_list` ≥ 4 pass(< 30s each)
+
+### 4.3 Final pytest + lint + leak verify
+- [ ] **Backend final baselines**
+  - `python -m pytest backend/tests/ -q --tb=no` → 1595+ collected / 0 failures(+6)
+  - `python -m mypy backend/src --strict` → 0 errors / 295 source files unchanged
+  - `python scripts/lint/run_all.py` → 8 V2 lints 8/8 green
+  - LLM SDK leak grep → 0
+  - Verify:Documented in progress.md ✅
+- [ ] **Frontend final baselines**
+  - `cd frontend && npm run lint` clean
+  - `cd frontend && npm run build` success / 76+ modules / ~210 kB(estimated +6 KB)
+  - `cd frontend && npm run test` → 31+ tests pass(+8)
+  - Playwright e2e:15 → 19+ tests pass(+4)
+  - Verify:Documented in progress.md ✅
+
+### 4.4 Retrospective.md
+- [ ] **Create `docs/03-implementation/agent-harness-execution/phase-57/sprint-57-4/retrospective.md`**
+  - Q1 What went well
+  - Q2 What didn't go well + AD-Sprint-Plan-4 mixed 4th application calibration verify(actual_hr / committed_hr ratio + 4-data-point window mean + KEEP/SHIFT recommendation)
+  - Q3 What we learned + Day 0 三-prong second fully-applied sprint observations(time / drifts / ROI evidence vs 57.3 first application)
+  - Q4 Audit Debt deferred(明確標 ID + target sprint)
+  - Q5 Next steps + Phase 57.x next-sprint candidates(rolling planning;不寫具體未來 sprint 任務,只寫 carryover 候選)
+  - Q6 Solo-dev policy validation
+  - Verify:`wc -l retrospective.md` ≥ 200 lines
+
+### 4.5 Memory snapshot + MEMORY.md index
+- [ ] **Create `memory/project_phase57_4_admin_tenants_list.md`**
+  - Same format as `project_phase57_3_tenant_settings.md`
+  - Verify:File created + frontmatter complete
+- [ ] **Update MEMORY.md index** add 1 line entry
+  - Verify:`grep "phase57_4" MEMORY.md` shows 1 result
+
+### 4.6 Open PR + CI green + solo-dev merge
+- [ ] **Push branch + open PR**
+  - Push:`git push -u origin feature/sprint-57-4-admin-tenants-list-bundle`
+  - PR title:`Sprint 57.4 — Phase 57+ SaaS Frontend 3/N: Admin Tenants Console list bundle`
+  - PR body:Sprint goal + 5 USs + acceptance + AD-Sprint-Plan-4 4th app verdict + D-findings reference
+  - Verify:5 active CI checks green;solo-dev policy review_count=0 satisfied
+- [ ] **Squash merge to main**
+  - DoD:GitHub UI squash + merge;branch deleted post-merge
+  - Verify:main HEAD updated;`git pull main` shows new commit
+
+### 4.7 Closeout PR
+- [ ] **Closeout branch + PR**
+  - Branch:`chore/sprint-57-4-closeout`
+  - Updates:SITUATION-V2 §9 milestones row + §11 Last Updated + Update history;CLAUDE.md Phase / Latest Sprint / main HEAD / Last Updated / Current Phase fields
+  - Commit message:`docs(closeout, sprint-57-4): SITUATION-V2 + CLAUDE.md sync to Phase 57+ Frontend SaaS 3/N opens`
+  - PR body:reference Sprint 57.4 PR + summary stats(pytest delta / Vitest delta / Playwright delta / Vite build modules delta / calibration ratio)
+  - Verify:Squash merge to main;both branches deleted;working tree clean

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-4-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-4-plan.md
@@ -1,0 +1,590 @@
+# Sprint 57.4 — Phase 57+ SaaS Frontend 3rd: Admin Tenants Console List View Bundle (backend list endpoint + frontend console)
+
+> **Sprint Type**: Phase 57+ third sprint — mixed scope class (backend + frontend bundle) for first admin tenants console list UX over 56.1+57.3 single-tenant CRUD stack;closes plan-time Prong 2 D1 RED finding (backend admin tenants.py 缺 GET `""` list endpoint);4th application of `mixed` 0.60 multiplier
+> **Owner Categories**: §Frontend (16-frontend-design.md §Admin Tenants Console) / §Backend Admin API (extends 56.1+57.3 admin tenants endpoint set with list) / consumes 56.1 Tenant ORM + 56.2 RBAC + 57.3 single-tenant CRUD pattern
+> **Phase**: 57 (Frontend SaaS — 3/N sprint;follow-on candidates: Onboarding self-serve wizard (still requires backend re-design) / Feature flags admin UI / Audit log frontend view / DR / GDPR;rolling planning per .claude/rules/sprint-workflow.md)
+> **Workload**: 5 days (Day 0-4); bottom-up est ~14 hr → calibrated commit **~8 hr** (multiplier **0.60** per AD-Sprint-Plan-4 scope-class matrix `mixed` 4th application;3-data-point window mean **0.92** ✅ in band → KEEP 0.60 mid-band;若 ratio outside [0.85, 1.20] → AD-Sprint-Plan-N+1 logged)
+> **Branch**: `feature/sprint-57-4-admin-tenants-list-bundle`
+> **Plan Authority**: This document (per CLAUDE.md §Sprint Execution Workflow)
+> **Roadmap Source**: 16-frontend-design.md §Admin Tenants Console + 56.1+57.3 admin tenants endpoint set + Sprint 57.3 retrospective Q5 (Phase 57.x candidate scope user-approved 2026-05-07 Option A pre-emptive bundle) + plan-time Prong 2 探勘 D1 RED 已 caught (backend admin tenants.py 缺 GET `""` list endpoint)
+> **AD logging (sub-scope)**: AD-Sprint-Plan-4 scope-class matrix `mixed` 4th application(3-data-point window mean 0.92 KEEP 0.60 mid-band);Day 0 三-prong 探勘 v3 — Path + Content + Schema all attempted(Schema verdict = N/A 但 attempt 完成);此為 second fully-applied 三-prong sprint;ROI evidence accumulating
+
+---
+
+## Sprint Goal
+
+Open the **first admin tenants console list UX surface** for Phase 57+ SaaS Frontend by bundling 1 backend list endpoint + 1 frontend Admin Tenants Console page in a single mixed-scope sprint:
+
+- **US-1**: Backend `GET /admin/tenants` — paginated list of all tenants with optional filter by state / plan + ILIKE search on code+display_name;TenantListResponse Pydantic with items array + total count + limit + offset;require_admin_platform_role per 56.2 RBAC pattern;reuses Tenant ORM + TenantState/TenantPlan enum from 56.1 identity.py;6-8 unit + integration tests
+- **US-2**: Frontend `frontend/src/features/admin-tenants/` infra — service + store + types mirroring 57.3 tenant-settings pattern(plain fetch + `_handleResponse<T>` + Zustand;query state + filters + items + pagination);types.ts mirror US-1 TenantListResponse + TenantListQuery;3 Vitest unit tests
+- **US-3**: Frontend `features/admin-tenants/components/TenantListTable.tsx`(table with rows: code / display_name / state badge / plan badge / created_at / view button → navigate `/tenant-settings/{id}`)+ `TenantListFilters.tsx`(state dropdown + plan dropdown + search input + apply button);table empty-state + loading skeleton;3 Vitest unit tests
+- **US-4**: Frontend `pages/admin-tenants/index.tsx`(layout: filters bar top + table center + pagination bottom)+ `TenantListPagination.tsx`(prev/next + page indicator + total count display);URL query string sync(filters reflected in URL per shareability);2 Vitest unit tests
+- **US-5**: Routing + Playwright e2e + closeout — App.tsx 加 `/admin-tenants` route + Home nav link(always visible per 57.1 D10 Option C);3 Playwright e2e specs(`admin_tenants_list.spec.ts` happy + filter + click-row navigation + empty state);retrospective(6 必答 + AD-Sprint-Plan-4 mixed 4th app verify + Phase 57.x next-sprint candidates Q5)+ memory snapshot + SITUATION-V2 + CLAUDE.md sync
+
+Sprint 結束後:
+- (a) **Admin Tenants Console 主流量 functional** — admin user 可 browse `/admin-tenants` → 看 paginated tenant list → filter by state/plan → search by code → click row → navigate to `/tenant-settings/{id}` → 編輯後返回 list
+- (b) **Backend admin tenants.py 補齊 R(list) surface** — GET `""` 補齐 56.1+57.3 missing list capability;為後續 Onboarding self-serve / multi-tenant impersonation / audit trace 鋪通用 list pattern
+- (c) **AD-Sprint-Plan-4 `mixed` 4th-data-point** — 3-data-point window 平均 0.92 in band;若 ratio in band → 4-data-point window 形成 mid-band 穩定信號(若連續 4 in-band 可考慮 evaluate band tightening per matrix 紀律;若 outside → AD-Sprint-Plan-N+1 logged)
+- (d) **D1 RED finding plan-time closed** — 與 57.3 同樣 plan-time Prong 2 探勘 catch;Option A pre-emptive bundle user-approved 2026-05-07 → 17.md single-source 不變;可作為 plan-time 探勘 ROI evidence 第 4 個 data point
+- (e) **Frontend SaaS 3/N rolling planning continues** — Sprint 57.4 retro Q5 列出 Phase 57.x candidate scope(Onboarding self-serve wizard requires backend self-serve API design / Feature flags admin UI / Audit log frontend view / DR / GDPR / SaaS Stage 2);user approval required per rolling planning 紀律
+
+**主流量驗收標準**:
+- `npm run dev` → admin user browse `/admin-tenants` → see all tenants in paginated table(預設 limit=50 / offset=0)
+- `npm run dev` → admin user filter by state=ACTIVE → table refreshes only ACTIVE tenants
+- `npm run dev` → admin user filter by plan=ENTERPRISE → table refreshes only ENTERPRISE tenants
+- `npm run dev` → admin user search "ACME" → table refreshes ILIKE match
+- `npm run dev` → admin user click row → navigate to `/tenant-settings/{id}` → 57.3 view+edit functional
+- `pytest backend/tests/integration/api/test_admin_tenant_list.py` ≥ 6 new tests pass
+- Playwright e2e 3-4 tests pass(happy + filter + click-row + empty)< 30s each
+- `npm run lint && npm run build` clean
+- `npm run test` (Vitest unit) ≥ 8 new tests pass
+- Backend pytest baseline 1589 → 1595+(+6 from US-1)
+- 8 V2 lints baseline 8/8 unchanged
+
+---
+
+## Background
+
+### V2 進度
+
+- **22/22 sprints (100%) main progress completed** + **Phase 56-58 SaaS Stage 1 3/3 ✅ CLOSED** (Sprint 56.3) + **Phase 57+ Frontend SaaS 2/N completed**(Sprint 57.1 v2 Cost+SLA dashboards + Sprint 57.3 Tenant Settings bundle)
+- main HEAD: `a558f98b` (Sprint 57.3 closeout PR #109) — Day 0 verified
+- pytest baseline 1589 / mypy --strict 0/295 source files / 8 V2 lints 8/8 green / LLM SDK leak 0
+- Vitest baseline 23 / Playwright e2e baseline 15 / Vite build 69 modules / 203.02 kB
+- 57.3 calibration `mixed` 0.60 mid-band 3rd application ratio **0.57** under band (3-data-point mean **0.92 ✅** in band — KEEP 0.60 per matrix discipline single-sprint not enough to shift mid-band)
+- 14-sprint cumulative window 8/14 (57%) in-band slipped below 60% threshold for first time after 3 consecutive sprints in-band
+- **本 sprint = Phase 57+ SaaS Frontend 第 3 個 sprint**(3/N rolling;57.1 v2 Cost+SLA + 57.3 Tenant Settings bundle delivered;57.4 Admin Tenants Console list view)
+
+### 為什麼 57.4 是 Admin Tenants Console list bundle 而非純 frontend
+
+User approved 2026-05-07 Option A(`backend list endpoint + frontend Admin Tenants Console page bundle` — pre-emptive pivot from naive medium-frontend assumption per plan-time Prong 2 catch):
+
+1. **57.4 plan-time Prong 2 catch** — Day 0 plan-time content verify 揭露 56.1+57.3 admin tenants.py 既有 endpoints (POST `""` create + GET `/{id}/onboarding-status` + POST `/{id}/onboarding/{step}` + GET `/{id}` + PATCH `/{id}`),**沒有** GET `""` list endpoint;Admin Tenants Console UI 必要的 list+filter+pagination 完全不存在;類比 57.3 v1 D1 RED catch
+2. **Option A pre-emptive bundle 解決真正 backend gap** — 而非 abort;新增 GET `""` list 後 future Onboarding self-serve admin / impersonation / audit list view / multi-tenant compliance dashboard 全可重用 list pattern;ROI 高
+3. **Mixed scope class 4th data point** — `mixed` 多 backend + frontend 比例對於 Phase 57+ 持續 frontend SaaS 推進是常見組合;補強 calibration matrix mixed 軸從 3-data-point → 4-data-point window
+4. **Conservative US-1 scope** — 為避免 over-推測,US-1 list endpoint 只暴露 必要 query params(state / plan / search / limit / offset);不在 list endpoint 跨界(no per-tenant detail data;list-only;rich detail 走 57.3 GET `/{id}`)
+5. **AD-Plan-3 + AD-Plan-4 兩+三 prong already fold-in to sprint-workflow.md §Step 2.5 (Sprint 55.6 + 57.1 v2)** — 此 sprint 為 second fully-applied Day 0 三-prong 探勘 sprint(Path + Content + Schema all attempted);可作為 process AD ROI 第 4 個 data point(57.3 為 first;57.4 為 second)
+
+### 既有結構(Day 0 plan-time 探勘 grep 已驗證以下事實)
+
+✅ **以下 layout 是 plan-time 已 verified via Day 0 三-prong 探勘**:
+
+```
+backend/src/api/v1/admin/                          # ✅ 56.1+56.2+56.3+57.3 既有
+├── tenants.py                                     # ⚠️ MODIFY (US-1: add GET "" list endpoint)
+│   ├── @router.post("")                           # ✅ existing (56.1 create_tenant)
+│   ├── @router.get("/{id}/onboarding-status")     # ✅ existing (56.1)
+│   ├── @router.post("/{id}/onboarding/{step}")    # ✅ existing (56.1)
+│   ├── @router.get("/{id}")                       # ✅ existing (57.3)
+│   ├── @router.patch("/{id}")                     # ✅ existing (57.3)
+│   ├── @router.get("")                            # ❌ NEW (US-1 list endpoint)
+│   ├── class TenantResponse                       # ✅ existing (57.3 reusable for /{id})
+│   ├── class TenantListItem                       # ❌ NEW (US-1 lightweight subset)
+│   └── class TenantListResponse                   # ❌ NEW (US-1 items+pagination wrapper)
+├── cost_summary.py                                # ✅ existing (56.3)
+└── sla_reports.py                                 # ✅ existing (56.3)
+
+backend/src/platform_layer/identity/auth.py        # ✅ 56.2 existing
+└── require_admin_platform_role                    # ✅ existing reusable
+
+backend/src/infrastructure/db/models/identity.py   # ✅ 56.1 existing (no migration needed)
+├── class Tenant                                   # ✅ existing (filter+search target)
+├── class TenantState (enum)                       # ✅ existing reusable
+└── class TenantPlan (enum)                        # ✅ existing reusable
+
+frontend/src/                                      # ✅ 57.1 v2 + 57.3 既有 + Vitest setup
+├── features/
+│   ├── chat_v2/                                   # ✅ existing
+│   ├── governance/                                # ✅ existing (53.5)
+│   ├── cost-dashboard/                            # ✅ existing (57.1 v2)
+│   ├── sla-dashboard/                             # ✅ existing (57.1 v2)
+│   ├── tenant-settings/                           # ✅ existing (57.3)
+│   └── admin-tenants/                             # ❌ NEW (US-2 + US-3 + US-4)
+│       ├── components/TenantListTable.tsx         # ❌ NEW
+│       ├── components/TenantListFilters.tsx       # ❌ NEW
+│       ├── components/TenantListPagination.tsx    # ❌ NEW
+│       ├── services/adminTenantsService.ts        # ❌ NEW (plain fetch + _handleResponse)
+│       ├── store/adminTenantsStore.ts             # ❌ NEW (Zustand with filters + pagination)
+│       └── types.ts                               # ❌ NEW (mirror US-1 TenantListResponse)
+├── pages/
+│   ├── chat-v2/index.tsx                          # ✅ existing
+│   ├── governance/index.tsx                       # ✅ existing
+│   ├── verification/index.tsx                     # ✅ existing
+│   ├── cost-dashboard/index.tsx                   # ✅ existing
+│   ├── sla-dashboard/index.tsx                    # ✅ existing
+│   ├── tenant-settings/index.tsx                  # ✅ existing (57.3)
+│   └── admin-tenants/index.tsx                    # ❌ NEW (US-4)
+└── App.tsx                                        # ⚠️ MODIFY (US-5: add 1 route + 1 nav link)
+
+frontend/tests/                                     # ✅ existing (57.1 v2 + 57.3 Vitest setup)
+├── e2e/
+│   ├── chat/, governance/, cost_dashboard/, sla_dashboard/, tenant-settings/  # ✅ existing
+│   └── admin_tenants/admin_tenants_list.spec.ts   # ❌ NEW (US-5)
+└── unit/  (Vitest)                                 # ✅ existing (23 tests baseline)
+```
+
+### Sprint 57.3 retrospective Q5 對齊確認
+
+Sprint 57.3 retrospective Q5 列出 Phase 57.x candidate scope:
+- Admin tenant console list view (medium-frontend ~10-12 hr × 0.65) ✅ **此 sprint US-1~US-5(pivoted to mixed bundle 0.60 per Day 0 plan-time D1)**
+- Onboarding self-serve wizard ⛔ defer pending backend self-serve API
+- Feature flags admin UI ⛔ defer Phase 57.x
+- Audit log frontend view ⛔ defer Phase 57.x
+- DR + WAL streaming (large multi-domain) ⛔ defer Phase 57.x
+- Compliance partial GDPR (medium-backend) ⛔ defer Phase 57.x
+- SaaS Stage 2 Stripe + 月結 ⛔ defer Phase 57++
+- AD-Cat10-VisualVerifier + Frontend-Panel ⛔ defer Phase 57.x Group F
+- AD-Cat11-Multiturn / SSEEvents / ParentCtx ⛔ defer Phase 57.x Cat 11 bundle
+- AD-CI-6 production launch ⛔ defer Phase 58 dedicated sprint
+
+### V2 紀律 9 項對齊確認
+
+1. **Server-Side First** ✅ Backend GET list 完全 server-side;tenant_id filter 由 require_admin_platform_role JWT 驗證(super-admin 看所有 tenants 是合法 admin operation per 56.2 RBAC pattern)
+2. **LLM Provider Neutrality** ✅ 此 sprint 不動 LLM 鏈路
+3. **CC Reference 不照搬** ✅ Admin tenants list 為標準 SaaS admin console pattern;plain fetch + Zustand stack 既有
+4. **17.md Single-source** ✅ 此 sprint 不新增 cross-category interface;TenantListItem + TenantListResponse 為 admin API 內部 DTO,non-cross-category;不影響 17.md
+5. **11+1 範疇歸屬** ✅ US-1 §API admin layer(non-範疇)+ US-2~US-5 全 §Frontend(16-frontend-design.md);無範疇 1-12 backend module 變更;每檔案明確歸屬;無 AP-3
+6. **04 anti-patterns** ✅ AP-3 範疇歸屬合規 / AP-4(Potemkin)— 全有實際 wire-up + Playwright e2e + backend pytest 強制驗證 / AP-6(Hybrid Bridge Debt)— 不為 Stage 2 預寫 abstraction;list 嚴格限制 query params;不暴露 list-vs-detail 跨界 logic / AP-9(Verification)— Pydantic v2 query validation + Playwright + 422 invalid query test 強制 verify / AP-11(命名一致)— `admin-tenants` consistent naming(對齊 backend `admin/tenants.py` 路徑 + frontend `pages/admin-tenants/`)
+7. **Sprint workflow** ✅ plan → checklist → Day 0 三-prong 探勘(Path + Content + Schema all DONE)→ code → progress → retro;本文件依 57.3 plan 結構鏡射(14 sections / 5 days Day 0-4)
+8. **File header convention** ✅ 所有 new 檔案含 file header docstring;modify 檔案加 Modification History entry;MHist 1-line max per AD-Lint-3 + char-count guidance per AD-Lint-MHist-Verbosity
+9. **Multi-tenant rule** ✅ tenants 表本身非 TenantScopedMixin(它**就是** tenant);US-1 list 安全靠 require_admin_platform_role super-admin RBAC;non-admin 401/403;RLS check 8 V2 lint check_rls_policies 不適用 tenants 表(56.1 US-5 baseline)
+
+---
+
+## User Stories
+
+### US-1: Backend GET /admin/tenants list endpoint
+
+**As** a SaaS platform super-admin
+**I want** a paginated list endpoint that returns all tenants with optional filters by state / plan + ILIKE search
+**So that** I can browse + manage all tenants from web UI without DB tools,and frontend Admin Tenants Console page can render the table
+
+**Acceptance**:
+- `backend/src/api/v1/admin/tenants.py` 新增 `@router.get("", response_model=TenantListResponse)` endpoint
+- Pydantic `TenantListItem`(lightweight subset of TenantResponse)— `id` (UUID) / `code` (str) / `display_name` (str) / `state` (TenantState) / `plan` (TenantPlan) / `created_at` (datetime) / `updated_at` (datetime);**non-include** `provisioning_progress` / `onboarding_progress` / `meta_data`(reduce payload size for list view)
+- Pydantic `TenantListResponse` — `items: list[TenantListItem]` / `total: int` / `limit: int` / `offset: int`
+- Query parameters:
+  - `state: TenantState | None = Query(None)` — filter by exact state
+  - `plan: TenantPlan | None = Query(None)` — filter by exact plan
+  - `search: str | None = Query(None, max_length=128)` — ILIKE on `code` OR `display_name`
+  - `limit: int = Query(50, ge=1, le=200)` — pagination size
+  - `offset: int = Query(0, ge=0)` — pagination start
+- Auth dependency:`require_admin_platform_role` per 56.2 RBAC pattern(super-admin only;non-platform-admin → 401/403)
+- ORDER BY `created_at DESC`(newest first)
+- 6-8 tests:happy path no filter / filter by state / filter by plan / search by code substring / pagination limit+offset / 401 unauth / 403 wrong role / response shape assertion / empty result
+- `pytest backend/tests/integration/api/test_admin_tenant_list.py` pass
+- Backend pytest baseline 1589 → 1595+
+
+### US-2: Frontend Admin Tenants Infrastructure
+
+**As** the React app
+**I want** per-feature folder skeleton for admin-tenants mirroring tenant-settings pattern(infra reuse from 57.3)
+**So that** Admin Tenants Console UI has consistent code organization,types match US-1 TenantListResponse,store handles filters+pagination+items lifecycle
+
+**Acceptance**:
+- `frontend/src/features/admin-tenants/` skeleton:components/ services/ store/ types.ts
+- `types.ts`:mirror US-1 TenantListItem + TenantListResponse + `TenantListQuery` interface(state? / plan? / search? / limit / offset);re-export TenantState + TenantPlan from `tenant-settings/types`(no duplicate enum per 17.md spirit + AP-11 命名一致)
+- `adminTenantsService.ts`:`listTenants(query: TenantListQuery)` 構建 URLSearchParams 並 fetch GET;mirror `tenantSettingsService.ts` plain fetch + `_handleResponse<T>` pattern;`API_BASE = "/api/v1/admin"`
+- `adminTenantsStore.ts`:Zustand state(`query / items / total / loading / error`;actions:`setFilter / setPagination / loadData / reset`);mirror tenant-settings store pattern
+- 3 Vitest unit tests:listTenants happy + URLSearchParams construction + store loadData action
+
+### US-3: Frontend Admin Tenants Components (Table + Filters)
+
+**As** a SaaS platform super-admin
+**I want** a sortable table with state/plan badges + filter dropdowns + search input
+**So that** I can quickly find specific tenants and navigate to their detail page
+
+**Acceptance**:
+- `frontend/src/features/admin-tenants/components/TenantListTable.tsx`:
+  - Columns: Code (monospace) / Display Name / State (badge color: ACTIVE green / PROVISIONING+REQUESTED amber / SUSPENDED+ARCHIVED gray) / Plan (badge color: ENTERPRISE blue / STANDARD gray) / Created At (relative date) / View(button → `/tenant-settings/{id}`)
+  - Empty state:若 items.length === 0 → "No tenants match current filter" 提示 + Reset Filters 按鈕
+  - Loading skeleton:5 placeholder rows when `loading === true`
+- `frontend/src/features/admin-tenants/components/TenantListFilters.tsx`:
+  - State dropdown(All / PROVISIONING / REQUESTED / ACTIVE / SUSPENDED / ARCHIVED)
+  - Plan dropdown(All / STANDARD / ENTERPRISE)
+  - Search input(maxLength=128;debounced 300ms 後 trigger applyFilters)
+  - Apply button + Reset button(reset filters → reload)
+- 3 Vitest unit tests:TenantListTable render with mock data(rows + badges)+ TenantListTable empty state + TenantListFilters interactions(select state / search input)
+
+### US-4: Frontend Admin Tenants Page (Layout + Pagination)
+
+**As** a SaaS platform super-admin
+**I want** the page layout combining filters + table + pagination with URL query string sync
+**So that** I can share filter URLs with team members and navigate naturally
+
+**Acceptance**:
+- `frontend/src/pages/admin-tenants/index.tsx` page wrapper:
+  - Layout:`<TenantListFilters />` 上 + `<TenantListTable />` 中 + `<TenantListPagination />` 下
+  - On mount:解析 URL query string → set store filters → loadData
+  - On filter/pagination change:更新 URL query string(history.replaceState)+ trigger loadData
+- `frontend/src/features/admin-tenants/components/TenantListPagination.tsx`:
+  - Prev button(disabled if offset === 0)
+  - Next button(disabled if offset + limit >= total)
+  - Page indicator: "{offset+1}-{min(offset+limit,total)} of {total}"
+- 2 Vitest unit tests:page mount → loadData called + Pagination prev/next click → setPagination called
+
+### US-5: Routing + Playwright E2E + Closeout Ceremony
+
+**As** the V2 sprint executor
+**I want** App.tsx route + Home nav + Playwright e2e tests + retrospective + AD-Sprint-Plan-4 mixed 4th app calibration verify
+**So that** Sprint 57.4 closes Phase 57+ SaaS Frontend 3/N with full audit trail
+
+**Acceptance**:
+- `frontend/src/App.tsx`:add `<Route path="/admin-tenants" element={<AdminTenantsPage />} />`(non-wildcard)
+- Home page nav:add `<Link to="/admin-tenants">Admin Tenants Console</Link>` — always visible per 57.1 D10 Option C(no frontend role gate;backend 401/403 surfaces as Error UX)
+- `frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts`:
+  - happy path:admin auth → load `/admin-tenants` → assert table rendered with mock data 
+  - filter:select state=ACTIVE → assert table re-renders with filtered rows
+  - click row:click View button → assert URL navigates to `/tenant-settings/{id}` 
+  - empty state:filter with no match → assert empty state UI visible
+- retrospective.md(6 必答 + AD-Sprint-Plan-4 mixed 4th app calibration verify + Phase 57.x next-sprint candidates Q5 + Day 0 三-prong 探勘 second fully-applied sprint observations)
+- Memory snapshot `memory/project_phase57_4_admin_tenants_list.md`
+- SITUATION-V2 §9 + CLAUDE.md sync to **Phase 57+ SaaS Frontend 3/N (Sprint 57.4 closed — Admin Tenants Console list bundle)**
+
+---
+
+## Technical Specifications
+
+### Backend Endpoint Pattern (mirror 56.1 + 56.2 + 56.3 + 57.3)
+
+```python
+# backend/src/api/v1/admin/tenants.py — NEW additions
+
+class TenantListItem(BaseModel):
+    """Lightweight item for tenant list (subset of TenantResponse)."""
+    id: UUID
+    code: str
+    display_name: str
+    state: TenantState
+    plan: TenantPlan
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TenantListResponse(BaseModel):
+    """Paginated list response wrapper."""
+    items: list[TenantListItem]
+    total: int
+    limit: int
+    offset: int
+
+
+@router.get(
+    "",
+    response_model=TenantListResponse,
+    dependencies=[Depends(require_admin_platform_role)],
+)
+async def list_tenants(
+    state: TenantState | None = Query(None),
+    plan: TenantPlan | None = Query(None),
+    search: str | None = Query(None, max_length=128),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db_session),
+) -> TenantListResponse:
+    base_stmt = select(Tenant)
+    if state is not None:
+        base_stmt = base_stmt.where(Tenant.state == state)
+    if plan is not None:
+        base_stmt = base_stmt.where(Tenant.plan == plan)
+    if search is not None:
+        like = f"%{search}%"
+        base_stmt = base_stmt.where(
+            or_(Tenant.code.ilike(like), Tenant.display_name.ilike(like))
+        )
+
+    # Total count for pagination
+    count_stmt = select(func.count()).select_from(base_stmt.subquery())
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    # Paginated items (newest first)
+    page_stmt = (
+        base_stmt.order_by(Tenant.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    rows = (await db.execute(page_stmt)).scalars().all()
+
+    return TenantListResponse(
+        items=[TenantListItem.model_validate(t) for t in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+```
+
+### Service Pattern (mirror 57.3 tenantSettingsService.ts)
+
+```typescript
+// frontend/src/features/admin-tenants/services/adminTenantsService.ts
+import type { TenantListQuery, TenantListResponse } from "../types";
+
+const API_BASE = "/api/v1/admin";
+
+async function _handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let detail = `HTTP ${response.status}`;
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (body.detail) detail = body.detail;
+    } catch { /* ignore */ }
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+export async function listTenants(query: TenantListQuery): Promise<TenantListResponse> {
+  const params = new URLSearchParams();
+  if (query.state) params.set("state", query.state);
+  if (query.plan) params.set("plan", query.plan);
+  if (query.search) params.set("search", query.search);
+  params.set("limit", String(query.limit));
+  params.set("offset", String(query.offset));
+
+  const response = await fetch(
+    `${API_BASE}/tenants?${params.toString()}`,
+    { credentials: "include" },
+  );
+  return _handleResponse<TenantListResponse>(response);
+}
+```
+
+### Zustand Store Pattern (mirror 57.3 tenantSettingsStore.ts)
+
+```typescript
+// frontend/src/features/admin-tenants/store/adminTenantsStore.ts
+import { create } from "zustand";
+import type { TenantListQuery, TenantListItem } from "../types";
+import { listTenants } from "../services/adminTenantsService";
+
+interface AdminTenantsState {
+  query: TenantListQuery;
+  items: TenantListItem[];
+  total: number;
+  loading: boolean;
+  error: string | null;
+  setFilter: (partial: Partial<Omit<TenantListQuery, "limit" | "offset">>) => void;
+  setPagination: (partial: { limit?: number; offset?: number }) => void;
+  loadData: () => Promise<void>;
+  reset: () => void;
+}
+
+const DEFAULT_QUERY: TenantListQuery = {
+  state: undefined,
+  plan: undefined,
+  search: undefined,
+  limit: 50,
+  offset: 0,
+};
+
+export const useAdminTenantsStore = create<AdminTenantsState>((set, get) => ({
+  query: { ...DEFAULT_QUERY },
+  items: [],
+  total: 0,
+  loading: false,
+  error: null,
+  setFilter: (partial) =>
+    set((s) => ({ query: { ...s.query, ...partial, offset: 0 } })),
+  setPagination: (partial) =>
+    set((s) => ({ query: { ...s.query, ...partial } })),
+  loadData: async () => {
+    set({ loading: true, error: null });
+    try {
+      const data = await listTenants(get().query);
+      set({ items: data.items, total: data.total, loading: false });
+    } catch (err) {
+      set({ error: (err as Error).message, loading: false });
+    }
+  },
+  reset: () => set({ query: { ...DEFAULT_QUERY }, items: [], total: 0, loading: false, error: null }),
+}));
+```
+
+### Risk Class A/B/C — A retired, B+C still N/A
+
+- Risk Class A: paths-filter retired by 55.6 Option Z;此 sprint 不適用
+- Risk Class B: cross-platform mypy unused-ignore — 此 sprint 涉及 backend(US-1);若 import drift(`from sqlalchemy import or_, func` 既有 56.x 用過;低概率)→ 套 `# type: ignore[import-not-found, unused-ignore]` 雙 code per code-quality.md;mitigation 於 Day 1 sanity check 階段
+- Risk Class C: module-level singleton — backend 部分若 query helpers 涉及 module-level cache(56.x ServiceFactory pattern);US-1 list endpoint integration test 應在 `tests/integration/api/conftest.py` 確認 autouse `_reset_module_singletons` fixture 已存在(53.6+57.3 baseline);Day 1 sanity check verify
+
+### Day 0 三-prong 探勘 v3 capture (second fully-applied sprint)
+
+Sprint 57.4 是 Day 0 三-prong 探勘 second fully-applied sprint(Path + Content + Schema all attempted;Schema verdict = N/A 但 attempt 完成):
+- Prong 1 Path Verify ✅ done — 6 frontend folder existence checks + 2 backend file existence checks
+- Prong 2 Content Verify ✅ done — 6 backend assertion grep checks(D1 RED catch — backend admin tenants.py 缺 GET `""` list endpoint)
+- Prong 3 Schema Verify ✅ N/A — 無新 DB schema/migration;但 attempt 完成(per fold-in spirit;Tenant ORM 既有 7-9 fields verified for filter+search compatibility)
+
+**ROI:** D1 catch via Prong 2 (~30 min cost) prevented 8-12 hr Day 1+ rework(類比 57.3 Day 0 catch 8-12 hr 57.1 v1-style abort);**ROI ≈ 16-24×**;Sprint 57.4 為 second fully-applied 三-prong sprint;ROI evidence 累積 → Sprint 58+ 可考慮 evaluate 三-prong 為 standard practice
+
+---
+
+## Acceptance Criteria
+
+### Sprint-Wide
+
+- [ ] V2 主進度 22/22 (100%) 不變;Phase 56-58 SaaS Stage 1 backend 3/3 不變;Phase 57+ Frontend SaaS 2/N → 3/N
+- [ ] All 8 V2 lints green (新 backend code 不違反 LLM SDK / promptbuilder / sole_mutator / RLS gaps lints)
+- [ ] Backend pytest baseline 1589 → 1595+ (≥+6 from US-1)
+- [ ] Backend mypy --strict 0 errors (無新 source files;modify existing tenants.py only — 295 unchanged)
+- [ ] Backend LLM SDK leak: 0 不變
+- [ ] Anti-pattern checklist 11 項對齊
+- [ ] 5 active CI checks green(含 Frontend E2E chromium headless per 53.7 baseline)
+- [ ] Frontend `npm run lint && npm run build` clean
+- [ ] Frontend Vitest ≥+8 new tests pass(3 US-2 + 3 US-3 + 2 US-4)
+- [ ] Playwright e2e ≥3 tests pass(happy + filter + click-row + empty)
+- [ ] AD-Sprint-Plan-4 `mixed` 4th application captured + verdict logged in retro Q2
+- [ ] D1 RED finding plan-time closed(US-1 backend list endpoint production-ready)
+- [ ] Day 0 三-prong 探勘 second fully-applied sprint observations documented in retro Q3
+
+### Per-User-Story
+
+詳見 §User Stories acceptance per US.
+
+---
+
+## Day-by-Day Plan
+
+### Day 0 — Setup + Day-0 三-prong 探勘 + Pre-flight Verify
+
+- 0.1 Branch + plan + checklist commit
+- 0.2 Day-0 三-prong 探勘(per AD-Plan-3 + AD-Plan-4 fold-in promoted)— **Prong 1 Path Verify**:`features/admin-tenants/` + `pages/admin-tenants/` + `tests/e2e/admin_tenants/` 不存在(expect)/ admin endpoint helpers existing per 57.3 baseline / `require_admin_platform_role` 已存在 / Tenant ORM exists;**Prong 2 Content Verify**:`api/v1/admin/tenants.py` GET `""` (no path param) list endpoint 不存在(D1 RED already caught — 已 user-confirmed Option A pre-emptive bundle 2026-05-07)/ TenantPlan + TenantState enum 已定義 / Tenant ORM `code` + `display_name` columns ILIKE-able / `or_` + `func` from sqlalchemy 既有 56.x usage;**Prong 3 Schema Verify**:N/A 此 sprint(無新 DB schema/migration;但 attempt 完成 per fold-in spirit;Tenant ORM existing 7+ fields all reusable for list query)
+- 0.3 Calibration multiplier pre-read(`mixed` 0.60 mid-band 4th application;3-data-point window mean 0.92 KEEP per AD-Sprint-Plan-4 matrix;若 ratio in band → 4-data-point window opens;若 outside → AD-Sprint-Plan-N+1 logged)
+- 0.4 Pre-flight verify(backend pytest baseline 1589 / 8 V2 lints baseline / mypy baseline / LLM SDK leak baseline / frontend Vitest 23 + Playwright 15 + Vite build 69 modules / 203.02 kB)
+- 0.5 Day 0 progress.md commit + push;catalogue D-findings(D1 closed by Option A pre-emptive bundle;D2-D8 informational);若 scope shift > 20% revise plan §Risks per AD-Plan-1 audit-trail
+
+### Day 1 — US-1 Backend GET list endpoint
+
+- 1.1 Add `class TenantListItem(BaseModel)` with 7 ORM-mirror fields + `from_attributes=True`
+- 1.2 Add `class TenantListResponse(BaseModel)` wrapper(items+total+limit+offset)
+- 1.3 Add `@router.get("", response_model=TenantListResponse)` endpoint with 5 query params + `require_admin_platform_role`
+- 1.4 NEW test file `backend/tests/integration/api/test_admin_tenant_list.py`(6-8 tests:happy no filter / filter by state / filter by plan / search by code / pagination limit+offset / 401 unauth / 403 wrong role / response shape / empty result)
+- 1.5 Day 1 sanity checks:`pytest backend/tests/integration/api/test_admin_tenant_list.py` pass / `mypy --strict backend/src/api/v1/admin/tenants.py` clean / 8 V2 lints unchanged
+- 1.6 Day 1 commit + push + progress.md
+
+### Day 2 — US-2 Frontend Infra (types + service + store)
+
+- 2.1 `frontend/src/features/admin-tenants/` skeleton(components/ services/ store/ types.ts)
+- 2.2 `types.ts` mirror US-1 TenantListItem + TenantListResponse + TenantListQuery interface;re-export TenantState + TenantPlan from `tenant-settings/types`(no duplicate enum)
+- 2.3 `adminTenantsService.ts` plain fetch + URLSearchParams + `_handleResponse<T>` helper(mirror tenantSettingsService)
+- 2.4 `adminTenantsStore.ts` Zustand store(query + items + pagination state + setFilter + setPagination + loadData actions)
+- 2.5 3 Vitest unit tests US-2(listTenants happy + URLSearchParams construction + store loadData action)
+- 2.6 Day 2 sanity checks:`npm run lint && npm run build` + Vitest pass
+- 2.7 Day 2 commit + push + progress.md
+
+### Day 3 — US-3 + US-4 Frontend Components + Page Layout
+
+- 3.1 `TenantListTable.tsx`(rows + state/plan badges + View button + empty state + loading skeleton)
+- 3.2 `TenantListFilters.tsx`(state dropdown + plan dropdown + search input + apply/reset buttons + 300ms debounce)
+- 3.3 `TenantListPagination.tsx`(prev/next + page indicator + total count)
+- 3.4 `pages/admin-tenants/index.tsx` page wrapper(URL query sync on mount + filter/pagination change)
+- 3.5 5 Vitest unit tests(3 US-3 Table render + Empty state + Filters interaction;2 US-4 page mount + Pagination click)
+- 3.6 Day 3 sanity checks:`npm run lint && npm run build` + Vitest pass
+- 3.7 Day 3 commit + push + progress.md
+
+### Day 4 — US-5 Routing + Playwright E2E + Closeout Ceremony
+
+- 4.1 App.tsx route `/admin-tenants` + Home nav `<Link>`(always visible per 57.1 D10 Option C)
+- 4.2 Playwright e2e `admin_tenants_list.spec.ts`(4 cases:happy + filter + click-row + empty)
+- 4.3 Final pytest + lint + leak verify(backend 1589 → 1595+ / mypy 0 / 8 V2 lints / LLM SDK 0 / frontend lint+build + Vitest 23 → 31+ + Playwright 15 → 18+)
+- 4.4 Retrospective.md(6 必答 + AD-Sprint-Plan-4 mixed 4th app verify + Day 0 三-prong second fully-applied sprint observations + Phase 57.x next-sprint candidates Q5)
+- 4.5 Memory snapshot `memory/project_phase57_4_admin_tenants_list.md` + MEMORY.md index update
+- 4.6 Open PR + CI green + solo-dev merge to main
+- 4.7 Closeout PR(SITUATION-V2 §9 + CLAUDE.md sync to **Phase 57+ SaaS Frontend 3/N (Sprint 57.4 closed — Admin Tenants Console list bundle)**)
+
+---
+
+## File Change List
+
+| File | Status | Lines (est) |
+|------|--------|-------------|
+| `backend/src/api/v1/admin/tenants.py` | MODIFIED | +90 (TenantListItem + TenantListResponse + 1 endpoint) |
+| `backend/tests/integration/api/test_admin_tenant_list.py` | NEW | ~180 |
+| `frontend/src/features/admin-tenants/types.ts` | NEW | ~40 |
+| `frontend/src/features/admin-tenants/services/adminTenantsService.ts` | NEW | ~50 |
+| `frontend/src/features/admin-tenants/store/adminTenantsStore.ts` | NEW | ~80 |
+| `frontend/src/features/admin-tenants/components/TenantListTable.tsx` | NEW | ~140 |
+| `frontend/src/features/admin-tenants/components/TenantListFilters.tsx` | NEW | ~100 |
+| `frontend/src/features/admin-tenants/components/TenantListPagination.tsx` | NEW | ~60 |
+| `frontend/src/pages/admin-tenants/index.tsx` | NEW | ~70 |
+| `frontend/src/App.tsx` | MODIFIED | +6 (1 Route + 1 Link) |
+| `frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts` | NEW | ~140 |
+| Vitest unit tests (~8 new across 5 files) | NEW | ~280 |
+| `docs/.../sprint-57-4/{progress,retrospective}.md` | NEW | ~600 |
+| `memory/project_phase57_4_admin_tenants_list.md` | NEW | ~60 |
+
+**Total**: ~640 source LOC + ~600 test LOC + ~660 docs LOC
+
+---
+
+## Dependencies & Risks
+
+### Dependencies (must exist before code starts)
+
+- ✅ Phase 56.1 backend Tenant ORM model `class Tenant` (identity.py) — Day 0 verified
+- ✅ Phase 56.1 backend `TenantState` + `TenantPlan` enum (identity.py) — Day 0 verified
+- ✅ Phase 56.2 backend `require_admin_platform_role` auth dep (auth.py:140) — Day 0 verified
+- ✅ Phase 57.3 backend `TenantResponse` Pydantic + GET `/{id}` + PATCH `/{id}` reusable for click-row navigation — Day 0 verified
+- ✅ Phase 57.3 frontend `tenant-settings/types.ts` exports TenantState + TenantPlan enum reusable — Day 0 verified
+- ✅ Phase 57.1 v2 frontend cost-dashboard service+store pattern reusable — Day 0 verified
+- ✅ Phase 57.1 v2 frontend Vitest setup — Day 0 verified
+- ✅ Phase 53.6 frontend Playwright auth fixture pattern reusable — Day 0 verified
+
+### Risk Classes (per sprint-workflow.md §Common Risk Classes)
+
+**Risk Class A (paths-filter vs required_status_checks)**: 已 closed by 55.6 Option Z (paths-filter retired 永久);此 sprint 不適用。
+
+**Risk Class B (cross-platform mypy unused-ignore)**: 低概率 — 此 sprint backend 全用既有依賴(SQLAlchemy 2.x async / FastAPI / Pydantic v2 / 56.x query patterns);若新 import(`or_`, `func`)drift → 套 `# type: ignore[import-not-found, unused-ignore]` 雙 code per code-quality.md;mitigation 於 Day 1 sanity check 階段。
+
+**Risk Class C (module-level singleton across event loops)**: 低概率 — 此 sprint backend 不引入新 module-level singleton;57.3+56.x integration suite already 含 autouse `_reset_module_singletons` fixture;Day 1 sanity check 階段 verify 0 cascade failures。
+
+### Day 0 三-prong 探勘 D-findings v3 (catalogued during Day 0)
+
+**D1** 🔴 RED — backend admin tenants.py 沒 GET `""` list endpoint (只有 POST `""` create + GET/PATCH /{id} for single);**Closed by Option A pre-emptive bundle**(user-approved 2026-05-07 — bundle 1 backend list endpoint + frontend Admin Tenants Console page 解決真正 backend gap)。Implication:此 sprint 多了 US-1 backend scope ~3-4 hr;multiplier shift `medium-frontend` 0.65 → `mixed` 0.60。
+
+**D2** 🟢 GREEN — `require_admin_platform_role` exists at `auth.py:140`(56.2 RBAC pattern reused by 57.3)。Implication:US-1 list endpoint reuse;與 sla_reports + cost_summary + 57.3 GET/PATCH 一致;auth pattern 一致無需新增。
+
+**D3** 🟢 GREEN — Tenant ORM `code` + `display_name` columns 既有 string 型別 + ILIKE-able。Implication:US-1 list endpoint search 用 SQLAlchemy `or_` + `ilike` 即可;不需 ORM column 改動。
+
+**D4** 🟢 GREEN — TenantState + TenantPlan enum 已定義(identity.py)+ 57.3 frontend `tenant-settings/types.ts` re-exports。Implication:US-2 frontend types.ts 直接 re-export(no duplicate enum per 17.md spirit + AP-11 命名一致)。
+
+**D5** 🟢 GREEN — `TenantResponse` Pydantic 既有 57.3 + GET `/{id}` 既有 57.3 — click-row navigation `/tenant-settings/{id}` 直接 functional 無需新 backend 工作。Implication:US-3 frontend View button → router push 即可;US-5 e2e click-row 測試 reuse 57.3 view path。
+
+**D6** 🟠 YELLOW — tenants 表本身**無 RLS policy**(非 TenantScopedMixin — 它**就是** tenant — 56.1 US-5 baseline 0 gaps)。Implication:8 V2 lint check_rls_policies 不適用 tenants 表(已 whitelisted per 56.1 baseline);US-1 list endpoint 安全靠 require_admin_platform_role super-admin RBAC(JWT super-admin role check);non-admin 401/403;非 RLS 隔離(super-admin 看所有 tenants 是合法 admin operation)。
+
+**D7** 🟢 GREEN — 57.3 frontend tenant-settings/store/tenantSettingsStore.ts pattern reusable for adminTenantsStore.ts(Zustand + plain fetch + saving/saveError state simplified to loading+error since list view non-mutating)。Implication:US-2 store 開發 ~30-40 min(pattern reuse 高);無新概念。
+
+**D8** 🟠 YELLOW — Pagination URL query string sync(US-4)需 `history.replaceState` + `URLSearchParams` 處理;React Router 非預設提供 query state hook(較 React Router v6 新版功能 `useSearchParams` 可考慮);Day 3 first-thing 確認 React Router version + `useSearchParams` API 可用性;若不可用 → fallback 用 `window.history.replaceState` 直接操作。
+
+**Cumulative scope shift** = +backend 3-4 hr(D1 → US-1)= **+25-30%** vs naive medium-frontend 假設(~10 hr × 0.65)→ pivot to `mixed` 0.60(3-data-point mean 0.92)→ ~14 hr × 0.60 = ~8 hr;< 50% threshold per AD-Plan-1(若 > 50% 則 abort);user-confirmed Option A 2026-05-07 → 繼續 Day 1+;no plan re-version required mid-sprint。
+
+### Sprint-specific Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| US-1 ILIKE on Tenant.code 大表性能(若未來 tenants 表 > 10K) | 此 sprint 範圍內 tenants 表通常 < 100 rows(per-instance SaaS);Day 1 sanity check 不 benchmark;Phase 58+ scaling sprint 再評估 add `code` ILIKE index |
+| URL query string sync 在 Playwright e2e 環境若 React Router v6 useSearchParams 不可用 | Day 3 first thing verify React Router version;若 v6+ → 用 `useSearchParams`;若 v5 → fallback `window.history.replaceState` + `useEffect` 監聽 location.search |
+| Vitest unit test 對 Zustand store async loadData 的測試需要 `vi.mocked` adminTenantsService.listTenants | 既有 57.3 tenant-settings store 測試 pattern reusable;Day 2 直接 follow |
+| Frontend bundle size 增量(~70 modules vs 69 baseline) | 控制 +6 modules;< 5% size 增加;Vite tree-shaking 應自動處理 |
+
+---
+
+## Definition of Done
+
+詳見 §Acceptance Criteria — Sprint-Wide。
+
+---
+
+## References
+
+- 16-frontend-design.md §Admin Tenants Console (per Phase 57+ candidate scope)
+- 56.1 admin tenants endpoint set (POST create + GET onboarding-status + POST onboarding-step)
+- 57.3 admin tenants single CRUD (GET /{id} + PATCH /{id})
+- 56.2 RBAC pattern (require_admin_platform_role)
+- 53.5/53.6 Frontend governance + Playwright e2e patterns
+- 57.1 v2 frontend cost-dashboard + sla-dashboard infra patterns
+- 57.3 frontend tenant-settings infra (Zustand + plain fetch + types)
+- AD-Sprint-Plan-4 scope-class multiplier matrix (`mixed` 0.60 4th application)
+- AD-Plan-3 + AD-Plan-4 sprint-workflow.md §Step 2.5 Prong 2 + 3 (promoted Sprint 55.6 + 57.1 v2 fold-in)
+- .claude/rules/sprint-workflow.md §Common Risk Classes
+- Sprint 57.3 plan + checklist (format template — 14 sections / 5 days Day 0-4)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,14 @@
  * Category: Frontend / app-root
  *
  * Modification History:
+ *   - 2026-05-07: Sprint 57.4 Day 4 — add /admin-tenants route + Home Link (US-5)
  *   - 2026-05-07: Sprint 57.3 Day 4 — add /tenant-settings route + Home Link (US-5)
  *   - 2026-05-06: Sprint 57.1 Day 3 — add /cost-dashboard + /sla-dashboard routes (US-4)
  *   - 2026-04-2x: Sprint 49.1 — initial placeholder router with /chat-v2 + /governance + /verification
  */
 
 import { Link, Route, Routes } from "react-router-dom";
+import AdminTenantsPage from "./pages/admin-tenants";
 import ChatV2Page from "./pages/chat-v2";
 import CostDashboardPage from "./pages/cost-dashboard";
 import GovernancePage from "./pages/governance";
@@ -24,7 +26,7 @@ function Home() {
     <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
       <h1>IPA Platform V2</h1>
       <p>
-        <strong>Status:</strong> Phase 57+ SaaS Frontend 2/N — Sprint 57.3 Tenant Settings bundle.
+        <strong>Status:</strong> Phase 57+ SaaS Frontend 3/N — Sprint 57.4 Admin Tenants Console list bundle.
       </p>
       <p>Pages currently registered:</p>
       <ul>
@@ -46,6 +48,9 @@ function Home() {
         <li>
           <Link to="/tenant-settings">/tenant-settings</Link> — Sprint 57.3 tenant CRUD R+U (admin-platform role)
         </li>
+        <li>
+          <Link to="/admin-tenants">/admin-tenants</Link> — Sprint 57.4 admin tenants console list (admin-platform role)
+        </li>
       </ul>
       <p>
         Backend health: <code>GET /api/v1/health</code> (proxied to localhost:8001)
@@ -64,6 +69,7 @@ export default function App() {
       <Route path="/cost-dashboard/*" element={<CostDashboardPage />} />
       <Route path="/sla-dashboard/*" element={<SLADashboardPage />} />
       <Route path="/tenant-settings/*" element={<TenantSettingsPage />} />
+      <Route path="/admin-tenants" element={<AdminTenantsPage />} />
     </Routes>
   );
 }

--- a/frontend/src/features/admin-tenants/components/TenantListFilters.tsx
+++ b/frontend/src/features/admin-tenants/components/TenantListFilters.tsx
@@ -1,0 +1,112 @@
+/**
+ * File: frontend/src/features/admin-tenants/components/TenantListFilters.tsx
+ * Purpose: Filter bar (state dropdown + plan dropdown + search input + Apply/Reset).
+ * Category: Frontend / admin-tenants / components
+ * Scope: Phase 57 / Sprint 57.4 US-3
+ *
+ * Description:
+ *   Local form state for filter inputs; on Apply -> call store.setFilter +
+ *   loadData. On Reset -> store.reset + loadData. Search input has
+ *   maxLength=128 (matches backend Query validation).
+ *
+ *   Note: 57.4 ships with explicit Apply button (no debounce) per
+ *   AP-6 — debounce can be added later when search frequency tuning
+ *   becomes a real need.
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { useState } from "react";
+
+import { useAdminTenantsStore } from "../store/adminTenantsStore";
+import { TenantPlan, TenantState } from "../types";
+
+const ROW_STYLE: React.CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.75rem",
+  alignItems: "flex-end",
+  padding: "0.75rem",
+  background: "#fafafa",
+  border: "1px solid #ddd",
+  borderRadius: "0.25rem",
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: "0.85rem",
+  fontWeight: 600,
+  color: "#444",
+  display: "flex",
+  flexDirection: "column",
+};
+
+export function TenantListFilters(): JSX.Element {
+  const { setFilter, reset, loadData } = useAdminTenantsStore();
+
+  const [stateInput, setStateInput] = useState<TenantState | "">("");
+  const [planInput, setPlanInput] = useState<TenantPlan | "">("");
+  const [searchInput, setSearchInput] = useState<string>("");
+
+  const handleApply = (): void => {
+    setFilter({
+      state: stateInput === "" ? undefined : stateInput,
+      plan: planInput === "" ? undefined : planInput,
+      search: searchInput === "" ? undefined : searchInput,
+    });
+    void loadData();
+  };
+
+  const handleReset = (): void => {
+    setStateInput("");
+    setPlanInput("");
+    setSearchInput("");
+    reset();
+    void loadData();
+  };
+
+  return (
+    <div style={ROW_STYLE}>
+      <label style={LABEL_STYLE}>
+        State
+        <select
+          value={stateInput}
+          onChange={(e) => setStateInput(e.target.value as TenantState | "")}
+        >
+          <option value="">All</option>
+          <option value={TenantState.REQUESTED}>REQUESTED</option>
+          <option value={TenantState.PROVISIONING}>PROVISIONING</option>
+          <option value={TenantState.ACTIVE}>ACTIVE</option>
+          <option value={TenantState.SUSPENDED}>SUSPENDED</option>
+          <option value={TenantState.ARCHIVED}>ARCHIVED</option>
+        </select>
+      </label>
+
+      <label style={LABEL_STYLE}>
+        Plan
+        <select
+          value={planInput}
+          onChange={(e) => setPlanInput(e.target.value as TenantPlan | "")}
+        >
+          <option value="">All</option>
+          <option value={TenantPlan.STANDARD}>STANDARD</option>
+          <option value={TenantPlan.ENTERPRISE}>ENTERPRISE</option>
+        </select>
+      </label>
+
+      <label style={LABEL_STYLE}>
+        Search
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          maxLength={128}
+          placeholder="Code or display name…"
+          style={{ minWidth: "16rem" }}
+        />
+      </label>
+
+      <button onClick={handleApply}>Apply</button>
+      <button onClick={handleReset}>Reset</button>
+    </div>
+  );
+}

--- a/frontend/src/features/admin-tenants/components/TenantListPagination.tsx
+++ b/frontend/src/features/admin-tenants/components/TenantListPagination.tsx
@@ -1,0 +1,59 @@
+/**
+ * File: frontend/src/features/admin-tenants/components/TenantListPagination.tsx
+ * Purpose: Prev/Next + page indicator for admin tenants list.
+ * Category: Frontend / admin-tenants / components
+ * Scope: Phase 57 / Sprint 57.4 US-4
+ *
+ * Description:
+ *   Reads { query (limit/offset), total } from store. Prev disabled at
+ *   offset=0; Next disabled when offset + limit >= total. Indicator shows
+ *   "{from}-{to} of {total}" range.
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { useAdminTenantsStore } from "../store/adminTenantsStore";
+
+const ROW_STYLE: React.CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  alignItems: "center",
+  marginTop: "1rem",
+  padding: "0.5rem 0",
+};
+
+export function TenantListPagination(): JSX.Element {
+  const { query, total, setPagination, loadData } = useAdminTenantsStore();
+
+  const { limit, offset } = query;
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + limit, total);
+  const prevDisabled = offset === 0;
+  const nextDisabled = offset + limit >= total;
+
+  const handlePrev = (): void => {
+    if (prevDisabled) return;
+    setPagination({ offset: Math.max(0, offset - limit) });
+    void loadData();
+  };
+
+  const handleNext = (): void => {
+    if (nextDisabled) return;
+    setPagination({ offset: offset + limit });
+    void loadData();
+  };
+
+  return (
+    <div style={ROW_STYLE}>
+      <button onClick={handlePrev} disabled={prevDisabled}>
+        ← Prev
+      </button>
+      <button onClick={handleNext} disabled={nextDisabled}>
+        Next →
+      </button>
+      <span style={{ color: "#666", fontSize: "0.9rem" }}>
+        {from}-{to} of {total}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/features/admin-tenants/components/TenantListTable.tsx
+++ b/frontend/src/features/admin-tenants/components/TenantListTable.tsx
@@ -1,0 +1,159 @@
+/**
+ * File: frontend/src/features/admin-tenants/components/TenantListTable.tsx
+ * Purpose: Read-only table of tenants — Sprint 57.4 US-3.
+ * Category: Frontend / admin-tenants / components
+ * Scope: Phase 57 / Sprint 57.4 US-3
+ *
+ * Description:
+ *   Renders TenantListItem[] from store as a table:
+ *     Code | Display Name | State (badge) | Plan (badge) | Created | View
+ *   View button navigates to /tenant-settings/?tenant_id={id} (consumes 57.3
+ *   Tenant Settings page). Loading skeleton (5 placeholder rows) and empty
+ *   state (with Reset Filters button) are rendered conditionally based on
+ *   store flags.
+ *
+ *   Mirrors inline-style pattern from 57.3 TenantSettingsView (no Tailwind).
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ *
+ * Related:
+ *   - ../store/adminTenantsStore.ts (consumes items + loading)
+ *   - ../types.ts (TenantState + TenantPlan badge color helpers)
+ */
+
+import { useNavigate } from "react-router-dom";
+
+import { useAdminTenantsStore } from "../store/adminTenantsStore";
+import { TenantPlan, TenantState, type TenantListItem } from "../types";
+
+function stateBadgeColor(state: TenantState): string {
+  switch (state) {
+    case TenantState.ACTIVE:
+      return "#0a0";
+    case TenantState.PROVISIONING:
+    case TenantState.REQUESTED:
+      return "#a80";
+    case TenantState.SUSPENDED:
+    case TenantState.ARCHIVED:
+      return "#888";
+    default:
+      return "#666";
+  }
+}
+
+function planBadgeColor(plan: TenantPlan): string {
+  return plan === TenantPlan.ENTERPRISE ? "#06c" : "#888";
+}
+
+const BADGE_STYLE: React.CSSProperties = {
+  padding: "0.15rem 0.5rem",
+  borderRadius: "0.25rem",
+  color: "white",
+  fontSize: "0.85rem",
+  whiteSpace: "nowrap",
+};
+
+const TH_STYLE: React.CSSProperties = {
+  textAlign: "left",
+  borderBottom: "2px solid #ccc",
+  padding: "0.5rem",
+  fontWeight: 600,
+};
+
+const TD_STYLE: React.CSSProperties = {
+  borderBottom: "1px solid #eee",
+  padding: "0.5rem",
+};
+
+interface RowProps {
+  tenant: TenantListItem;
+  onView: (id: string) => void;
+}
+
+function TenantRow({ tenant, onView }: RowProps): JSX.Element {
+  return (
+    <tr>
+      <td style={{ ...TD_STYLE, fontFamily: "monospace" }}>{tenant.code}</td>
+      <td style={TD_STYLE}>{tenant.display_name}</td>
+      <td style={TD_STYLE}>
+        <span style={{ ...BADGE_STYLE, background: stateBadgeColor(tenant.state) }}>
+          {tenant.state}
+        </span>
+      </td>
+      <td style={TD_STYLE}>
+        <span style={{ ...BADGE_STYLE, background: planBadgeColor(tenant.plan) }}>
+          {tenant.plan}
+        </span>
+      </td>
+      <td style={{ ...TD_STYLE, fontSize: "0.85rem", color: "#666" }}>
+        {tenant.created_at}
+      </td>
+      <td style={TD_STYLE}>
+        <button onClick={() => onView(tenant.id)}>View</button>
+      </td>
+    </tr>
+  );
+}
+
+export function TenantListTable(): JSX.Element {
+  const navigate = useNavigate();
+  const { items, loading, reset, loadData } = useAdminTenantsStore();
+
+  const handleView = (id: string): void => {
+    navigate(`/tenant-settings/?tenant_id=${encodeURIComponent(id)}`);
+  };
+
+  const handleReset = (): void => {
+    reset();
+    void loadData();
+  };
+
+  if (loading) {
+    return (
+      <div role="status" aria-label="Loading tenants" style={{ padding: "1rem" }}>
+        {[0, 1, 2, 3, 4].map((i) => (
+          <div
+            key={i}
+            style={{
+              height: "2rem",
+              background: "#f0f0f0",
+              marginBottom: "0.5rem",
+              borderRadius: "0.25rem",
+            }}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div style={{ padding: "2rem", textAlign: "center", color: "#666" }}>
+        <p>No tenants match current filter.</p>
+        <button onClick={handleReset} style={{ marginTop: "0.5rem" }}>
+          Reset Filters
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", marginTop: "0.5rem" }}>
+      <thead>
+        <tr>
+          <th style={TH_STYLE}>Code</th>
+          <th style={TH_STYLE}>Display Name</th>
+          <th style={TH_STYLE}>State</th>
+          <th style={TH_STYLE}>Plan</th>
+          <th style={TH_STYLE}>Created</th>
+          <th style={TH_STYLE}>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        {items.map((t) => (
+          <TenantRow key={t.id} tenant={t} onView={handleView} />
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/src/features/admin-tenants/services/adminTenantsService.ts
+++ b/frontend/src/features/admin-tenants/services/adminTenantsService.ts
@@ -1,0 +1,64 @@
+/**
+ * File: frontend/src/features/admin-tenants/services/adminTenantsService.ts
+ * Purpose: REST client for 57.4 admin tenant list endpoint.
+ * Category: Frontend / admin-tenants / services
+ * Scope: Phase 57 / Sprint 57.4 US-2
+ *
+ * Description:
+ *   Wraps GET /api/v1/admin/tenants list endpoint. Builds URLSearchParams
+ *   from TenantListQuery (only setting params that are non-undefined).
+ *   Mirrors plain-fetch + _handleResponse<T> pattern from 57.3
+ *   tenantSettingsService.ts.
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 2)
+ *
+ * Related:
+ *   - backend/src/api/v1/admin/tenants.py (GET "" list endpoint)
+ *   - ../types.ts (TenantListQuery + TenantListResponse)
+ *   - ../../tenant-settings/services/tenantSettingsService.ts (pattern reference)
+ */
+
+import type { TenantListQuery, TenantListResponse } from "../types";
+
+const API_BASE = "/api/v1/admin";
+
+async function _handleResponse<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    let detail = `HTTP ${response.status}`;
+    try {
+      const body = (await response.json()) as { detail?: string };
+      if (body.detail) detail = body.detail;
+    } catch {
+      // ignore JSON parse failure; use status only
+    }
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+/**
+ * Build a URLSearchParams instance from a TenantListQuery, omitting
+ * undefined optional filters (state / plan / search).
+ */
+export function buildListSearchParams(query: TenantListQuery): URLSearchParams {
+  const params = new URLSearchParams();
+  if (query.state !== undefined) params.set("state", query.state);
+  if (query.plan !== undefined) params.set("plan", query.plan);
+  if (query.search !== undefined && query.search !== "") {
+    params.set("search", query.search);
+  }
+  params.set("limit", String(query.limit));
+  params.set("offset", String(query.offset));
+  return params;
+}
+
+export async function listTenants(
+  query: TenantListQuery,
+): Promise<TenantListResponse> {
+  const params = buildListSearchParams(query);
+  const response = await fetch(
+    `${API_BASE}/tenants?${params.toString()}`,
+    { credentials: "include" },
+  );
+  return _handleResponse<TenantListResponse>(response);
+}

--- a/frontend/src/features/admin-tenants/store/adminTenantsStore.ts
+++ b/frontend/src/features/admin-tenants/store/adminTenantsStore.ts
@@ -1,0 +1,101 @@
+/**
+ * File: frontend/src/features/admin-tenants/store/adminTenantsStore.ts
+ * Purpose: Zustand store for Admin Tenants Console list state (filters + pagination + items).
+ * Category: Frontend / admin-tenants / store
+ * Scope: Phase 57 / Sprint 57.4 US-2
+ *
+ * Description:
+ *   Mirrors 57.3 tenantSettingsStore Zustand pattern. State holds:
+ *     - query  TenantListQuery with state/plan/search filters + limit+offset
+ *     - items  current page TenantListItem[] from server
+ *     - total  total count for pagination indicator
+ *     - loading/error  fetch lifecycle flags
+ *
+ *   Action setFilter resets offset to 0 (filter change should restart
+ *   pagination); setPagination changes limit/offset only.
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 2)
+ *
+ * Related:
+ *   - ../services/adminTenantsService.ts (listTenants)
+ *   - ../types.ts (TenantListQuery + TenantListItem)
+ *   - ../../tenant-settings/store/tenantSettingsStore.ts (pattern reference)
+ */
+
+import { create } from "zustand";
+
+import { listTenants } from "../services/adminTenantsService";
+import type {
+  TenantListItem,
+  TenantListQuery,
+  TenantPlan,
+  TenantState,
+} from "../types";
+
+const DEFAULT_QUERY: TenantListQuery = {
+  state: undefined,
+  plan: undefined,
+  search: undefined,
+  limit: 50,
+  offset: 0,
+};
+
+interface FilterPartial {
+  state?: TenantState;
+  plan?: TenantPlan;
+  search?: string;
+}
+
+interface PaginationPartial {
+  limit?: number;
+  offset?: number;
+}
+
+interface AdminTenantsState {
+  query: TenantListQuery;
+  items: TenantListItem[];
+  total: number;
+  loading: boolean;
+  error: string | null;
+  setFilter: (partial: FilterPartial) => void;
+  setPagination: (partial: PaginationPartial) => void;
+  loadData: () => Promise<void>;
+  reset: () => void;
+}
+
+export const useAdminTenantsStore = create<AdminTenantsState>((set, get) => ({
+  query: { ...DEFAULT_QUERY },
+  items: [],
+  total: 0,
+  loading: false,
+  error: null,
+  setFilter: (partial) =>
+    set((s) => ({
+      query: {
+        ...s.query,
+        ...partial,
+        offset: 0, // filter change resets pagination
+      },
+    })),
+  setPagination: (partial) =>
+    set((s) => ({
+      query: { ...s.query, ...partial },
+    })),
+  loadData: async () => {
+    set({ loading: true, error: null });
+    try {
+      const data = await listTenants(get().query);
+      set({ items: data.items, total: data.total, loading: false });
+    } catch (err) {
+      set({ error: (err as Error).message, loading: false, items: [], total: 0 });
+    }
+  },
+  reset: () =>
+    set({
+      query: { ...DEFAULT_QUERY },
+      items: [],
+      total: 0,
+      loading: false,
+      error: null,
+    }),
+}));

--- a/frontend/src/features/admin-tenants/types.ts
+++ b/frontend/src/features/admin-tenants/types.ts
@@ -1,0 +1,64 @@
+/**
+ * File: frontend/src/features/admin-tenants/types.ts
+ * Purpose: TypeScript interfaces mirroring 57.4 backend TenantListItem + TenantListResponse.
+ * Category: Frontend / admin-tenants / types
+ * Scope: Phase 57 / Sprint 57.4 US-2
+ *
+ * Description:
+ *   Mirrors backend Pydantic schemas at backend/src/api/v1/admin/tenants.py
+ *   (Sprint 57.4 US-1 list endpoint). TenantState + TenantPlan enums are
+ *   re-exported from ../tenant-settings/types to avoid duplicate definitions
+ *   (per 17.md single-source spirit + AP-11 命名一致).
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 2)
+ *
+ * Related:
+ *   - backend/src/api/v1/admin/tenants.py (TenantListItem + TenantListResponse)
+ *   - ../tenant-settings/types (TenantState + TenantPlan source of truth)
+ *   - ./services/adminTenantsService.ts (consumer)
+ *   - ./store/adminTenantsStore.ts (consumer)
+ */
+
+import type { TenantPlan, TenantState } from "../tenant-settings/types";
+
+export { TenantPlan, TenantState } from "../tenant-settings/types";
+
+/**
+ * Lightweight subset of Tenant ORM returned by GET /admin/tenants list.
+ * Excludes JSONB progress + meta_data (clients fetch via GET /{id}).
+ */
+export interface TenantListItem {
+  id: string;
+  code: string;
+  display_name: string;
+  state: TenantState;
+  plan: TenantPlan;
+  created_at: string; // ISO 8601 datetime
+  updated_at: string;
+}
+
+/**
+ * Paginated list response wrapper.
+ */
+export interface TenantListResponse {
+  items: TenantListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Query params for GET /admin/tenants list endpoint.
+ *
+ * - state / plan: exact filter (undefined = no filter)
+ * - search: ILIKE on code+display_name (max 128 chars; undefined = no search)
+ * - limit: pagination size (default 50; range 1..200)
+ * - offset: pagination start (default 0)
+ */
+export interface TenantListQuery {
+  state?: TenantState;
+  plan?: TenantPlan;
+  search?: string;
+  limit: number;
+  offset: number;
+}

--- a/frontend/src/pages/admin-tenants/index.tsx
+++ b/frontend/src/pages/admin-tenants/index.tsx
@@ -1,0 +1,62 @@
+/**
+ * File: frontend/src/pages/admin-tenants/index.tsx
+ * Purpose: Admin Tenants Console page (filters + table + pagination).
+ * Category: Frontend / pages / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-4
+ *
+ * Description:
+ *   Loads on mount + on store query change. URL query string sync deferred
+ *   per AP-6 (will land alongside multi-page filter shareability when a
+ *   real need surfaces; this sprint ships in-memory filter state only).
+ *
+ *   Backend enforces require_admin_platform_role; frontend lets 401/403
+ *   surface as Error UX (Home Link always visible per 57.1 D10 Option C).
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { useEffect } from "react";
+
+import { TenantListFilters } from "../../features/admin-tenants/components/TenantListFilters";
+import { TenantListPagination } from "../../features/admin-tenants/components/TenantListPagination";
+import { TenantListTable } from "../../features/admin-tenants/components/TenantListTable";
+import { useAdminTenantsStore } from "../../features/admin-tenants/store/adminTenantsStore";
+
+export function AdminTenantsPage(): JSX.Element {
+  const { error, loadData } = useAdminTenantsStore();
+
+  useEffect(() => {
+    void loadData();
+  }, [loadData]);
+
+  return (
+    <div style={{ padding: "2rem", fontFamily: "system-ui, sans-serif" }}>
+      <h1>Admin Tenants Console</h1>
+      <p style={{ color: "#666", fontSize: "0.9rem" }}>
+        Browse + filter all tenants. Backend enforces admin-platform role
+        (Sprint 57.4 list endpoint). 401/403 surfaces as error below.
+      </p>
+
+      <TenantListFilters />
+
+      {error && (
+        <div
+          style={{
+            marginTop: "1rem",
+            padding: "1rem",
+            border: "1px solid #a00",
+            color: "#a00",
+          }}
+        >
+          <p>Error: {error}</p>
+          <button onClick={() => void loadData()}>Retry</button>
+        </div>
+      )}
+
+      <TenantListTable />
+      <TenantListPagination />
+    </div>
+  );
+}
+
+export default AdminTenantsPage;

--- a/frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts
+++ b/frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * File: frontend/tests/e2e/admin_tenants/admin_tenants_list.spec.ts
+ * Purpose: Playwright e2e — admin tenants console list view (Sprint 57.4 US-5).
+ * Category: Frontend / e2e / admin_tenants
+ * Scope: Phase 57 / Sprint 57.4 US-5
+ *
+ * Description:
+ *   Validates the Admin Tenants Console list page (57.4 US-1..US-4):
+ *     1. Happy path: load page → table renders with mocked rows.
+ *     2. Filter: select state=ACTIVE → second GET fired with state filter.
+ *     3. Click View → navigates to /tenant-settings/?tenant_id=...
+ *     4. Empty state: backend returns items=[] → "No tenants match" + Reset.
+ *
+ *   Uses page.route() browser-layer mock per 57.1 v2 D19 + 57.3 D13 pattern.
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 4)
+ */
+
+import { expect, test } from "@playwright/test";
+
+const TENANT_LIST_ENDPOINT = "**/api/v1/admin/tenants?**";
+const TENANT_GET_ENDPOINT = "**/api/v1/admin/tenants/**";
+
+const baseTenantA = {
+  id: "00000000-0000-4000-8000-0000000000a1",
+  code: "ACME_E2E",
+  display_name: "Acme E2E Corp",
+  state: "active",
+  plan: "enterprise",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-05-07T00:00:00Z",
+};
+
+const baseTenantB = {
+  id: "00000000-0000-4000-8000-0000000000b2",
+  code: "REQ_PENDING",
+  display_name: "Requested Pending",
+  state: "requested",
+  plan: "enterprise",
+  created_at: "2026-02-01T00:00:00Z",
+  updated_at: "2026-05-07T00:00:00Z",
+};
+
+test.describe("Sprint 57.4 US-5 — Admin Tenants Console list e2e", () => {
+  test("happy path: page renders mocked rows + state badges", async ({ page }) => {
+    await page.route(TENANT_LIST_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [baseTenantA, baseTenantB],
+          total: 2,
+          limit: 50,
+          offset: 0,
+        }),
+      });
+    });
+
+    await page.goto("/admin-tenants");
+
+    await expect(page.getByRole("heading", { name: "Admin Tenants Console" })).toBeVisible();
+    await expect(page.getByText("ACME_E2E")).toBeVisible();
+    await expect(page.getByText("REQ_PENDING")).toBeVisible();
+    // Badges are <span> elements. The state dropdown also has lowercase
+    // option values, so disambiguate via the table cell role + first match.
+    await expect(page.locator("td span").filter({ hasText: "active" })).toBeVisible();
+    await expect(page.locator("td span").filter({ hasText: "requested" })).toBeVisible();
+  });
+
+  test("filter: select state=ACTIVE triggers second GET with state filter", async ({ page }) => {
+    let lastRequestUrl = "";
+    await page.route(TENANT_LIST_ENDPOINT, async (route) => {
+      lastRequestUrl = route.request().url();
+      const url = new URL(lastRequestUrl);
+      const stateFilter = url.searchParams.get("state");
+      const items = stateFilter === "active" ? [baseTenantA] : [baseTenantA, baseTenantB];
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items,
+          total: items.length,
+          limit: 50,
+          offset: 0,
+        }),
+      });
+    });
+
+    await page.goto("/admin-tenants");
+    await expect(page.getByText("REQ_PENDING")).toBeVisible();
+
+    // First select is the State dropdown.
+    const stateSelect = page.getByRole("combobox").nth(0);
+    await stateSelect.selectOption("active");
+    await page.getByRole("button", { name: "Apply" }).click();
+
+    await expect.poll(() => lastRequestUrl).toContain("state=active");
+    await expect(page.getByText("REQ_PENDING")).not.toBeVisible();
+    await expect(page.getByText("ACME_E2E")).toBeVisible();
+  });
+
+  test("click View navigates to /tenant-settings/?tenant_id=...", async ({ page }) => {
+    await page.route(TENANT_LIST_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [baseTenantA],
+          total: 1,
+          limit: 50,
+          offset: 0,
+        }),
+      });
+    });
+
+    // Mock the GET /{id} so the destination page also responds (otherwise
+    // tenant-settings page would show error from real backend miss).
+    await page.route(TENANT_GET_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          ...baseTenantA,
+          provisioning_progress: {},
+          onboarding_progress: {},
+          meta_data: {},
+        }),
+      });
+    });
+
+    await page.goto("/admin-tenants");
+    await expect(page.getByText("ACME_E2E")).toBeVisible();
+
+    await page.getByRole("button", { name: "View" }).click();
+
+    await expect(page).toHaveURL(/\/tenant-settings\/?\?tenant_id=/);
+    await expect(page.getByRole("heading", { name: "Tenant Settings" })).toBeVisible();
+  });
+
+  test("empty state: items=[] shows No tenants match + Reset Filters button", async ({ page }) => {
+    await page.route(TENANT_LIST_ENDPOINT, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
+      });
+    });
+
+    await page.goto("/admin-tenants");
+    await expect(page.getByText(/No tenants match/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Reset Filters" })).toBeVisible();
+  });
+});

--- a/frontend/tests/unit/admin-tenants/TenantListFilters.test.tsx
+++ b/frontend/tests/unit/admin-tenants/TenantListFilters.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * File: frontend/tests/unit/admin-tenants/TenantListFilters.test.tsx
+ * Purpose: Unit test for TenantListFilters — Apply triggers setFilter+loadData.
+ * Category: Frontend / tests / unit / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-3
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TenantListFilters } from "../../../src/features/admin-tenants/components/TenantListFilters";
+import * as svc from "../../../src/features/admin-tenants/services/adminTenantsService";
+import { useAdminTenantsStore } from "../../../src/features/admin-tenants/store/adminTenantsStore";
+import { TenantState } from "../../../src/features/admin-tenants/types";
+
+describe("TenantListFilters", () => {
+  afterEach(() => {
+    useAdminTenantsStore.getState().reset();
+    vi.restoreAllMocks();
+  });
+
+  it("Apply with state=ACTIVE selected triggers setFilter + loadData", async () => {
+    const listSpy = vi
+      .spyOn(svc, "listTenants")
+      .mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
+    render(<TenantListFilters />);
+
+    // First select is State dropdown.
+    const stateSelect = screen.getAllByRole("combobox")[0];
+    fireEvent.change(stateSelect, { target: { value: TenantState.ACTIVE } });
+
+    fireEvent.click(screen.getByText("Apply"));
+
+    await vi.waitFor(() => expect(listSpy).toHaveBeenCalled());
+    expect(useAdminTenantsStore.getState().query.state).toBe(TenantState.ACTIVE);
+  });
+});

--- a/frontend/tests/unit/admin-tenants/TenantListPagination.test.tsx
+++ b/frontend/tests/unit/admin-tenants/TenantListPagination.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * File: frontend/tests/unit/admin-tenants/TenantListPagination.test.tsx
+ * Purpose: Unit test for TenantListPagination — Next click advances offset + triggers loadData.
+ * Category: Frontend / tests / unit / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-4
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TenantListPagination } from "../../../src/features/admin-tenants/components/TenantListPagination";
+import * as svc from "../../../src/features/admin-tenants/services/adminTenantsService";
+import { useAdminTenantsStore } from "../../../src/features/admin-tenants/store/adminTenantsStore";
+
+describe("TenantListPagination", () => {
+  afterEach(() => {
+    useAdminTenantsStore.getState().reset();
+    vi.restoreAllMocks();
+  });
+
+  it("Next click advances offset by limit and triggers loadData", async () => {
+    const listSpy = vi
+      .spyOn(svc, "listTenants")
+      .mockResolvedValue({ items: [], total: 100, limit: 50, offset: 50 });
+    useAdminTenantsStore.setState({
+      query: { limit: 50, offset: 0, state: undefined, plan: undefined, search: undefined },
+      total: 100,
+    });
+
+    render(<TenantListPagination />);
+    fireEvent.click(screen.getByText("Next →"));
+
+    await vi.waitFor(() => expect(listSpy).toHaveBeenCalled());
+    expect(useAdminTenantsStore.getState().query.offset).toBe(50);
+  });
+
+  it("Prev disabled at offset=0 + Next disabled when offset+limit >= total", () => {
+    useAdminTenantsStore.setState({
+      query: { limit: 50, offset: 0, state: undefined, plan: undefined, search: undefined },
+      total: 30,
+    });
+    render(<TenantListPagination />);
+    expect(screen.getByText("← Prev")).toBeDisabled();
+    expect(screen.getByText("Next →")).toBeDisabled();
+    expect(screen.getByText(/1-30 of 30/)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/admin-tenants/TenantListTable.test.tsx
+++ b/frontend/tests/unit/admin-tenants/TenantListTable.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * File: frontend/tests/unit/admin-tenants/TenantListTable.test.tsx
+ * Purpose: Unit test for TenantListTable — render rows + empty state.
+ * Category: Frontend / tests / unit / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-3
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 3)
+ */
+
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TenantListTable } from "../../../src/features/admin-tenants/components/TenantListTable";
+import { useAdminTenantsStore } from "../../../src/features/admin-tenants/store/adminTenantsStore";
+import {
+  TenantPlan,
+  TenantState,
+  type TenantListItem,
+} from "../../../src/features/admin-tenants/types";
+
+const SAMPLE: TenantListItem[] = [
+  {
+    id: "00000000-0000-0000-0000-000000000001",
+    code: "ACME",
+    display_name: "Acme Corp",
+    state: TenantState.ACTIVE,
+    plan: TenantPlan.ENTERPRISE,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-05-07T00:00:00Z",
+  },
+  {
+    id: "00000000-0000-0000-0000-000000000002",
+    code: "OTHER",
+    display_name: "Other Co",
+    state: TenantState.REQUESTED,
+    plan: TenantPlan.ENTERPRISE,
+    created_at: "2026-02-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+  },
+];
+
+describe("TenantListTable", () => {
+  afterEach(() => {
+    useAdminTenantsStore.getState().reset();
+  });
+
+  it("renders rows with code + display_name + state/plan badges", () => {
+    useAdminTenantsStore.setState({ items: SAMPLE, total: SAMPLE.length, loading: false });
+    render(
+      <MemoryRouter>
+        <TenantListTable />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("ACME")).toBeInTheDocument();
+    expect(screen.getByText("OTHER")).toBeInTheDocument();
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    // Each badge text appears once per row.
+    expect(screen.getAllByText("active")).toHaveLength(1);
+    expect(screen.getAllByText("requested")).toHaveLength(1);
+    expect(screen.getAllByText("enterprise")).toHaveLength(2);
+    // View buttons one per row.
+    expect(screen.getAllByText("View")).toHaveLength(2);
+  });
+
+  it("renders empty state with Reset Filters button when items=[]", () => {
+    useAdminTenantsStore.setState({ items: [], total: 0, loading: false });
+    render(
+      <MemoryRouter>
+        <TenantListTable />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/No tenants match/)).toBeInTheDocument();
+    expect(screen.getByText("Reset Filters")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/unit/admin-tenants/adminTenantsService.test.ts
+++ b/frontend/tests/unit/admin-tenants/adminTenantsService.test.ts
@@ -1,0 +1,112 @@
+/**
+ * File: frontend/tests/unit/admin-tenants/adminTenantsService.test.ts
+ * Purpose: Unit test for adminTenantsService — URL building + listTenants happy + error throw.
+ * Category: Frontend / tests / unit / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-2
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 2)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildListSearchParams,
+  listTenants,
+} from "../../../src/features/admin-tenants/services/adminTenantsService";
+import {
+  TenantPlan,
+  TenantState,
+  type TenantListQuery,
+  type TenantListResponse,
+} from "../../../src/features/admin-tenants/types";
+
+const MOCK_RESPONSE: TenantListResponse = {
+  items: [
+    {
+      id: "00000000-0000-0000-0000-000000000001",
+      code: "ACME",
+      display_name: "Acme Corp",
+      state: TenantState.ACTIVE,
+      plan: TenantPlan.ENTERPRISE,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-05-07T00:00:00Z",
+    },
+  ],
+  total: 1,
+  limit: 50,
+  offset: 0,
+};
+
+describe("adminTenantsService", () => {
+  describe("buildListSearchParams", () => {
+    it("omits undefined optional filters and emits limit+offset", () => {
+      const query: TenantListQuery = { limit: 50, offset: 0 };
+      const params = buildListSearchParams(query);
+      expect(params.has("state")).toBe(false);
+      expect(params.has("plan")).toBe(false);
+      expect(params.has("search")).toBe(false);
+      expect(params.get("limit")).toBe("50");
+      expect(params.get("offset")).toBe("0");
+    });
+
+    it("emits all filters when provided + skips empty search string", () => {
+      const query: TenantListQuery = {
+        state: TenantState.ACTIVE,
+        plan: TenantPlan.ENTERPRISE,
+        search: "ACME",
+        limit: 25,
+        offset: 25,
+      };
+      const params = buildListSearchParams(query);
+      expect(params.get("state")).toBe("active");
+      expect(params.get("plan")).toBe("enterprise");
+      expect(params.get("search")).toBe("ACME");
+      expect(params.get("limit")).toBe("25");
+      expect(params.get("offset")).toBe("25");
+
+      const emptySearch: TenantListQuery = {
+        search: "",
+        limit: 50,
+        offset: 0,
+      };
+      expect(buildListSearchParams(emptySearch).has("search")).toBe(false);
+    });
+  });
+
+  describe("listTenants", () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(global, "fetch");
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it("calls fetch with correct URL + parses JSON response", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(MOCK_RESPONSE), { status: 200 }),
+      );
+      const result = await listTenants({
+        state: TenantState.ACTIVE,
+        limit: 50,
+        offset: 0,
+      });
+      const calledUrl = fetchSpy.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("/api/v1/admin/tenants?");
+      expect(calledUrl).toContain("state=active");
+      expect(calledUrl).toContain("limit=50");
+      expect(result).toEqual(MOCK_RESPONSE);
+    });
+
+    it("throws Error with detail message on 403", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "forbidden" }), { status: 403 }),
+      );
+      await expect(
+        listTenants({ limit: 50, offset: 0 }),
+      ).rejects.toThrow("forbidden");
+    });
+  });
+});

--- a/frontend/tests/unit/admin-tenants/adminTenantsStore.test.ts
+++ b/frontend/tests/unit/admin-tenants/adminTenantsStore.test.ts
@@ -1,0 +1,74 @@
+/**
+ * File: frontend/tests/unit/admin-tenants/adminTenantsStore.test.ts
+ * Purpose: Unit test for adminTenantsStore — loadData populates items + total + setFilter resets offset.
+ * Category: Frontend / tests / unit / admin-tenants
+ * Scope: Phase 57 / Sprint 57.4 US-2
+ *
+ * Created: 2026-05-07 (Sprint 57.4 Day 2)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as svc from "../../../src/features/admin-tenants/services/adminTenantsService";
+import { useAdminTenantsStore } from "../../../src/features/admin-tenants/store/adminTenantsStore";
+import {
+  TenantPlan,
+  TenantState,
+  type TenantListResponse,
+} from "../../../src/features/admin-tenants/types";
+
+const MOCK: TenantListResponse = {
+  items: [
+    {
+      id: "00000000-0000-0000-0000-000000000001",
+      code: "ACME",
+      display_name: "Acme Corp",
+      state: TenantState.ACTIVE,
+      plan: TenantPlan.ENTERPRISE,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-05-07T00:00:00Z",
+    },
+  ],
+  total: 1,
+  limit: 50,
+  offset: 0,
+};
+
+describe("adminTenantsStore", () => {
+  beforeEach(() => {
+    useAdminTenantsStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loadData success populates items + total + clears loading", async () => {
+    vi.spyOn(svc, "listTenants").mockResolvedValueOnce(MOCK);
+    await useAdminTenantsStore.getState().loadData();
+    const state = useAdminTenantsStore.getState();
+    expect(state.loading).toBe(false);
+    expect(state.error).toBeNull();
+    expect(state.items).toHaveLength(1);
+    expect(state.total).toBe(1);
+  });
+
+  it("setFilter resets offset to 0 even when offset was advanced", () => {
+    useAdminTenantsStore.getState().setPagination({ offset: 50 });
+    expect(useAdminTenantsStore.getState().query.offset).toBe(50);
+    useAdminTenantsStore.getState().setFilter({ state: TenantState.ACTIVE });
+    const state = useAdminTenantsStore.getState();
+    expect(state.query.state).toBe(TenantState.ACTIVE);
+    expect(state.query.offset).toBe(0);
+  });
+
+  it("loadData failure sets error + clears items", async () => {
+    vi.spyOn(svc, "listTenants").mockRejectedValueOnce(new Error("HTTP 500"));
+    await useAdminTenantsStore.getState().loadData();
+    const state = useAdminTenantsStore.getState();
+    expect(state.loading).toBe(false);
+    expect(state.error).toBe("HTTP 500");
+    expect(state.items).toEqual([]);
+    expect(state.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Open Phase 57+ SaaS Frontend **3/N** — Admin Tenants Console list bundle. Closes plan-time D1 RED finding (backend admin tenants.py 缺 GET `""` list endpoint) via Option A pre-emptive bundle (user-approved 2026-05-07).

- **US-1** Backend `GET /admin/tenants` list endpoint (TenantListItem + TenantListResponse + state/plan/search/limit/offset Query params + ORDER BY (created_at DESC, id DESC))
- **US-2** Frontend `features/admin-tenants/` infra (types/service/store mirroring 57.3 tenant-settings pattern)
- **US-3** Frontend components TenantListTable + TenantListFilters (state/plan badges + Apply/Reset)
- **US-4** Frontend TenantListPagination + `pages/admin-tenants/index.tsx` page layout
- **US-5** App.tsx route `/admin-tenants` + Home Link + Playwright e2e + retrospective + memory

## Stats

| Metric | Baseline | After 57.4 | Delta | vs Plan |
|--------|----------|------------|-------|---------|
| Backend pytest | 1589 | 1598 | +9 | 150% of +6 |
| Backend mypy --strict | 0/295 source files | 0/295 (unchanged) | 0 | ✅ |
| 8 V2 lints | 8/8 | 8/8 | 0 | ✅ |
| LLM SDK leak | 0 | 0 | 0 | ✅ |
| Vitest | 23 | 35 | +12 | 200% of +6 |
| Playwright e2e | 19 | 23 | +4 | ✅ |
| Vite build | 69 modules / 203.02 kB | 75 modules / 209.11 kB | +6 / +6.09 kB | wire-up |

## Calibration

- `mixed` 0.60 mid-band **4th application**: actual ~3.5 hr / committed 8.4 hr → ratio **0.42** ⬇️ below [0.85, 1.20] band lower edge
- 4-data-point window mean **0.79** below band — pattern reuse from 57.3 tenant-settings drove dramatic acceleration
- **AD-Sprint-Plan-6** (NEW) logged: propose split `mixed` into `mixed-greenfield` (0.60) vs `mixed-pattern-reuse` (~0.40)

## D-findings

8 catalogued (1 RED + 5 GREEN + 2 YELLOW):
- **D1 🔴 RED** plan-time Prong 2 catch — backend missing GET `""` list endpoint → closed via Option A pre-emptive bundle
- D9 mid-Day-1 — pagination stability fix (secondary sort key `Tenant.id` + ILIKE search isolation in test)
- D14 mid-Day-4 — Playwright strict-mode selector fix (`getByText("active")` 2 matches → `.locator("td span").filter()` + `getByRole("heading")`)

## Day 0 三-prong (second fully-applied sprint)

- Prong 1 Path Verify: 8 checks 0 drift
- Prong 2 Content Verify: 6 checks 1 RED + 5 GREEN
- Prong 3 Schema Verify: N/A (但 attempt 完成 per fold-in spirit)
- ROI ≈ 16-24× (~30 min cost prevented 8-12 hr Day 1+ rework)

## Test plan

- [x] Backend pytest 1598/0 fails
- [x] Backend mypy --strict 0/295 source files
- [x] 8 V2 lints 8/8 green (含 check_rls_policies tenants 表 whitelisted per 56.1 baseline)
- [x] LLM SDK leak 0
- [x] Frontend ESLint clean / Vite build success
- [x] Vitest 35/35 passed
- [x] Playwright e2e 23/23 passed
- [ ] CI checks pass on this PR

## V2 紀律 9 項對齐

1. ✅ Server-Side First (require_admin_platform_role JWT super-admin RBAC)
2. ✅ LLM Provider Neutrality (LLM SDK leak 0)
3. ✅ CC Reference 不照搬
4. ✅ 17.md Single-source (no cross-category interface change)
5. ✅ 11+1 範疇歸屬 (US-1 §API admin / US-2~US-5 §Frontend)
6. ✅ 04 anti-patterns (AP-3 / AP-4 / AP-6 / AP-9 / AP-11 全綠)
7. ✅ Sprint workflow (plan→checklist→Day 0 三-prong→code→progress→retro)
8. ✅ File header convention (MHist 1-line per AD-Lint-3)
9. ✅ Multi-tenant rule (tenants 表 whitelisted; super-admin RBAC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)