### PR TITLE
fix(frontend, state-inspector): drop production-only outer padding wrapper + codify 3 Phase-2 re-point systematic anti-patterns (FIX-011)

### DIFF
--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -4,7 +4,45 @@
 
 **Selection Rule**: User explicitly selects → draft plan kicks off Sprint XX.Y; otherwise items wait here indefinitely until selected or archived.
 
-**Updated**: 2026-05-24 (Sprint 57.38 closeout — 3-domain batched: Option 2 class split decision for `frontend-verbatim-css-repoint` (`-simple` 0.50 / `-with-extras` 0.65) + Domain B `/subagents` Phase-2 re-point + Domain C `AD-FullBleed-Pages-Audit` FIX-010 follow-up 0 sites missing happy outcome. **3 carryover ADs CLOSED**: `class-split-proposal` / `multi-dimensional-variance-watch` / `baseline-lift`.)
+**Updated**: 2026-05-24 (Sprint 57.38 follow-up FIX-011 + 3 systematic anti-patterns codified — user-reported `/state-inspector` outer padding (FIX-011 resolved) + `[v18 by orchestrator_loop]` baseline misalignment (AP-Phase2-B AD) + all-page buttons black borders (AP-Phase2-C AD). 3 NEW carryover ADs added below.)
+
+---
+
+## 🆕 Sprint 57.38 Follow-up Carryover (2026-05-24 — 3 user-reported issues → FIX-011 + 3 NEW ADs + frontend-mockup-fidelity.md updated)
+
+User-reported via screenshots after Sprint 57.38 PR #176 merge `44489aba`:
+
+1. `/state-inspector` left/right padding visibly wider than mockup
+2. `/state-inspector` detail card title `[v18 by orchestrator_loop]` — `by` baseline lower than mono tokens
+3. All-page buttons render black borders vs mockup light grey
+
+### What got fixed in PR (this hotfix)
+
+- ✅ **Issue 1 — FIX-011**: `StateInspectorPage.tsx` drop `padding: 18` from outer wrapper (production-only Sprint 57.19 vintage; mockup has no outer wrapper)
+- ✅ **3 systematic anti-patterns codified** in `docs/rules-on-demand/frontend-mockup-fidelity.md` §Phase-2 re-point systematic anti-patterns:
+  - **AP-Phase2-A**: Production-only outer padding wrapper (translation-era artifact)
+  - **AP-Phase2-B**: Inline mixed-font span baseline misalignment
+  - **AP-Phase2-C**: Tailwind utility `border-border` → shadcn `--sc-border` token residue
+- ✅ Code review checklist (3 new mandatory items per Phase-2 re-point PR)
+
+### 🆕 NEW carryover ADs (Sprint 57.39+)
+
+- 🆕 **`AD-State-Inspector-Outer-Padding-Wrapper-Fix`** — ✅ RESOLVED by FIX-011 (logged for trace)
+- 🆕 **`AD-Inline-Font-Baseline-Alignment`** — needs typography audit + targeted fix(es) on mockup pages with mixed-font inline spans (e.g. `/state-inspector` detail title, possibly others); recommended fix shape: `display: inline-flex; align-items: baseline` on outer row span. Estimated ~2-3 hr; mid-priority. Class: `sprint-meta + micro-fix` 0.65 candidate.
+- 🆕 **`AD-Shadcn-Border-Token-Visual-Audit-Or-Align-To-Mockup`** — decide between:
+  - **Path A** (1-line global fix): align `--sc-border` value to `--border` in `index.css`. Pros: every shadcn-system page instantly visually closer to mockup. Cons: violates Sprint 57.28 4-layer dual-track design intent.
+  - **Path B** (completeness): continue Phase-2 epic re-point until all 6 🟡 routes done; shadcn token usage naturally disappears.
+  - Recommended: **B**, but A is acceptable transitional fix.
+- 🆕 **Sister-bug observation**: FIX-010 (`/loop-debug` fullBleed prop drop) + FIX-011 (`/state-inspector` outer padding wrapper) form a recurring **layout-class production-only artifact** class. Each Phase-2 re-point sprint Day 0 Prong 1 should grep for these artifacts on the target page BEFORE Day 1 code.
+
+### Why Sprint 57.38 Day 2.1 audit missed Issue 1
+
+Domain C `AD-FullBleed-Pages-Audit` cross-referenced production `AppShellV2` mounts vs mockup outer wrapper classes (`chat-shell` / `loop-canvas` / `page-head`) — looking for **fullBleed prop drops**. It found 0 sites. But the audit scope was **only the `fullBleed` decision class**; it did NOT scan for *production-only outer padding wrappers ADDED inside the AppShellV2 mount*. Issue 1 falls into a different class (AP-Phase2-A) that the Sprint 57.38 audit didn't cover.
+
+**Lesson for next audit**: extend Day 0 grep to include:
+```bash
+grep -n "style={{.*padding\|<div style={{[^}]*padding" frontend/src/pages/<target>/<page>.tsx
+```
 
 ---
 

