### PR TITLE
chore(rules): remove stale graphify references from CLAUDE.md + rules README

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -2,7 +2,7 @@
 
 **Purpose**: V2 開發規則總覽 + on-demand 載入指南。所有規則對齐 `docs/03-implementation/agent-harness-planning/` 21 份權威文件。
 
-**Last Updated**: 2026-05-26（Sprint 57.51 — 新增 lint-detector-authoring 到 on-demand 11→12）
+**Last Updated**: 2026-05-29（Sprint 57.62 closeout chore — 移除 graphify-usage on-demand 12→11；graphify 已停用 per user decision Sprint 52.5）
 **Status**: Active
 
 ---
@@ -14,7 +14,7 @@
 | 位置 | 行為 | 用途 |
 |------|------|------|
 | **`.claude/rules/*.md`**（頂層 4 條 + 本 README）| ✅ Claude Code 自動載入每個 session | 高頻 critical 規則 |
-| **`docs/rules-on-demand/*.md`**（12 條）| ⏸️ 預設不載入，需 AI 主動 `Read` | 情境式規則 |
+| **`docs/rules-on-demand/*.md`**（11 條）| ⏸️ 預設不載入，需 AI 主動 `Read` | 情境式規則 |
 
 **為何脫離 .claude/**: Claude Code 會**遞迴掃描 .claude/ 整樹**載入 project memory；2026-05-09 第一版的 `.claude/rules/on-demand/` 子目錄結構雖然語義上是 on-demand，實際仍被 Claude Code 自動載入（佔 ~39KB／session，違反設計意圖）。將 on-demand rules 移到 `docs/rules-on-demand/` 後 Claude Code 不再掃描，真正落實 Hybrid。
 
@@ -33,7 +33,7 @@
 
 ---
 
-## 📋 On-Demand（12 條，需要時主動 Read）
+## 📋 On-Demand（11 條，需要時主動 Read）
 
 > **AI 規則**：碰到下列「Trigger」時，**先 Read 對應規則檔再開始 code**。
 
@@ -52,7 +52,6 @@
 | [`frontend-react.md`](../../docs/rules-on-demand/frontend-react.md) | 純 React/TypeScript 通用約定 |
 | [`frontend-mockup-fidelity.md`](../../docs/rules-on-demand/frontend-mockup-fidelity.md) | 前端頁面開發 / mockup port / 改 `styles-mockup.css` / 設計系統 |
 | [`lint-detector-authoring.md`](../../docs/rules-on-demand/lint-detector-authoring.md) | 寫新 AP-N detector / 維護現有 AP-N detector / debug detector false-positive / 擴 detector 涵蓋新檔案類 |
-| [`graphify-usage.md`](../../docs/rules-on-demand/graphify-usage.md) | 用 graphify-out/ 加速理解 codebase |
 
 ---
 
@@ -107,7 +106,6 @@
 | docs/rules-on-demand/git-workflow.md | CLAUDE.md §Code Standards |
 | docs/rules-on-demand/frontend-mockup-fidelity.md | CLAUDE.md §Frontend Mockup-Fidelity Hard Constraint / 16-frontend-design.md |
 | docs/rules-on-demand/lint-detector-authoring.md | 04-anti-patterns.md §AP-N detector authoring（Sprint 57.48 D-DAY0-6 lesson codified Sprint 57.51）|
-| docs/rules-on-demand/graphify-usage.md | CLAUDE.md §graphify（純本地工具）|
 
 > **權威排序**：V2 規劃文件（21 份）> 本目錄規則 > 既有代碼。衝突以上位者為準。
 
@@ -129,11 +127,13 @@
 |--------|--------|------|
 | `agent-framework.md` | V1 MAF 已封存（Sprint 49.1） | `docs/rules-on-demand/adapters-layer.md` |
 | `azure-openai-api.md` | 內容拆分到 ABC 設計 + Azure 細節 | `docs/rules-on-demand/adapters-layer.md` §Azure OpenAI 特定細節 |
+| `graphify-usage.md` | graphify 已停用（per user decision Sprint 52.5 — 評估後選擇不再使用；post-checkout/post-commit hooks intentionally disabled）| 無（功能停用，非取代）；`docs/rules-on-demand/graphify-usage.md` + `graphify-out/` 保留 dormant 供 git history |
 
 ---
 
 ## Modification History
 
+- 2026-05-29: Sprint 57.62 closeout chore — 移除 graphify-usage on-demand（12 → 11 條）+ CLAUDE.md §graphify section + on-demand row 移除 + 記入「已淘汰的規則」表（graphify 已停用 per user decision Sprint 52.5；rule 檔 + `graphify-out/` 保留 dormant，未刪）
 - 2026-05-26: Sprint 57.51 — add `lint-detector-authoring.md` on-demand 11→12 (closes AD-Lint-Detector-Code-Aware-Masking-Rule)
 - 2026-05-22: 新增 `frontend-mockup-fidelity.md` 到 On-Demand 索引（10 → 11 條）+ 任務情境快查「前端頁面開發」配對 + V2 文件對應表（align to validated mockup-fidelity method）
 - 2026-05-09 (revised): on-demand rules 真正移出 `.claude/` → `docs/rules-on-demand/`（10 個檔案 git mv）。Root cause: Claude Code 遞迴掃描 `.claude/` 整樹載入 project memory，子目錄不阻止；本日上午第一版的 `.claude/rules/on-demand/` 結構並未真正生效（仍被自動載入 ~39KB／session）。修正後 on-demand rules 完全脫離 Claude Code memory 掃描範圍。節省 ~39KB context／session。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,7 +302,7 @@ python scripts/dev.py logs docker -f
 | `.claude/rules/multi-tenant-data.md` | tenant_id 鐵律 + RLS + GDPR / PII |
 | `.claude/rules/anti-patterns-checklist.md` | 11 條 PR 自檢 |
 
-**📋 On-demand（10 條，需要時主動 Read `docs/rules-on-demand/X.md`）**
+**📋 On-demand（9 條，需要時主動 Read `docs/rules-on-demand/X.md`）**
 
 | Rule | Trigger |
 |------|---------|
@@ -315,7 +315,6 @@ python scripts/dev.py logs docker -f
 | `git-workflow.md` | Commit message / branch naming |
 | `backend-python.md` | Python backend 通用約定 |
 | `frontend-react.md` | React/TS 通用約定 |
-| `graphify-usage.md` | 用 graphify-out/ 探索 codebase |
 
 > 完整 trigger 表 + 任務情境配對見 [`.claude/rules/README.md`](.claude/rules/README.md)。
 
@@ -578,44 +577,6 @@ Phase README → Code → Progress Doc  ❌ 跳過 plan + checklist
 1. **Target Market**: 台灣 / 香港。技術詞英文，使用者面向繁體中文。
 2. **BMAD Methodology**: 沿用 BMad Agile workflow。狀態追蹤於 `docs/bmm-workflow-status.yaml`。
 3. **MAF Status**: V1 整合的 Microsoft Agent Framework 已於 Sprint 49.1 完成封存到 `archived/v1-phase1-48/`。V2 不再以 MAF 為核心；如需 multi-agent builder 才有條件保留 adapter。
-
----
-
-## graphify
-
-This project has a graphify knowledge graph at `graphify-out/`.
-
-### Navigation rules
-- 回答架構或代碼問題前，讀 `graphify-out/GRAPH_REPORT.md`（god nodes + community structure）
-- 若 `graphify-out/wiki/index.md` 存在，優先用而非讀原始檔案
-- 最佳閱讀順序：L1–10（summary）→ L2184–2322（god nodes + surprising connections + hyperedges）。用 Grep 跳到特定 community 在 L2323+
-
-### Confidence handling（CRITICAL）
-當前 graph 約 25% EXTRACTED / 75% INFERRED。
-- **God Nodes 與 Community structure** — 高信任，可直接用
-- **Surprising Connections** — 多為 INFERRED，當作假說，引用前用 Read/Grep 驗證
-- **架構理由引用** — 用 `/graphify explain <node>` 確認支撐 edge 是 EXTRACTED（已驗證）還是 INFERRED（LLM 猜的）。若只有 INFERRED 支撐，回答時必須明示
-
-### ⚠️ Scope Control
-**`.graphifyignore` 必須存在於專案根**。`graphify update .` 不會記住初次 build 排除哪些目錄；缺少 `.graphifyignore` 會把 `reference/`（2,213 files）、`claudedocs sample/`（217 files）、debug PNG（~124 files）全納入。
-
-驗證 scope：
-```bash
-python -c "from graphify.detect import detect; from pathlib import Path; r = detect(Path('.')); print(f'{r[\"total_files\"]} files, {r[\"graphifyignore_patterns\"]} ignore patterns')"
-# 預期：~3,300 files、30 ignore patterns
-```
-
-若 >5,000 files，停下修 `.graphifyignore` 再繼續。
-
-### Maintenance
-
-| Command | When | Cost |
-|---------|------|------|
-| `graphify update .` | 代碼變更（.py / .ts / .tsx）| Free |
-| `/graphify --update` | docs / markdown / PDF / image | Paid (LLM) |
-| `/graphify .` | 全重建（罕用） | Paid (LLM) |
-
-預設：每次 code commit 後跑 `graphify update .` — 它用 manifest.json diff，小變更幾乎瞬間完成。
 
 ---
 


### PR DESCRIPTION
## Remove stale graphify references

graphify was deprecated **per user decision** (recorded in memory Sprint 52.5: evaluated + chose to stop; post-checkout/post-commit hooks intentionally disabled). But `CLAUDE.md` still carried an active `## graphify` section + an on-demand rules row that wrongly prompted graphify suggestions each session.

### Changes (De-activate — no file deletion)
- **CLAUDE.md**: removed `## graphify` section (-41 lines) + Code Standards on-demand row + count (10→9).
- **.claude/rules/README.md**: removed on-demand index row + V2-doc-mapping row + counts (12→11); recorded in `§已淘汰的規則` table.
- Per `§維護` convention, the rule file `docs/rules-on-demand/graphify-usage.md` + `graphify-out/` are kept **dormant (not deleted)** for git history.
- **memory unchanged** — `project_sprint_52_5_audit_carryover.md` already correctly records the stop-decision.

Docs-only; no source/test change. (Note: backend-ci paths-filter was retired Sprint 55.6 → this PR triggers full CI normally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)