### PR TITLE
fix(frontend): sidebar collapsed-state toggle button invisible (FIX-009)

### DIFF
--- a/claudedocs/4-changes/bug-fixes/FIX-009-sidebar-collapsed-toggle-invisible.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-009-sidebar-collapsed-toggle-invisible.md
@@ -1,0 +1,105 @@
+# FIX-009: Sidebar Collapsed-State Toggle Button Invisible
+
+**Date**: 2026-05-24
+**Sprint**: post-57.32 (hotfix on main)
+**Scope**: Frontend / `components/Sidebar.tsx` (production-only widget styling)
+**Severity**: 🟠 UX-blocking (user permanently stuck in collapsed state across F5 / sessions)
+
+---
+
+## Problem
+
+After clicking the sidebar collapse toggle, the sidebar shrinks to 56px icon-only width as designed — but **the toggle button itself becomes invisible**, leaving no UI affordance to expand back.
+
+Compounding the issue, `sidebarCollapsed` is persisted to `localStorage` (`ipa-ui-state`) via `zustand/middleware persist`, so the user is permanently stuck in the unrecoverable state across:
+
+- Page refreshes (F5)
+- New tabs
+- New browser sessions
+
+**Reported by**: User screenshot 2026-05-24 — `/overview` route with collapsed sidebar showing only nav-item icons in a narrow column, no chevron toggle visible.
+
+---
+
+## Root Cause
+
+The toggle button in `Sidebar.tsx:118-128` is unconditionally rendered (correct intent — production-only "collapse toggle has no counterpart in mockup, kept for usability" per the in-file comment at L14). However, in the collapsed state the button gets visually displaced **outside the sidebar viewport** by a chain of CSS layout constraints:
+
+| Layer | Value (verbatim mockup CSS) | Effect when collapsed |
+|-------|------------------------------|------------------------|
+| `.app[data-collapsed="true"]` grid | `grid-template-columns: 56px 1fr` | Sidebar column = **56px** |
+| `.sidebar-head` | `padding: 12px 14px; display: flex; gap: 10px` | Usable inner width = **56 − 28 = 28px** |
+| `.brand-mark` (always shown) | `width: 26px; flex-shrink: 0` | Occupies **26px** of the 28px |
+| Toggle button | `marginLeft: "auto"` (Sidebar.tsx:123) | Pushed beyond right edge into the 1fr `.main` column, visually covered by main content |
+
+Net result: brand-mark fills nearly the entire `.sidebar-head`; toggle button is shoved past the 56px boundary and clipped or overlaid by the adjacent main column. The chevron icon is technically in the DOM but not visible/clickable.
+
+`styles-mockup.css` is the verbatim mockup copy locked in by Sprint 57.28's 4-layer fidelity protocol (any edit fails `frontend/scripts/check-mockup-fidelity.mjs`), so the row-flex layout of `.sidebar-head` cannot be relaxed there. The toggle button is a production-only widget (the mockup has none), so a production-only inline-style override on `Sidebar.tsx` is the compliant path per `docs/rules-on-demand/frontend-mockup-fidelity.md` STYLE.md §1 escape-hatch.
+
+---
+
+## Solution
+
+In `Sidebar.tsx`, switch `.sidebar-head` to vertical-stack layout **only when collapsed**, via a conditional inline `style` prop on the `<div>`:
+
+```tsx
+<div
+  className="sidebar-head"
+  style={
+    sidebarCollapsed
+      ? { flexDirection: "column", height: "auto", padding: 8, gap: 6 }
+      : undefined
+  }
+>
+```
+
+Effects:
+- `flexDirection: "column"` stacks brand-mark above toggle button (inherited `align-items: center` from the base `.sidebar-head` rule centers them horizontally within the 56px column)
+- `height: "auto"` replaces fixed `52px` so both elements fit (≈ 8 + 26 + 6 + ~26 + 8 = ~74px)
+- `padding: 8` (8px all-around) replaces `12px 14px` to leave the 40px-wide inner space for the 26px elements
+- `gap: 6` tightens the vertical gap between brand-mark and button
+- `marginLeft: "auto"` on the button is a row-flex idiom → no-op under column flex, so left in place (no second conditional needed)
+
+Mockup expanded layout is **untouched** (style is `undefined` when not collapsed).
+
+---
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/Sidebar.tsx` | +5 line conditional inline `style` on `.sidebar-head` div; +Modification History entry |
+
+No CSS file touched. `styles-mockup.css` verbatim check still passes.
+
+---
+
+## Verification
+
+| Gate | Command | Expected |
+|------|---------|----------|
+| TypeScript | `cd frontend && npx tsc --noEmit -p tsconfig.app.json` | 0 errors (no new) |
+| ESLint | `cd frontend && npm run lint` | exit 0 |
+| Vitest | `cd frontend && npm run test -- --run` | 452/452 baseline (no behavioural change) |
+| Vite build | `cd frontend && npm run build` | success |
+| `styles-mockup.css` fidelity | `cd frontend && npm run check:mockup-fidelity` | diff empty + grep clean (CSS file untouched) |
+| Manual | Open `/overview` → collapse sidebar → F5 → toggle button visible below brand-mark → click → sidebar expands | ✅ |
+
+---
+
+## Impact
+
+- **Scope**: Frontend only (no backend, no API, no schema)
+- **User-visible**: collapse toggle now always reachable in both states
+- **Breaking**: none — expanded layout unchanged; mockup-fidelity guard unchanged
+- **Persisted state**: existing users already stuck in collapsed state will see the toggle on next reload and can expand again (no localStorage migration needed)
+
+---
+
+## Related
+
+- `frontend/src/components/Sidebar.tsx:118-128` — toggle button definition
+- `frontend/src/store/uiStore.ts` — `sidebarCollapsed` persist
+- `frontend/src/styles-mockup.css:205,218-251` — collapse grid + sidebar-head + collapsed-children rules
+- `docs/rules-on-demand/frontend-mockup-fidelity.md` — production-only escape-hatch policy
+- Sprint 57.28 PR #162 — verbatim-CSS foundation switch (the constraint we honor)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-32-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-32-checklist.md
@@ -176,13 +176,13 @@
 - [x] **CLAUDE.md** Current Sprint row + footer updated (minimal touch)
 - [x] **`sprint-workflow.md §Scope-class multiplier matrix`** updated — `frontend-verbatim-css-repoint` row now 4 data points + baseline-lift 1st-data-point validation result + MHist entry
 - [x] **`next-phase-candidates.md`** updated — Sprint 57.32 Carryover section added; baseline-lift AD updated with 1st validation status
-- [ ] **Day 4 commit** on `feature/sprint-57-32-sla-dashboard-repoint` (pending; next step)
-- [ ] **PR open** — `gh pr create` with body listing Sprint Goal + USs completed + 5 gates + baseline-lift 1st-validation narrative + 22-route sweep summary
-- [ ] **CI green → squash-merge** — if `/sla-dashboard` visual-regression baseline stale, expect manual ff-merge required (AD-CI-7-GHA-PR-Permission still open; same workaround as 57.31)
+- [x] **Day 4 commit** — `0d8eabd1` on `feature/sprint-57-32-sla-dashboard-repoint`
+- [x] **PR open** — PR #166 https://github.com/laitim2001/ai-semantic-kernel-framework-project/pull/166
+- [x] **CI green → squash-merge** — **All 7 checks PASS on 1st run** (Backend E2E / Frontend E2E chromium headless / Lighthouse informational / 2× Lint+Type+Build / 2× Lint+Type+Test with PG16 / v2-lints); no baseline regen needed (cleaner than Sprint 57.31); squash-merged as `eed0c70c` to main; feature branch deleted via `--delete-branch`
 
 ### 4.5 Sprint closeout self-check
 
-- [ ] Sacred Rule check — 0 unchecked items deleted
-- [ ] Acceptance Criteria — all 5 pass (PARITY + 0 catastrophic/structural + 5 gates green + baseline-lift validated + docs synced)
-- [ ] Working tree clean post-merge — on main; only untracked older-sprint debug PNGs
-- [ ] Branch deleted — `feature/sprint-57-32-sla-dashboard-repoint` deleted local + remote
+- [x] Sacred Rule check — 0 unchecked items deleted
+- [x] Acceptance Criteria — all 5 pass (PARITY + 0 catastrophic/structural + 5 gates green + baseline-lift 1st validation logged + docs synced)
+- [x] Working tree clean post-merge — on main; only untracked older-sprint debug PNGs
+- [x] Branch deleted — `feature/sprint-57-32-sla-dashboard-repoint` deleted local + remote

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -26,9 +26,10 @@
  *   collapse; i18n `nav.*` keys.
  *
  * Created: 2026-05-10 (Sprint 57.8 Day 1)
- * Last Modified: 2026-05-22
+ * Last Modified: 2026-05-24
  *
  * Modification History:
+ *   - 2026-05-24: FIX-009 — collapsed-state sidebar-head column-stack (toggle button no longer clipped past 56px boundary)
  *   - 2026-05-22: Sprint 57.29 US-B3 — verbatim re-point to mockup .sidebar/.nav-* classes (drop Tailwind translation)
  *   - 2026-05-17: Sprint 57.20 Day 1 — mockup shell.jsx port (tenant switcher + bottom user-card)
  *   - 2026-05-16: Sprint 57.18 US-C3 — PROP/DRAFT badge per entry + propCount header
@@ -106,8 +107,20 @@ export const Sidebar: FC = () => {
       data-collapsed={sidebarCollapsed || undefined}
       aria-label={t("shell.primaryNavigation")}
     >
-      {/* Sidebar head — brand mark + brand text + production-only collapse toggle */}
-      <div className="sidebar-head">
+      {/* Sidebar head — brand mark + brand text + production-only collapse toggle.
+          FIX-009 (2026-05-24): When collapsed, switch to column-stack so the
+          toggle button stays inside the 56px sidebar column (instead of being
+          pushed past the right edge by row-flex + marginLeft:auto + 26px
+          brand-mark in only 28px of usable inner width). Expanded layout is
+          untouched (style is undefined when !sidebarCollapsed). */}
+      <div
+        className="sidebar-head"
+        style={
+          sidebarCollapsed
+            ? { flexDirection: "column", height: "auto", padding: 8, gap: 6 }
+            : undefined
+        }
+      >
         <div className="brand-mark" aria-hidden="true" />
         {!sidebarCollapsed && (
           <Link to="/" className="brand-text grow" style={{ minWidth: 0 }}>


### PR DESCRIPTION
## Problem

After clicking the sidebar collapse toggle, the 56px icon-only sidebar **hides the toggle button itself** behind the right edge, leaving no UI affordance to expand back. Because `sidebarCollapsed` is `zustand persist`-ed to `localStorage` (`ipa-ui-state`), users are permanently stuck across F5 / new tabs / new browser sessions.

Reported by user screenshot 2026-05-24 (`/overview` route).

## Root Cause

| Layer | Value (verbatim mockup CSS) | Effect when collapsed |
|-------|------------------------------|------------------------|
| `.app[data-collapsed="true"]` grid | `grid-template-columns: 56px 1fr` | Sidebar column = **56px** |
| `.sidebar-head` | `padding: 12px 14px; display: flex; gap: 10px` | Usable inner width = **56 − 28 = 28px** |
| `.brand-mark` | `width: 26px; flex-shrink: 0` | Occupies **26px** of the 28px |
| Toggle button | `marginLeft: "auto"` (Sidebar.tsx:123) | Pushed past right edge into `.main` column, visually covered |

`styles-mockup.css` is locked verbatim by Sprint 57.28's 4-layer fidelity protocol — cannot relax. Toggle button is a **production-only widget** (mockup has none), so a production-only inline-style override on `Sidebar.tsx` is the compliant path per `docs/rules-on-demand/frontend-mockup-fidelity.md` STYLE.md §1 escape-hatch.

## Solution

`.sidebar-head` conditional inline style — only when collapsed:

```tsx
style={
  sidebarCollapsed
    ? { flexDirection: "column", height: "auto", padding: 8, gap: 6 }
    : undefined
}
```

Stacks brand-mark above toggle button (both centered horizontally inside the 56px column via inherited `align-items: center`). `marginLeft: "auto"` on the button is a row-flex idiom → no-op under column flex, so no second conditional needed. **Expanded layout is byte-identical** (style is `undefined` when not collapsed).

## Verification

| Gate | Result |
|------|--------|
| `tsc -b && vite build` | ✅ `built in 3.35s` |
| `npm run lint` | ✅ exit 0 |
| `npm run test` (Vitest) | ✅ **452/452 baseline** |
| `npm run check:mockup-fidelity` | ✅ diff guard + grep guard pass (`styles-mockup.css` untouched) |
| Manual | open `/overview` → collapse → F5 → toggle visible below brand-mark → click → expands ✅ |

## Impact

- **Scope**: Frontend only (no backend, API, schema)
- **User-visible**: collapse toggle now always reachable in both states
- **Breaking**: none — expanded layout unchanged; mockup-fidelity guard unchanged
- **Persisted state**: existing users stuck in collapsed state will see the toggle on next reload (no localStorage migration needed)

## Files

| File | Change |
|------|--------|
| `claudedocs/4-changes/bug-fixes/FIX-009-sidebar-collapsed-toggle-invisible.md` | NEW — full root cause + solution + verification |
| `frontend/src/components/Sidebar.tsx` | +12 lines — conditional inline style on `.sidebar-head` + comment + MHist entry |

Also includes 1 commit (`docs(sprint-57-32)`) catching up Sprint 57.32 §4.4/§4.5 checklist boxes that were verbally ticked during closeout but not committed before PR #166 merged.

## Related

- Sprint 57.28 PR #162 — verbatim-CSS foundation switch (the constraint we honor)
- `frontend/src/store/uiStore.ts` — `sidebarCollapsed` persist
- `frontend/src/styles-mockup.css:205,218-251` — collapse grid + sidebar-head rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)