--- a/claudedocs/4-changes/bug-fixes/FIX-011-state-inspector-outer-padding-and-systematic-anti-patterns.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-011-state-inspector-outer-padding-and-systematic-anti-patterns.md
@@ -1,0 +1,158 @@
+# FIX-011: `/state-inspector` excessive outer padding + 3 systematic Phase-2 re-point anti-patterns codified
+
+**Date**: 2026-05-24
+**Sprint**: 57.38 follow-up (not a sprint — single-commit micro-fix on hotfix branch + rule additions)
+**Scope**: Frontend page wrapper (1-line code) + frontend-mockup-fidelity.md rule additions + 3 NEW carryover ADs
+**Branch**: `fix/state-inspector-outer-padding-and-systematic-lessons`
+**PR**: (filled after open)
+**Class**: Layout-class production-only wrapper drop + systematic Phase-2 re-point lesson codification
+
+---
+
+## Problem (3 user-reported issues, 2026-05-24)
+
+User-reported via screenshots / observations after Sprint 57.38 PR #176 merged:
+
+1. **`/state-inspector` left/right padding visibly more than mockup** (mockup `localhost:8080/#state-inspector` content hugs viewport edge more tightly)
+2. **`[v18 by orchestrator_loop]` baseline misalignment** in `/state-inspector` detail card title — `by` text sits visibly lower than `v18` + `orchestrator_loop` mono tokens
+3. **All page buttons show black borders** but mockup uses light grey borders — user concern this is another CSS-translation drift like Sprint 57.18-57.27
+
+---
+
+## Root Cause Analysis
+
+### Issue 1 — outer padding wrapper
+
+**File**: `frontend/src/pages/state-inspector/StateInspectorPage.tsx:54+247`
+
+```tsx
+const STATE_PAGE_WRAPPER_STYLE = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 14,
+  padding: 18,   // ← Sprint 57.19 production-only addition
+};
+// ...
+<div style={STATE_PAGE_WRAPPER_STYLE}>   // ← wrapper not in mockup
+  <div className="page-head">...
+```
+
+**Mockup truth**: `reference/design-mockups/page-platform.jsx:25-145` `StateInspector` returns `<>` fragment starting directly with `<div className="page-head">`. No outer wrapper, no extra padding.
+
+**Cascade**: `.content` (mockup styles.css:412) provides `padding: 24px 28px 60px`. Production's extra `padding: 18` stacked on top → effective horizontal inset 28 + 18 = **46 px** vs mockup's intended **28 px**.
+
+**Origin**: Sprint 57.19 vintage decision. Sprint 57.37 Day 3 Domain B verbatim CSS re-point **preserved this wrapper** (line 247 comment: *"preserves Sprint 57.19 outer padding inside verbatim mockup"*) — the comment misread the wrapper as "backend wiring" worth preserving when it was actually a translation-era visual artifact that should have been deleted.
+
+### Issue 2 — `by` baseline misalignment
+
+**File**: `frontend/src/pages/state-inspector/StateInspectorPage.tsx:400-407` — detail card title
+
+```tsx
+// inline span row: <span>v18</span> <span className="subtle">by</span> <span className="mono">orchestrator_loop</span>
+```
+
+**Mockup design** (page-platform.jsx:97-102) intentionally mixes 3 fonts inline:
+- `<span>` regular Noto Sans TC
+- `<span className="subtle">` regular Noto Sans TC smaller
+- `<span className="mono">` Geist Mono
+
+**Cascade**: Default `vertical-align: baseline` on inline `<span>` means each font's metric box's baseline aligns. Geist Mono and Noto Sans TC have different `ascender:descender` ratios — visual baseline drift is **mockup-inherent** but mockup's reference renderer (system mono `Menlo` + system sans) shows smaller drift than production's Geist Mono + Noto Sans TC combo.
+
+**Not a bug in production code** — this is a font-pairing visual artifact that needs an explicit `align-items: baseline` hint to compensate. **Codified as AP-Phase2-B** (not fixed in this hotfix — deferred to AD).
+
+### Issue 3 — black button borders
+
+**Cascade analysis**:
+
+| Layer | Token | Dark theme value | Light theme value |
+|-------|-------|------------------|-------------------|
+| Mockup `.btn.outline` (styles.css:448-452) | `border-color: var(--border)` | `oklch(0.26 0.008 260)` (mid-grey L=26%) | `oklch(0.91 0.006 260)` (light grey L=91%) |
+| Production `index.css:92` `* { border-color: hsl(var(--sc-border)) }` global default | `--sc-border` | `hsl(217.2 32.6% 17.5%)` (dark grey-blue L=17.5% — near-black visually) | `hsl(214.3 31.8% 91.4%)` (light grey) |
+
+**Production default theme** (`frontend/index.html:2`): `<html class="dark" data-theme="dark">` — dark mode is the default.
+
+**Cause matrix**:
+- Buttons using **mockup-ui `Button`** → `.btn.outline` class → `var(--border)` (mockup token) → in dark mode `oklch(0.26 ...)` mid-grey ✅ mockup design intent
+- Buttons using **Tailwind utility `border-border`** → resolves to `hsl(var(--sc-border))` → in dark mode `hsl(... 17.5%)` near-black ❌ doesn't match mockup design intent
+- Plain `<button>` with no `.btn` class → falls through to `* { border-color: hsl(var(--sc-border)) }` → same near-black in dark mode
+
+**31 files** still use Tailwind utility `border-border` (per `grep -rln 'border-border'` in `frontend/src`). These are the not-yet-re-pointed pages from the Phase-2 epic (`/governance`, `/admin-tenants`, `/memory`, `/verification`, etc. — 6 🟡 routes remaining).
+
+**Not a CSS-translation drift** (Sprint 57.18-57.27 class). This is **Phase-2 epic incomplete migration**: the dual-token system (mockup `--border` + shadcn `--sc-border`) is intentional per Sprint 57.28 4-layer foundation, but the value gap between them (L=26% vs L=17.5% in dark) makes shadcn-system pages look "black-bordered" vs mockup "grey-bordered".
+
+---
+
+## Solution
+
+### Issue 1 — fixed in this PR (1-line code)
+
+`frontend/src/pages/state-inspector/StateInspectorPage.tsx:54`:
+
+```diff
+- const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column" as const, gap: 14, padding: 18 };
++ // FIX-011 (Sprint 57.38 follow-up 2026-05-24): dropped `padding: 18` — production-only
++ // Sprint 57.19 vintage outer padding artifact; mockup page-platform.jsx:25-145 has NO
++ // outer wrapper. .content already provides 24px 28px 60px padding; the extra 18px
++ // stacked on top added ~46px effective left/right inset vs mockup's intended 28px.
++ // `gap: 14` kept to preserve vertical rhythm between page-head + grid-stats + grid-2
++ // children (mockup relies on per-class margins which we conservatively reinforce here).
++ const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column" as const, gap: 14 };
+```
+
+Plus MHist entry at file header.
+
+### Issue 2 — NOT fixed in this PR; tracked as AD-Phase2-B-Inline-Font-Baseline-Alignment
+
+Codified as systematic AP-Phase2-B in `docs/rules-on-demand/frontend-mockup-fidelity.md`. Recommended fix shape: add `display: inline-flex; align-items: baseline` to the outer row span (page-platform.jsx:97 style). Defer to dedicated typography audit sprint OR include in next /state-inspector re-touch.
+
+### Issue 3 — NOT fixed in this PR; tracked as AD-Shadcn-Border-Token-Visual-Audit-Or-Align-To-Mockup
+
+Codified as systematic AP-Phase2-C in `docs/rules-on-demand/frontend-mockup-fidelity.md`. Two recommended paths:
+
+- **Path A (1-line global fix)**: align `--sc-border` value to `--border` in `index.css`. Pros: every shadcn-system page instantly looks closer to mockup. Cons: violates Sprint 57.28 dual-track design intent.
+- **Path B (completeness)**: continue Phase-2 epic re-point until all 6 🟡 routes done; shadcn token usage naturally disappears. Recommended.
+
+---
+
+## Verification
+
+- ✅ `npm run lint` — clean (only pre-existing jsx-ast-utils warnings)
+- ✅ `npm test -- --reporter=dot` — **Vitest 464/464 passed** (Sprint 57.38 baseline preserved)
+- ✅ `npm run build` — success
+- ✅ `node scripts/check-mockup-fidelity.mjs` — byte-identical + 51/51 baseline preserved
+- ✅ Visual inspection (user): `/state-inspector` left/right padding now matches mockup intent ~28 px (was ~46 px)
+
+---
+
+## Impact
+
+| Scope | Detail |
+|-------|--------|
+| Files changed | 1 production source (`StateInspectorPage.tsx`) + 1 rule doc (`frontend-mockup-fidelity.md`) + 1 FIX record (this file) + 1 memory subfile + 1 candidates file edit |
+| Effective production code | 1 line edit (`padding: 18` removed; 6-line comment added explaining why) + 1 MHist entry |
+| Cascade risk | 0 — affects only `/state-inspector` outer padding; LoopVisualizer / Card / KPI grid internals untouched |
+| Visual regression | Only `/state-inspector` route changes; ~18 px tighter left/right inset matching mockup |
+| Issue 2 + 3 | NOT touched in this PR — codified as systematic anti-patterns for future Phase-2 sprints; new ADs added to next-phase-candidates.md |
+
+---
+
+## Follow-up (deferred — not in this PR)
+
+3 NEW carryover ADs added to `claudedocs/1-planning/next-phase-candidates.md`:
+
+1. **`AD-State-Inspector-Outer-Padding-Wrapper-Fix`** — RESOLVED by this PR. (Logged for trace.)
+2. **`AD-Inline-Font-Baseline-Alignment`** — needs typography audit + targeted fix(es) on mockup pages with mixed font-family inline spans. Estimated ~2-3 hr; mid-priority.
+3. **`AD-Shadcn-Border-Token-Visual-Audit-Or-Align-To-Mockup`** — decide Path A vs Path B; if A, 1-line `index.css` change; if B, accelerate Phase-2 epic 6 🟡 routes.
+
+---
+
+## References
+
+- `frontend/src/pages/state-inspector/StateInspectorPage.tsx:54+247` — wrapper definition + usage
+- `reference/design-mockups/page-platform.jsx:25-145` — mockup `StateInspector` truth (no outer wrapper)
+- `reference/design-mockups/styles.css:412` — `.content` padding `24px 28px 60px`
+- `frontend/src/index.css:92` — `* { border-color: hsl(var(--sc-border)) }` global default
+- `frontend/src/styles-mockup.css:46,62,81,100,120,133,145,159` — `--border` per-theme values (mockup tokens)
+- `docs/rules-on-demand/frontend-mockup-fidelity.md` §Phase-2 re-point systematic anti-patterns — codified 3 new AP entries (AP-Phase2-A/B/C)
+- `claudedocs/4-changes/bug-fixes/FIX-010-loop-debug-fullbleed-prop.md` — sibling layout-class production drift (sister bug; `/loop-debug` was fullBleed prop drop; this one is outer padding wrapper)
+- Sprint 57.18-57.27 epic (`claudedocs/5-status/v2-investigation-20260522/03-mockup-consistency-rootcause.md`) — distinct from this issue class; THIS bug is NOT a CSS-translation drift

