### PR TITLE
chore(closeout, sprint-57-11): update CLAUDE.md with post-merge main HEAD `923e808b` (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,12 +69,12 @@ Build enterprise AI agent teams that work like **human professional teams** — 
 
 | Attribute | Value |
 |-----------|-------|
-| **Phase** | V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend 6/N（57.1/57.3/57.4/57.7/57.8/57.9）+ 57.10 PIVOTED Convention Codify ✅ |
-| **Latest Sprint** | 57.10 PIVOTED ✅ 2026-05-09 — Frontend Convention Codify (CONVENTION.md 667 行 + STYLE.md 447 行；PR #122 main `7d85df4c`）。詳細 retro 見 `memory/project_phase57_10_convention_codify.md` |
-| **Last main-progress Sprint** | 57.9 ✅ 2026-05-09 — Governance Real Ship + TanStack 4-page Migration（PR #120 main `49e63ef2`）|
-| **main HEAD** | `7d85df4c` (Sprint 57.10 via PR #122, 2026-05-09) |
-| **Next Phase 候選** | Phase 57.11+ 5 候選（user 明確選定才起草 plan）：(a) Verification real ship + SSE silent-drop fix ⭐ ~12-14 hr / (b) AD-Test-Tenant-Code-Pollution 衛生 mini ~3-5 hr / (c) Agent Harness UI suite (LoopVisualizer/MemoryViewer/SubagentTree) ~15-20 hr / (d) Tier 1 IaC + DR drill ~15-20 hr / (e) SOC 2 + SBOM ~12-15 hr |
-| **Roadmap** | Phase 49-55 V2 ✅ / Phase 56-58 SaaS Stage 1 3/3 ✅ / Phase 57+ Frontend 6/N（57.1/57.3/57.4/57.7/57.8/57.9）/ 57.10 PIVOTED Convention Codify ✅ |
+| **Phase** | V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend 7/N（57.1/57.3/57.4/57.7/57.8/57.9/57.11）+ 57.10 PIVOTED Convention Codify ✅ |
+| **Latest Sprint** | 57.11 ✅ 2026-05-10 — Verification Real Ship + AD-Frontend-SSE-Silent-Drop-Fix bundle (PR #125 main `923e808b`)。pytest 1622→1635 / Vitest 93→119 / Playwright 27→31。詳細 retro 見 `memory/project_phase57_11_verification_ship.md` |
+| **Last Convention Codify Sprint** | 57.10 PIVOTED ✅ 2026-05-09 — Frontend Convention Codify (CONVENTION.md 667 行 + STYLE.md 447 行;PR #122 main `7d85df4c`)|
+| **main HEAD** | `923e808b` (Sprint 57.11 via PR #125, 2026-05-10) |
+| **Next Phase 候選** | Phase 57.12+ 5 候選（user 明確選定才起草 plan）:(a) Agent Harness UI suite (LoopVisualizer + MemoryViewer + SubagentTree) ⭐ ~15-20 hr — User Option A bundle (a)+(c) complement / (b) AD-Bundle-Size-285kB optimization sprint ~3-5 hr / (c) AD-AdminTenant-Patch-Flake + AD-Governance-RBAC-Flake (closed via 57.11) audit cycle mini ~2-3 hr / (d) Tier 1 IaC + DR drill ~15-20 hr / (e) SOC 2 + SBOM ~12-15 hr |
+| **Roadmap** | Phase 49-55 V2 ✅ / Phase 56-58 SaaS Stage 1 3/3 ✅ / Phase 57+ Frontend 7/N（57.1/57.3/57.4/57.7/57.8/57.9/57.11）/ 57.10 PIVOTED Convention Codify ✅ |
 | **Tech Stack** | FastAPI + React 18 + PostgreSQL + Redis（V1 沿用）|
 | **Architecture** | TAO/ReAct loop + 11+1 範疇 全 Level 4（Cat 9 L5）+ LLM Provider 中性（CI-enforced）+ Multi-tenant 3 鐵律 |
 | **Branch Protection** | enforce_admins=true / **review_count=0**（solo-dev policy 永久，2026-05-03 Sprint 53.2 起）/ 5 active required CI checks |
@@ -574,10 +574,10 @@ V1 完整 CLAUDE.md 已保留於 `CLAUDE.backup.md`。如需查閱 V1 架構（M
 
 ---
 
-**Last Updated**: 2026-05-09 (Sprint 57.10 PIVOTED closeout — Frontend Convention Codify)
-**Recent Sprints (詳情見 memory/)**: 57.10 (Convention Codify) / 57.9 (Governance ship) / 57.8 (AppShell V2 + chat-v2) / 57.7 (IAM + frontend foundation) / 57.6 (Reality Gap Fix) / 57.5 (Reality Check)
+**Last Updated**: 2026-05-10 (Sprint 57.11 closeout — Verification Real Ship + AD-Frontend-SSE-Silent-Drop-Fix bundle)
+**Recent Sprints (詳情見 memory/)**: 57.11 (Verification ship) / 57.10 (Convention Codify) / 57.9 (Governance ship) / 57.8 (AppShell V2 + chat-v2) / 57.7 (IAM + frontend foundation) / 57.6 (Reality Gap Fix) / 57.5 (Reality Check)
 **Project Start**: 2025-11-14
-**Current Phase**: V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend 6/N（57.10 Convention Codify）。Phase 57.11+ 候選 5 條 pending user 明確選定（見上方表格 Next Phase 候選 row）。
-**main HEAD**: `7d85df4c` (Sprint 57.10 via PR #122, 2026-05-09)
+**Current Phase**: V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend 7/N（57.11 Verification Real Ship）。Phase 57.12+ 候選 5 條 pending user 明確選定（見上方表格 Next Phase 候選 row）。
+**main HEAD**: `923e808b` (Sprint 57.11 via PR #125, 2026-05-10)
 **V2 Authority**: `docs/03-implementation/agent-harness-planning/` (21 docs — 20 規劃 + 1 review)
 **V1 Reference**: `CLAUDE.backup.md` + `docs/07-analysis/V9/00-index.md`


### PR DESCRIPTION
## Summary

Sprint 57.11 closeout CLAUDE.md sync per Sprint 57.7+57.8+57.9+57.10 batched-update pattern.

## Changes

- main HEAD: `7d85df4c` (Sprint 57.10) → `923e808b` (Sprint 57.11 via PR #125)
- Frontend ship counter: 6/N → **7/N** (verification promoted to shipped)
- Latest Sprint row: Sprint 57.11 Verification Real Ship + AD-Frontend-SSE-Silent-Drop-Fix bundle
- Recent Sprints: prepend 57.11 entry
- Next Phase candidates: refresh to Phase 57.12+ (Agent Harness UI suite top per User Option A bundle (a)+(c) complement; Bundle-Size opt; audit cycle for closed flakes; Tier 1 IaC; SOC 2 + SBOM)
- Last Updated date: 2026-05-09 → 2026-05-10

## Sprint 57.11 ship summary (per PR #125)

- pytest 1622 → 1635 (+13 backend tests; AD-Governance-RBAC-Flake fixed via dispose_engine() autouse)
- Vitest 93 → 119 (+26 frontend tests across Day 2+3)
- Playwright 27 → 31 (+4 verification e2e; STRETCH SSE-injection deferred to AD-Verification-RealShip-E2E)
- V2 lints 9/9 / mypy strict 304 clean / RLS 17/18/13 → 18/19/13
- Build main 295.14 kB > 285 kB ceiling → AD-Bundle-Size-285kB-Carryover (Phase 57.12+ optimization)

## Closed ADs (4 via Sprint 57.11)

- AD-Cat10-Frontend-Panel (54.1 carryover)
- AD-Verification-RealShip-Deferred (Sprint 57.10 deferral)
- AD-Frontend-SSE-Silent-Drop-Fix (CONVENTION.md §7 codified)
- AD-Governance-RBAC-Flake (dispose_engine() autouse fix)

## NEW carryover ADs

- AD-Bundle-Size-285kB-Carryover (Phase 57.12+)
- AD-Verification-RealShip-E2E (Phase 57.12+ STRETCH SSE-injection)
- AD-AdminTenant-Patch-Flake (audit cycle — 3 pre-existing local-only DB pollution failures)
- AD-Verification-Log-Retention + AD-Verification-AuditCorrelation (Phase 58+)

## Test plan

- [ ] CI passes (paths-filter may skip backend-ci since CLAUDE.md only — accepted per `sprint-workflow.md` §Risk Class A)
- [ ] After merge: next session opens at correct main HEAD `923e808b` (verifiable via `git log main --oneline -1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)