--- a/docs/rules-on-demand/frontend-mockup-fidelity.md
+++ b/docs/rules-on-demand/frontend-mockup-fidelity.md
@@ -93,4 +93,82 @@ Sprint 57.18-57.27（10 個 sprint）前端始終無法與 mockup 一致：`/ove
 
 ---
 
-**維護責任**：每個 frontend sprint kickoff 必讀本檔；Code reviewer 以 DoD 5 條 + 鐵律 7 條為 PR 強制檢查項。
+## Phase-2 re-point systematic anti-patterns（2026-05-24 user-reported issues 後加入）
+
+Sprint 57.18-57.27 epic 解決了「CSS 翻譯 → HSL approximation」這條主軸 drift。但 Phase-2 per-page re-point（57.29+）開展後又揭示**另外 3 條獨立的系統性 drift class**，需在每個 re-point sprint 的 Day 0 + Day 2.5 對齊驗證納入。
+
+### Anti-pattern AP-Phase2-A：Production-only 外層 padding wrapper（翻譯遺產）
+
+**症狀**：Production page 的 root JSX 元素包了一層 `<div style={{ padding: <N>, ... }}>` 或類似 wrapper，外層 padding 跟 `.content` 預設 `padding: 24px 28px 60px` 疊加 → 視覺左右 inset 比 mockup 明顯多 10-20+ px。
+
+**前車**：`/state-inspector` `STATE_PAGE_WRAPPER_STYLE = { padding: 18, ... }`（Sprint 57.19 vintage；Sprint 57.37 verbatim re-point 誤以為「保留 backend wiring」而保留）→ FIX-011 fixed 2026-05-24。
+
+**Day 0 Prong 1 額外 grep**：
+```bash
+grep -n "padding:.*[0-9]\|style={{ padding" frontend/src/pages/<target>/<page>.tsx
+# mockup page-*.jsx return 通常以 <> fragment 或 <div className="page-head"> 起；無 padding wrapper
+```
+
+**判定規則**：
+- Mockup 頁面 return 第一層是否有 `<div style={{ padding: ... }}>` 或 `<div className="some-page-wrapper" style={{...}}>`？→ 若 mockup 無 → production 該層必須刪
+- 例外：若 mockup 有 fullbleed 設計（`loop-canvas` / `chat-shell`），production 用 `AppShellV2 fullBleed` prop 而**不是**自己加 padding wrapper
+
+**Re-point sprint Day 1 task**：刪除所有 production-only padding/margin wrapper；如需內部間距，用 mockup `.grid-X` / `.col` / `.row` class（這些 class 本身含 gap 邏輯）。
+
+---
+
+### Anti-pattern AP-Phase2-B：Inline 混 font-family span 缺 baseline 對齊提示
+
+**症狀**：mockup 設計中混排 `<span class="mono">` + `<span class="subtle">` + 普通 `<span>` 在同一 inline row。Mono 字體（Geist Mono）跟 sans 字體（Noto Sans TC）baseline 距離大；production 渲染時 mono 字 baseline 看起來「下沉」明顯，跟 mockup 看起來不一致。
+
+**前車**：`/state-inspector` detail card title `[v18 by orchestrator_loop]` —`by` 字 baseline 明顯低於 `v18` + `orchestrator_loop` 兩個 mono token。Mockup 設計用 `<span class="row" style={{ gap: 6 }}>` 包，但**未強制 baseline 對齊**；mockup 本身在系統 mono `Menlo` 渲染時差距小，production 用 `Geist Mono` 差距大。
+
+**Day 0 Prong 2 grep**：
+```bash
+grep -n 'className="mono"\|className=".*\bmono\b\|className="subtle"' reference/design-mockups/<target-page>.jsx
+# 看是否同 inline row 有 mono + subtle / 普通 sans 混排
+```
+
+**Re-point sprint Day 1 task（推薦）**：
+- 若 mockup 該 row 設計用 `<span class="row">` 包多個不同 font-family 的 span，production 應**主動補加** baseline 對齊：要嘛 outer span 加 `display: inline-flex; align-items: baseline`，要嘛內 span 加 `vertical-align: baseline`
+- 不算違反「verbatim CSS swap」原則 —— mockup 自身沒設這個 prop 是因為 mockup 渲染環境 font 差距小
+
+**驗證**：Day 2.5 後 baseline sweep，截圖該 row vs mockup `localhost:8080/#<route>` 1:1 對比。
+
+---
+
+### Anti-pattern AP-Phase2-C：Tailwind utility `border-border` → shadcn token 殘留（Phase-2 未 re-point 的 page）
+
+**症狀**：production 內 31+ files 還在用 Tailwind `border border-border` / `border-b-2 border-border` 等 utility class。這些 utility 透過 `tailwind.config` 解析到 `hsl(var(--sc-border))` —— shadcn-system **`--sc-border`**，**不是** mockup `--border`。視覺差距：
+- Mockup dark `--border: oklch(0.26 0.008 260)` (L=26%) — 中深灰
+- Shadcn dark `--sc-border: hsl(217.2 32.6% 17.5%)` (L=17.5%) — 更深，視覺接近黑
+
+**這不是「CSS translation drift」class（不像 Sprint 57.18-57.27 翻譯方法錯）**——這是 **Phase-2 epic incomplete migration** class：剩 6 個 🟡 routes 還沒 re-point，這些 page 的所有 Tailwind utility border 都還在用 shadcn token。
+
+**Day 0 Prong 2 grep（用於 audit pages）**：
+```bash
+grep -rln "border-border\|\bborder\s+border-" frontend/src/pages/<route>/ frontend/src/features/<feature>/
+# 若 > 0 sites，re-point sprint 必須包含 Tailwind utility → mockup verbatim CSS class 替換
+```
+
+**Re-point sprint Day 1 task**：
+- 把 Tailwind utility class（`border-border`, `bg-card`, `text-muted-foreground`, `bg-muted/30` 等）→ mockup verbatim class（`.card`, `.subtle`, `.mono`, etc.）
+- 移除 `text-card-foreground` / `bg-card` 等 shadcn-system token usage —— 用 mockup CSS classes 取代
+
+**全局 fix candidate（高 ROI 替代路徑）**：
+- Option **A** — 對齊 `--sc-border` 值到 mockup `--border`（1-line `index.css` 改：dark `--sc-border` → `oklch(0.26 0.008 260)` / light → `oklch(0.91 0.006 260)`）。**Pros**：未 re-point page 立刻視覺對齊 mockup；**Cons**：違反 Sprint 57.28 4-layer 設計意圖（shadcn token 故意 dual-track）
+- Option **B** — 加速 Phase-2 re-point 剩 6 🟡 routes；不再追加 shadcn-system tokens；等 epic close 該 utility 自然消失（completeness path）
+
+**推薦**：B（completeness），但 A 是 acceptable 過渡 fix 若用戶覺得視覺差距難忍。
+
+### Code review checklist（新增 3 條）
+
+每個 Phase-2 re-point sprint PR 必須能對下列 3 條回答 ✅ / N/A：
+
+- [ ] **AP-Phase2-A**: production root JSX 第一層有 `<div style={{ padding: X }}>` 或 wrapper？若有，已對照 mockup 確認該層**應該存在**（fullBleed 例外）；否則已刪除
+- [ ] **AP-Phase2-B**: 若 mockup row 中混排 mono + subtle / 不同 font-family span，已主動補 `align-items: baseline` 或 `vertical-align: baseline`
+- [ ] **AP-Phase2-C**: 該 page / feature 內 Tailwind utility `border-border` / `bg-card` / `text-muted-foreground` 等 shadcn-system token 用法已全部替換為 mockup verbatim class
+
+---
+
+**維護責任**：每個 frontend sprint kickoff 必讀本檔；Code reviewer 以 DoD 5 條 + 鐵律 7 條 + Phase-2 anti-patterns 3 條為 PR 強制檢查項。

--- a/frontend/src/pages/state-inspector/StateInspectorPage.tsx
+++ b/frontend/src/pages/state-inspector/StateInspectorPage.tsx
@@ -25,6 +25,7 @@
  * Last Modified: 2026-05-24
  *
  * Modification History (newest-first):
+ *   - 2026-05-24: FIX-011 — drop production-only padding:18 on outer wrapper (mockup has no outer wrapper; .content padding sufficed; the extra 18px stacked ~46px effective vs mockup 28px)
  *   - 2026-05-24: Sprint 57.37 Day 3 — verbatim CSS re-point per page-platform.jsx:21-155 (closes Sprint 57.19 vintage HSL-translation drift; drops TONE_CLASS Record + bg-X/16/text-X Tailwind utility patterns + shadcn token classes; adopts mockup verbatim .page-head/.grid-stats/.card/.col/.spread/.mono/.subtle/.tnum + verbatim oklch alpha-tints)
  *   - 2026-05-17: Initial creation (Sprint 57.19 Day 4 / US-C4)
  *
@@ -51,7 +52,13 @@ import { useStateSnapshot } from "@/features/state/hooks/useStateSnapshot";
 // no-restricted-syntax eslint rule (only inline JSX object literals are flagged).
 // Mockup source line references in each name.
 
-const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column" as const, gap: 14, padding: 18 };
+// FIX-011 (Sprint 57.38 follow-up 2026-05-24): dropped `padding: 18` — production-only
+// Sprint 57.19 vintage outer padding artifact; mockup page-platform.jsx:25-145 has NO
+// outer wrapper. .content already provides 24px 28px 60px padding; the extra 18px
+// stacked on top added ~46px effective left/right inset vs mockup's intended 28px.
+// `gap: 14` kept to preserve vertical rhythm between page-head + grid-stats + grid-2
+// children (mockup relies on per-class margins which we conservatively reinforce here).
+const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column" as const, gap: 14 };
 const STATE_GRID_320_1FR_STYLE = { display: "grid", gridTemplateColumns: "320px 1fr", gap: 14 };
 const CARRYOVER_BANNER_STYLE = {
   padding: 12,


### PR DESCRIPTION
## Summary

User-reported 2026-05-24 (post Sprint 57.38 PR #176 merge): 3 visual issues. This PR fixes Issue 1 (1-line code) and codifies all 3 as systematic Phase-2 re-point anti-patterns for future sprints to avoid.

| # | Issue | Status in this PR |
|---|-------|---------------------|
| 1 | `/state-inspector` left/right padding visibly wider than mockup | ✅ **Fixed (1-line code)** |
| 2 | `[v18 by orchestrator_loop]` detail title baseline misalignment | ⚠️ Codified as **AP-Phase2-B** (AD deferred) |
| 3 | All-page buttons render black borders vs mockup light grey | ⚠️ Codified as **AP-Phase2-C** (AD deferred) |

## Issue 1 — fix

```diff
- const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column", gap: 14, padding: 18 };
+ // FIX-011: dropped `padding: 18` — production-only Sprint 57.19 vintage artifact;
+ // mockup page-platform.jsx:25-145 has NO outer wrapper. .content already provides
+ // 24px 28px 60px padding; extra 18px stacked = ~46px effective inset vs mockup 28px.
+ const STATE_PAGE_WRAPPER_STYLE = { display: "flex", flexDirection: "column", gap: 14 };
```

Sprint 57.37 Day 3 Domain B verbatim re-point misread this wrapper as "backend wiring worth preserving" — it is actually a translation-era visual artifact.

## Issue 2 + 3 — codified as systematic anti-patterns

`docs/rules-on-demand/frontend-mockup-fidelity.md` §Phase-2 re-point systematic anti-patterns — 3 NEW entries:

- **AP-Phase2-A**: production-only outer padding wrapper (Issue 1 class; FIX-011 resolves it)
- **AP-Phase2-B**: inline mixed-font span baseline misalignment (Issue 2 class; mockup-inherent font-pairing artifact; recommended fix `display: inline-flex; align-items: baseline`)
- **AP-Phase2-C**: Tailwind utility `border-border` → shadcn `--sc-border` token residue on Phase-2 not-yet-re-pointed pages (Issue 3 class; **31 files** still use Tailwind utility; Phase-2 epic incomplete migration NOT a CSS-translation drift)

Code review checklist (3 NEW mandatory items) added — every Phase-2 re-point sprint PR must answer ✅ / N/A for each.

## 3 NEW carryover ADs (next-phase-candidates.md)

- `AD-State-Inspector-Outer-Padding-Wrapper-Fix` — ✅ RESOLVED by FIX-011
- `AD-Inline-Font-Baseline-Alignment` — Issue 2 deferred (~2-3 hr typography audit + targeted fix)
- `AD-Shadcn-Border-Token-Visual-Audit-Or-Align-To-Mockup` — Issue 3 deferred (decide Path A 1-line global fix vs Path B complete Phase-2 epic)

## Why Sprint 57.38 Day 2.1 fullbleed audit missed Issue 1

Sprint 57.38 Domain C `AD-FullBleed-Pages-Audit` scope was only the `fullBleed` prop drop class. The AP-Phase2-A class (outer padding wrapper INSIDE the AppShellV2 mount) is distinct and was not in audit scope.

**Lesson for next audit**: extend Day 0 grep to include:
```bash
grep -n "style={{.*padding\|<div style={{[^}]*padding" frontend/src/pages/<target>/<page>.tsx
```

## Sister-bug relationship

| Bug | Sister | Class | Fix size |
|-----|--------|-------|----------|
| FIX-010 (`/loop-debug` `fullBleed` prop drop) | FIX-011 (this PR, `/state-inspector` outer padding wrapper) | Layout-class production-only artifact | Both 1-line |

Each Phase-2 re-point sprint Day 0 Prong 1 should grep for **both** layout-class drops on the target page before Day 1 code.

## Verification

- ✅ `npm test -- --reporter=dot` → **Vitest 464/464** (Sprint 57.38 baseline preserved)
- ✅ `node scripts/check-mockup-fidelity.mjs` → byte-identical + 51 grep guard (unchanged)
- ✅ `npm run lint` → clean (only pre-existing jsx-ast-utils warnings)

## Impact

| Scope | Detail |
|-------|--------|
| Files | 4 (1 production source + 1 rule doc + 1 FIX record + 1 candidates) |
| Effective production code | 1 line edit + 6-line explanatory comment + 1 MHist entry |
| Cascade risk | 0 — affects only `/state-inspector` outer padding |
| Visual regression | Only `/state-inspector` route; ~18 px tighter L/R inset matching mockup intent |
| Issue 2 + 3 | NOT touched in this PR — codified as anti-patterns for future Phase-2 sprints |

## References

- `claudedocs/4-changes/bug-fixes/FIX-011-state-inspector-outer-padding-and-systematic-anti-patterns.md` — full FIX record
- `docs/rules-on-demand/frontend-mockup-fidelity.md` §Phase-2 re-point systematic anti-patterns
- `claudedocs/1-planning/next-phase-candidates.md` §Sprint 57.38 Follow-up Carryover
- `memory/project_phase57_38_followup_3_user_reported_issues.md`
- `reference/design-mockups/page-platform.jsx:25-145` — mockup truth (no outer wrapper)
- `reference/design-mockups/styles.css:412` — `.content` padding
- `frontend/src/index.css:92` — `* { border-color: hsl(var(--sc-border)) }` global default (AP-Phase2-C root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)