### PR TITLE
chore(templates): portable claude-workflow-kit (sprint flow + CI + rules)

### DIFF
--- a/templates/claude-workflow-kit/TEMPLATE-GUIDE.md
+++ b/templates/claude-workflow-kit/TEMPLATE-GUIDE.md
@@ -1,0 +1,142 @@
+# Claude Workflow Kit — 製作與移植教學
+
+**Purpose**: 把本項目（ai-semantic-kernel-framework）驗證過的「sprint 紀律 + CI gate + 規則載入 + 變更紀錄」流程，抽成可移植到**任何新項目**的通用模版。
+**Created**: 自動帶入（見 init 腳本）
+**Status**: Active
+
+---
+
+## 0. 這個 kit 是什麼
+
+`templates/claude-workflow-kit/` 是一個**自包含模版**，分三部分：
+
+| 部分 | 路徑 | 用途 |
+|------|------|------|
+| **可注入內容** | `kit/` | 會被複製到目標項目的所有檔案（規則、CI、PR 模版、lint 框架、claudedocs 骨架） |
+| **bootstrap 腳本** | `init-workflow.ps1` | 互動式問答 → 變數替換 → 注入到目標 repo |
+| **本教學** | `TEMPLATE-GUIDE.md` | 你現在讀的這份 |
+
+設計原則：**只帶方法論層，丟掉內容層**（見下方 §2 分類表）。
+
+---
+
+## 1. 快速開始（3 步）
+
+```powershell
+# 1. 進到 kit 目錄
+cd C:\Users\Chris\Downloads\ai-semantic-kernel-framework-project\templates\claude-workflow-kit
+
+# 2. 跑 bootstrap（互動式；缺的參數會問你）
+.\init-workflow.ps1 -TargetPath "C:\path\to\new-project"
+
+# 3. 進新項目，commit 初始流程骨架
+cd C:\path\to\new-project
+git add .claude .github scripts claudedocs CLAUDE.md docs
+git commit -m "chore(workflow): bootstrap sprint workflow kit"
+```
+
+完成後新項目立即擁有：5 步 sprint 流程、CI gate、PR 自檢模版、Hybrid 規則載入、FIX/CHANGE/REFACTOR 變更紀錄、claudedocs 骨架。
+
+---
+
+## 2. 核心觀念：兩層切開（移植成敗關鍵）
+
+本項目流程之所以耐用，是「方法論層」疊在「內容層」上。模版化 = **帶走骨架、丟掉血肉**。
+
+| 分類 | 代表檔案 | 處理方式 |
+|------|---------|---------|
+| **A. 直接攜帶**（通用方法論） | `sprint-workflow.md` 5 步骨架、`file-header-convention.md`、`rules/README.md` Hybrid 載入、`PULL_REQUEST_TEMPLATE.md`、`run_all.py` lint wrapper、`claudedocs/` 變更慣例、`settings.json` SessionStart hook | kit 已通用化，照用 |
+| **B. 參數化**（保留結構、換內容） | `CLAUDE.md`、`ci.yml` 的實際命令、`anti-patterns-checklist.md` 的條目 | bootstrap 用 placeholder 自動換；條目自己補 |
+| **C. 丟棄**（原項目專屬） | 11+1 範疇、LLM provider neutrality、multi-tenant 三鐵律、calibration agent_factor 矩陣、`check_llm_sdk_leak` / `check_rls_policies` | **不放進 kit**；需要時才針對新項目自寫 |
+
+> 為什麼要丟 C：原項目的 calibration 比率矩陣是「該團隊累積 50+ sprint 的歷史數據」，搬到新項目是錯的基準。新項目應從 `multiplier 0.6` 預設重新累積。
+
+---
+
+## 3. Placeholder 對照表
+
+bootstrap 腳本會把下列 token 全文替換。手動客製時也照這張表：
+
+| Token | 意義 | 範例值 |
+|-------|------|--------|
+| `{{PROJECT_NAME}}` | 項目名稱 | `my-saas-app` |
+| `{{PROJECT_DESC}}` | 一句話描述 | `A multi-tenant billing platform` |
+| `{{PRIMARY_LANGUAGE}}` | 主語言 | `TypeScript` / `Python` / `Go` |
+| `{{FORMAT_CMD}}` | 格式化命令 | `prettier --write .` / `black .` |
+| `{{LINT_CMD}}` | lint 命令 | `npm run lint` / `flake8 src` |
+| `{{TYPECHECK_CMD}}` | 型別檢查 | `tsc --noEmit` / `mypy src --strict` |
+| `{{TEST_CMD}}` | 測試命令 | `npm test` / `pytest` |
+| `{{DEFAULT_BRANCH}}` | 主分支 | `main` |
+| `{{DATE}}` | 注入日期 | `2026-05-31` |
+
+---
+
+## 4. 注入後你要做的客製（10 分鐘）
+
+1. **`CLAUDE.md`** — 填 Mission / 技術棧 / 核心約束（取代原項目的 11+1 範疇）。
+2. **`anti-patterns-checklist.md`** — `§Project-Specific` 區塊補新項目自己的教訓（一開始可留空，每次踩坑加一條）。
+3. **`docs/rules-on-demand/`** — 把新項目真正需要的情境式規則放這（資料庫慣例、API 風格…）；通用 4 條已在 `.claude/rules/`。
+4. **`.github/workflows/ci.yml`** — 確認 toolchain 命令對；若無前端可刪 frontend job。
+5. **`scripts/lint/run_all.py`** — 預設只有框架；要加新項目專屬 AST 檢查時，照 `_example_detector` 模式寫。
+6. **分支保護** — 到 GitHub Settings → Branches，把 CI job 名加進 required status checks（本項目經驗：solo dev 設 `review_count=0` + `enforce_admins=true`）。
+
+---
+
+## 5. 回流同步紀律（重要）
+
+模版會持續演進。維持**單向同步**：
+
+- ✅ 通用改進（5 步流程優化、新增通用 lint 框架）→ 改在 `templates/claude-workflow-kit/kit/`，再 re-inject 到各項目。
+- ❌ 各項目的專屬內容（calibration、domain 規則）**不回流**到 kit。
+- 每次 re-inject 前先 `git diff`，避免覆蓋目標項目已客製的 `CLAUDE.md` / `anti-patterns` 條目（bootstrap 對既有檔預設**不覆蓋**，需 `-Force`）。
+
+---
+
+## 6. 進階：升級成 GitHub template repo
+
+若要 `gh repo create new --template`：
+
+```powershell
+# 把 kit/ 內容推到一個新 repo（注意：保留 placeholder 不替換）
+gh repo create my-org/claude-workflow-template --private
+# 在該 repo Settings → 勾 "Template repository"
+# 新項目： gh repo create new-proj --template my-org/claude-workflow-template
+#         然後仍需跑一次 placeholder 替換（可把 init-workflow.ps1 也放進 template repo）
+```
+
+starter-kit（本方案）vs template repo 取捨：starter-kit 適合「我在本機跨多項目注入」；template repo 適合「團隊/組織共用、雲端一鍵」。兩者可並存。
+
+---
+
+## 附錄：kit 檔案清單
+
+```
+kit/
+├── CLAUDE.md                          # 參數化項目導航
+├── .claude/
+│   ├── settings.json                  # SessionStart hook + plugins 佔位
+│   └── rules/
+│       ├── README.md                  # Hybrid 載入策略（通用化）
+│       ├── sprint-workflow.md         # 5 步流程（通用精簡版）
+│       ├── file-header-convention.md  # 檔頭 + MHist 規範
+│       └── anti-patterns-checklist.md # PR 自檢骨架 + 6 條通用反模式
+├── .github/
+│   ├── PULL_REQUEST_TEMPLATE.md       # PR 自檢模版（參數化）
+│   └── workflows/
+│       └── ci.yml                     # CI gate 結構（參數化）
+├── scripts/lint/
+│   ├── run_all.py                     # 一站式 lint wrapper 框架
+│   └── _example_detector.py           # 自寫 AST 檢查範本
+├── docs/rules-on-demand/
+│   └── README.md                      # on-demand 規則放置說明
+└── claudedocs/
+    ├── README.md
+    ├── 1-planning/.gitkeep
+    ├── 4-changes/{bug-fixes,feature-changes,refactoring}/.gitkeep
+    └── templates/
+        ├── sprint-plan-template.md
+        ├── sprint-checklist-template.md
+        ├── FIX-template.md
+        ├── CHANGE-template.md
+        └── REFACTOR-template.md
+```

--- a/templates/claude-workflow-kit/init-workflow.ps1
+++ b/templates/claude-workflow-kit/init-workflow.ps1
@@ -1,0 +1,130 @@
+<#
+.SYNOPSIS
+    Bootstrap the Claude Workflow Kit into a target project.
+
+.DESCRIPTION
+    Copies the generic sprint-workflow / CI / PR-template / lint-framework /
+    claudedocs skeleton from kit/ into a target repository, then replaces all
+    {{TOKEN}} placeholders with project-specific values.
+
+    Two-layer principle: this kit carries ONLY the methodology layer. Project-
+    specific content (domain rules, calibration history) must be added by hand
+    after injection — see TEMPLATE-GUIDE.md sections 2 and 4.
+
+.PARAMETER TargetPath
+    Destination project root (must exist; should be a git repo).
+
+.PARAMETER Force
+    Overwrite files that already exist in the target. Default: skip existing
+    files (so re-injection never clobbers your customized CLAUDE.md / rules).
+
+.EXAMPLE
+    .\init-workflow.ps1 -TargetPath "C:\code\my-new-project"
+
+.EXAMPLE
+    .\init-workflow.ps1 -TargetPath "C:\code\my-app" -ProjectName "my-app" `
+        -PrimaryLanguage "TypeScript" -LintCmd "npm run lint" `
+        -TypecheckCmd "tsc --noEmit" -TestCmd "npm test" -FormatCmd "prettier --write ."
+#>
+param(
+    [Parameter(Mandatory = $true)][string]$TargetPath,
+    [string]$ProjectName,
+    [string]$ProjectDesc,
+    [string]$PrimaryLanguage,
+    [string]$FormatCmd,
+    [string]$LintCmd,
+    [string]$TypecheckCmd,
+    [string]$TestCmd,
+    [string]$DefaultBranch = "main",
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Resolve paths -----------------------------------------------------------
+$KitRoot = Join-Path $PSScriptRoot "kit"
+if (-not (Test-Path $KitRoot)) {
+    throw "kit/ folder not found next to this script at: $KitRoot"
+}
+if (-not (Test-Path $TargetPath)) {
+    throw "TargetPath does not exist: $TargetPath"
+}
+$TargetPath = (Resolve-Path $TargetPath).Path
+
+# --- Prompt for missing required tokens (interactive) ------------------------
+function Get-OrAsk([string]$value, [string]$prompt, [string]$default) {
+    if ($value) { return $value }
+    $answer = Read-Host "$prompt$([string]::IsNullOrEmpty($default) ? '' : " [$default]")"
+    if ([string]::IsNullOrWhiteSpace($answer) -and $default) { return $default }
+    return $answer
+}
+
+$ProjectName     = Get-OrAsk $ProjectName     "Project name"                    (Split-Path $TargetPath -Leaf)
+$ProjectDesc     = Get-OrAsk $ProjectDesc     "One-line project description"    "TODO: describe this project"
+$PrimaryLanguage = Get-OrAsk $PrimaryLanguage "Primary language (Python/TypeScript/Go/...)" "Python"
+$FormatCmd       = Get-OrAsk $FormatCmd       "Format command"                  "black ."
+$LintCmd         = Get-OrAsk $LintCmd         "Lint command"                    "flake8 src"
+$TypecheckCmd    = Get-OrAsk $TypecheckCmd    "Type-check command"              "mypy src --strict"
+$TestCmd         = Get-OrAsk $TestCmd         "Test command"                    "pytest"
+
+$today = (Get-Date).ToString("yyyy-MM-dd")
+
+$tokens = @{
+    '{{PROJECT_NAME}}'     = $ProjectName
+    '{{PROJECT_DESC}}'     = $ProjectDesc
+    '{{PRIMARY_LANGUAGE}}' = $PrimaryLanguage
+    '{{FORMAT_CMD}}'       = $FormatCmd
+    '{{LINT_CMD}}'         = $LintCmd
+    '{{TYPECHECK_CMD}}'    = $TypecheckCmd
+    '{{TEST_CMD}}'         = $TestCmd
+    '{{DEFAULT_BRANCH}}'   = $DefaultBranch
+    '{{DATE}}'             = $today
+}
+
+# --- Copy + token-replace ----------------------------------------------------
+$textExt = @('.md', '.py', '.json', '.yml', '.yaml', '.txt', '.ts', '.tsx', '.js')
+$copied = 0; $skipped = 0; $replaced = 0
+
+Get-ChildItem -Path $KitRoot -Recurse -File | ForEach-Object {
+    $relative = $_.FullName.Substring($KitRoot.Length).TrimStart('\', '/')
+    $dest = Join-Path $TargetPath $relative
+    $destDir = Split-Path $dest -Parent
+
+    if ((Test-Path $dest) -and (-not $Force)) {
+        Write-Host "  skip (exists): $relative" -ForegroundColor DarkYellow
+        $skipped++
+        return
+    }
+
+    if (-not (Test-Path $destDir)) {
+        New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+    }
+
+    if ($textExt -contains $_.Extension.ToLower()) {
+        $content = Get-Content -Raw -Encoding UTF8 $_.FullName
+        foreach ($k in $tokens.Keys) {
+            if ($content.Contains($k)) {
+                $content = $content.Replace($k, $tokens[$k])
+                $replaced++
+            }
+        }
+        # Write UTF-8 without BOM
+        [System.IO.File]::WriteAllText($dest, $content, [System.Text.UTF8Encoding]::new($false))
+    }
+    else {
+        Copy-Item $_.FullName $dest -Force
+    }
+    Write-Host "  inject: $relative" -ForegroundColor Green
+    $copied++
+}
+
+# --- Summary -----------------------------------------------------------------
+Write-Host ""
+Write-Host "Done. $copied file(s) injected, $skipped skipped (already existed), $replaced token-replacement(s)." -ForegroundColor Cyan
+Write-Host ""
+Write-Host "Next steps (see TEMPLATE-GUIDE.md section 4):" -ForegroundColor Cyan
+Write-Host "  1. Edit CLAUDE.md  -> fill Mission / tech stack / core constraints"
+Write-Host "  2. Edit .claude/rules/anti-patterns-checklist.md -> add project-specific anti-patterns"
+Write-Host "  3. Verify .github/workflows/ci.yml toolchain commands"
+Write-Host "  4. On GitHub: add CI job names to branch protection required status checks"
+Write-Host "  5. git add . && git commit -m 'chore(workflow): bootstrap sprint workflow kit'"

--- a/templates/claude-workflow-kit/kit/.claude/rules/README.md
+++ b/templates/claude-workflow-kit/kit/.claude/rules/README.md
@@ -1,0 +1,66 @@
+# `.claude/rules/` + `docs/rules-on-demand/` Index
+
+**Purpose**: Development rules overview + on-demand loading guide for **{{PROJECT_NAME}}**.
+**Status**: Active
+
+---
+
+## Loading Strategy (Hybrid)
+
+To control session context usage, rules are split into two tiers:
+
+| Location | Behavior | Use |
+|----------|----------|-----|
+| **`.claude/rules/*.md`** (3 always-loaded + this README) | ✅ Claude Code auto-loads every session | High-frequency critical rules |
+| **`docs/rules-on-demand/*.md`** | ⏸️ Not loaded by default; AI must `Read` when triggered | Situational rules |
+
+**Why not put everything in `.claude/`?** Claude Code recursively scans the whole `.claude/` tree into project memory. On-demand rules placed under `.claude/` would still be auto-loaded, defeating the purpose. Keeping them under `docs/rules-on-demand/` keeps them out of the auto-scan until explicitly Read.
+
+**Why Hybrid?** Loading every rule costs context at session start; loading nothing risks the AI missing the sprint workflow / file-header / anti-pattern discipline. Hybrid keeps the 3 highest-ROI rules always-loaded and the rest on-demand.
+
+---
+
+## 🔴 Always-Loaded (3 critical, always in context)
+
+| File | Purpose |
+|------|---------|
+| [`sprint-workflow.md`](./sprint-workflow.md) | Plan → Checklist → Day-0 Verify → Code → Update → Progress + workload calibration |
+| [`file-header-convention.md`](./file-header-convention.md) | File header + Modification History (1-line max) |
+| [`anti-patterns-checklist.md`](./anti-patterns-checklist.md) | PR self-check list (universal + project-specific) |
+
+---
+
+## 📋 On-Demand (Read when triggered)
+
+> **AI rule**: when you hit a trigger below, **Read the rule file BEFORE starting to code.**
+> Add your project's situational rules here. Suggested starters:
+
+| File (create under `docs/rules-on-demand/`) | Trigger (when to Read) |
+|------|------------------------|
+| `git-workflow.md` | Writing commit messages / opening a branch |
+| `testing.md` | Writing tests / planning test coverage |
+| `code-quality.md` | Fixing lint / type-check errors |
+| `<your-domain>.md` | Domain-specific conventions (DB schema, API style, auth, …) |
+
+---
+
+## Task-to-Rule Quick Map
+
+| Situation | Always | Read on-demand |
+|-----------|--------|----------------|
+| Start a sprint | `sprint-workflow.md` | — |
+| Create a new file | `file-header-convention.md` | `<domain>.md` |
+| Code review / PR self-check | `anti-patterns-checklist.md` | `git-workflow.md` |
+
+---
+
+## Maintenance
+
+- Rule changes = workflow changes → tag PR title `chore(rules)`.
+- New rules go through the standard `sprint-workflow.md` flow.
+- Retire old rules via an `archive` change, not deletion (preserve git history).
+- **Promote/demote**: if an on-demand rule is Read in 3 consecutive sprints, promote it to always-loaded (and vice versa).
+
+---
+
+**Maintained per** `claude-workflow-kit`. The methodology layer is portable; the content is yours to grow.

--- a/templates/claude-workflow-kit/kit/.claude/rules/anti-patterns-checklist.md
+++ b/templates/claude-workflow-kit/kit/.claude/rules/anti-patterns-checklist.md
@@ -1,0 +1,75 @@
+# Anti-Patterns Checklist (PR must pass)
+
+**Purpose**: A code-review self-check list. Every PR must answer ✅ / ❌ / N/A for each item before merge.
+**Category**: Framework / Development Process
+**Status**: Active
+
+> This file ships with **universal** anti-patterns. Add your project's own lessons under `§Project-Specific` as you learn them — start empty, append one line each time you hit a new trap.
+
+---
+
+## How to use
+
+Before opening a PR, fill ✅ (pass) / ❌ (fail) / N/A for each item. Any ❌ must be fixed before merge. Reviewers treat this as a mandatory gate.
+
+---
+
+## Universal Anti-Patterns
+
+### AP-U1: Orphan / Side-Track Code
+**Symptom**: code exists but nothing on the main flow calls it; modules tagged "PoC"/"experimental" that never get retired; multiple parallel versions.
+**Self-check**: Can the new code be traced from a real entry point (API route / main / exported surface)? Is there no `_v1` / `_v2` / `_old` duplicate?
+**Fix**: main-flow code must be reachable; PoCs go in an `experimental/` area with a deadline; delete unused code (git keeps history).
+
+### AP-U2: Partial Features / TODO Stubs
+**Symptom**: function exists but throws "not implemented"; core logic left as `// TODO`; mock/placeholder data shipped as real.
+**Self-check**: If this feature were toggled on, would it actually work end-to-end? Coverage ≥ 80%?
+**Fix**: start it = finish it. No TODO for core behavior; no fake data.
+
+### AP-U3: Cross-Directory Scattering
+**Symptom**: one concern's code spread across 3+ directories that don't know about each other; duplicate dataclasses/types.
+**Self-check**: Is this feature's code concentrated in one place? Any duplicate type definitions?
+**Fix**: keep each concern in one module; shared logic in a clearly-named shared location.
+
+### AP-U4: Naming-Behavior Mismatch (Potemkin)
+**Symptom**: a `validator` that only saves; a `verifier` that doesn't verify; empty stub with a complete-looking interface.
+**Self-check**: Does the name match what it actually does? Is there a negative test (what breaks if you turn it off)?
+**Fix**: name = behavior; add an end-to-end + negative test.
+
+### AP-U5: Mock vs Real Divergence
+**Symptom**: dev uses a mock, prod uses the real thing, and the two drift; bugs reproduce only in prod.
+**Self-check**: Do mock and real share the same interface/ABC? Does CI exercise the real path?
+**Fix**: mock and real implement the same interface; CI runs the real path; mock doesn't simplify away edge cases.
+
+### AP-U6: Version-Suffix Residue
+**Symptom**: `_v1` / `_v2` / `_old` / `_new` / `_legacy` in file / class / function names; rename left half-done.
+**Self-check**: Any version suffixes in this PR? Does naming reflect actual behavior? Did you grep the whole codebase for stragglers?
+**Fix**: no version suffixes; complete renames with a full-codebase grep; no leftover aliases unless there's a documented deprecation plan.
+
+---
+
+## Project-Specific (TODO — grow this)
+
+> Append your own as you learn them. One entry each:
+>
+> ### AP-P1: <name>
+> **Symptom**: …
+> **Self-check**: …
+> **Fix**: …
+
+*(none yet)*
+
+---
+
+## PR Template Insert
+
+```markdown
+## Anti-Pattern Checklist
+- [ ] AP-U1: No orphan / side-track code (traceable from entry point)
+- [ ] AP-U2: No partial features / TODO stubs (works end-to-end + tests)
+- [ ] AP-U3: No cross-directory scattering (one concern, one place)
+- [ ] AP-U4: Name matches behavior (+ negative test)
+- [ ] AP-U5: Mock and real share the same interface
+- [ ] AP-U6: No version suffixes; naming consistent
+<!-- add AP-P* project-specific rows here -->
+```

--- a/templates/claude-workflow-kit/kit/.claude/rules/file-header-convention.md
+++ b/templates/claude-workflow-kit/kit/.claude/rules/file-header-convention.md
@@ -1,0 +1,108 @@
+# File Header & Modification Convention
+
+**Purpose**: Standard metadata header on new files + a 1-line-per-entry Modification History, so anyone (human or AI) can grasp a file's purpose fast and trace why it changed.
+**Category**: Development Process / Standards
+**Status**: Active
+
+---
+
+## Why
+
+| Pain | Fix |
+|------|-----|
+| AI/dev opens a file and can't tell its purpose → wasted exploration | Header pins purpose + scope in one read |
+| "Structure exists but no real content" (Potemkin) | Description + Key Components force a real statement of intent |
+| `git blame` can't answer "why was it designed this way" | Section headers carry the Why + Alternative considered |
+| Changes accumulate with no history | Modification History records behavioral/structural changes |
+
+---
+
+## New File Header Template
+
+Adapt the comment syntax to {{PRIMARY_LANGUAGE}} (`"""..."""` for Python, `/** ... */` for TS/JS, `// ...` for Go, etc.):
+
+```
+File: <relative path>
+Purpose: <one sentence>
+Scope: <Sprint XX.Y / module>
+
+Description:
+    <2-5 lines: what it does, why it exists, what it interacts with>
+
+Key Components:
+    - ClassA: <purpose>
+    - function_b(): <purpose>
+
+Created: YYYY-MM-DD (Sprint XX.Y)
+Last Modified: YYYY-MM-DD
+
+Modification History (newest-first):
+    - YYYY-MM-DD: Initial creation (Sprint XX.Y) — <reason>
+```
+
+---
+
+## Section Header Convention
+
+For each important class / large function / logic block, add a short comment stating **WHY** (not WHAT):
+
+```
+# === ClassName: one-line role ===
+# Why: <the problem this solves / the decision behind it>
+# Alternative considered:
+#   - <option> — rejected because <reason>
+```
+
+---
+
+## Modification History Rules
+
+### Format — 1 line max per entry
+
+```
+Modification History (newest-first):
+    - YYYY-MM-DD: <verb> <what> (Sprint XX.Y) — <one-line reason>
+```
+
+- Each entry must fit one line (respect your linter's max-line-length including indent).
+- Prefer verbs over noun phrases (`extract` > `extraction of`; `add` > `addition of`).
+- Don't quote long paths; use a short scope keyword instead.
+- If the reason doesn't fit one line → move detail to the commit message body or the `claudedocs/4-changes/FIX-XXX` record.
+
+### Verbs
+
+| Verb | Use |
+|------|-----|
+| Add | new feature / method |
+| Fix | bug fix |
+| Refactor | restructure, behavior unchanged |
+| Update | enhance existing behavior |
+| Remove | delete feature / dead code |
+| Align | conform to a spec / contract |
+
+### When to record
+
+| Change type | Record? | Example |
+|-------------|---------|---------|
+| **Trivial** | ❌ No | typo / format / variable rename |
+| **Behavioral** | ✅ Yes | bug fix / new feature / logic refactor |
+| **Structural** | ✅ Yes | file split / interface change |
+
+---
+
+## Prohibited
+
+1. **Inline history comments** — `x = compute()  # changed from old() on 2026-05-01`. Use Modification History; `git blame` already has the detail.
+2. **Dead-code comments** — delete commented-out old code; git has the history.
+3. **Vague commit messages** — `update` / `fix` / `changes`. Use `type(scope): specific what + why`.
+4. **Skipping `claudedocs/4-changes/`** for behavioral changes.
+5. **Multi-line / bulleted Modification History entries** — one line each; rich detail goes in the commit body or the 4-changes record.
+
+---
+
+## Exceptions
+
+- Auto-generated files (migrations, proto, openapi): may omit the hand-written header.
+- Third-party vendored files: leave as-is.
+- Empty `__init__.py` / index files: may omit.
+- Test files: a simplified header is fine (File / Purpose / Created / Modified).

--- a/templates/claude-workflow-kit/kit/.claude/rules/sprint-workflow.md
+++ b/templates/claude-workflow-kit/kit/.claude/rules/sprint-workflow.md
@@ -1,0 +1,185 @@
+# Sprint Workflow Rules
+
+**Purpose**: Enforce sprint execution discipline so scope is explicit, traceable, and reviewable.
+**Category**: Development Process
+**Status**: Active
+
+---
+
+## Overview
+
+This document enforces a **mandatory 5-step sprint flow**. Skipping plan + checklist leads to scattered implementation, unclear PR scope, and blind retrospectives.
+
+**Golden Rule**:
+```
+Sprint Plan → Sprint Checklist → Day-0 Verify → Code → Update Checklist → Progress Doc
+```
+
+---
+
+## Step 1: Create Plan File
+
+**Before writing any code**, create `docs/sprints/sprint-XX-Y-plan.md`.
+
+**Required sections** (mirror the most recent completed sprint's plan for format consistency):
+- **Sprint Goal**: one sentence — what does this sprint deliver?
+- **User Stories**: 3-5 in "As a / I want / So that" format
+- **Technical Specifications**: design decisions + rationale
+- **File Change List**: explicit list of files to create/modify (with counts)
+- **Acceptance Criteria**: measurable, testable definition of done
+- **Deliverables**: `- [ ]` checkbox list mapping to stories
+- **Workload**: estimate (see calibration below)
+- **Dependencies & Risks**: what could block + mitigation
+
+> **Format consistency**: read the *most recent completed* sprint plan first and mirror its section count / naming / detail level. Express scope differences through **content** (more stories / files), not **structure** (don't add/rename sections).
+
+### Workload Calibration
+
+State the estimate in this form:
+
+> Bottom-up est ~X hr → calibrated commit ~Y hr (multiplier Z)
+
+- **X** = sum of raw per-task estimates
+- **Z** = calibration multiplier, default **0.6** (start here; bottom-up estimates tend to over-shoot)
+- **Y** = X × Z = what you actually commit to
+
+**Adjusting Z** (3-sprint moving evidence; ignore single outliers):
+- 3+ consecutive sprints with `actual/committed > 1.2` → raise Z (under-estimating)
+- 3+ consecutive sprints with `actual/committed < 0.7` → lower Z (buffer too generous)
+
+The Day-N / sprint-end retrospective recomputes `actual/committed` to verify Z.
+
+---
+
+## Step 2: Create Checklist File
+
+Immediately after plan approval, create `docs/sprints/sprint-XX-Y-checklist.md`.
+
+```markdown
+# Sprint XX.Y — Checklist
+
+[link to plan]
+
+## Day N — Task Group
+
+### N.M Task Description
+- [ ] **Specific deliverable**
+  - DoD: measurable definition of done
+  - Verify: `<command>`
+```
+
+**Rules**:
+- Use `- [ ]` format; one logical unit per checkbox
+- Each task has a DoD + a verify command
+- Map each task to a plan acceptance criterion
+- **Do NOT put time estimates in the checklist** — per-day actuals go in `progress.md`; sprint-aggregate calibration lives in the plan §Workload only
+
+**Sacred rule**: only change `[ ]` → `[x]`. **Never delete** unchecked items (that hides scope cuts). If scope is cut, leave `[ ]` and note the reason in `progress.md`.
+
+---
+
+## Step 2.5: Day-0 Plan-vs-Repo Verify
+
+**Mandatory** between drafting and Day-1 code. Plans drafted from memory drift from the real repo (renamed classes, moved files, changed signatures, schema deltas). Catch drift in ~30 min at Day 0 instead of paying hours of mid-sprint rework.
+
+Run a **grep/glob pass** over every claim in the plan:
+
+1. **Path verify** — every file path in §File Change List: confirm new files don't exist yet; edited files do exist.
+2. **Content verify** — every factual claim about existing code ("X is unused", "Y class extends Z", "consumer imports A"): grep the symbol/pattern to confirm. Path existing ≠ body matching the claim.
+3. **Schema verify** (when DB schema in scope) — every new table/column/migration: grep the actual model/migration to confirm name + type + nullable; confirm the next migration number isn't taken.
+
+**Catalog findings** in `progress.md` under a "Drift findings" header (`D1`, `D2`, …) and cross-reference plan §Risks. **Do NOT silently rewrite the plan** — add findings to §Risks to preserve the audit trail of planned-vs-actual.
+
+**Go/no-go**:
+- scope shift ≤ 20% → continue, note risk
+- 20-50% → revise plan §Acceptance + §Workload, re-confirm
+- > 50% → abort + redraft from reality baseline
+
+---
+
+## Step 3: Implement Code
+
+Only after plan + checklist + Day-0 verify exist.
+
+1. Create feature branch: `git checkout -b feature/sprint-XX-Y-<scope>`
+2. Code against checklist deliverables, one at a time
+3. Commit per logical unit
+
+**Prohibited**: starting code before plan/checklist; committing without a checklist entry; scope creep without updating plan + checklist.
+
+---
+
+## Step 4: Update Checklist During Implementation
+
+- As you complete: `[ ]` → `[x]` (change, never delete)
+- If blocked: add `🚧 blocked: <reason>` below the task; continue elsewhere or escalate
+- Commit checklist updates daily
+
+---
+
+## Step 5: Progress & Retrospective
+
+**Daily** — update `docs/sprints/sprint-XX-Y/progress.md`:
+```markdown
+# Sprint XX.Y Progress — YYYY-MM-DD
+## Today's Accomplishments
+- Task X.Y — actual Z min (est ~W min, delta ±N%)
+## Remaining for Next Day
+## Notes (learnings / decisions / risks)
+```
+
+**Sprint end** — create `retrospective.md`: did well / improve next / action items + estimate accuracy (`actual/committed` ratio to verify the multiplier).
+
+---
+
+## Change Record Conventions
+
+When fixing bugs or changing features, create a record in `claudedocs/4-changes/`:
+
+| Type | Directory | Naming |
+|------|-----------|--------|
+| Bug Fix | `4-changes/bug-fixes/` | `FIX-XXX-description.md` |
+| Feature Change | `4-changes/feature-changes/` | `CHANGE-XXX-description.md` |
+| Refactoring | `4-changes/refactoring/` | `REFACTOR-XXX-description.md` |
+
+Templates live in `claudedocs/templates/`.
+
+---
+
+## Before Commit Checklist
+
+1. **Corresponds to a checklist task** (message matches task ID)
+2. **Format + lint + type + test pass**:
+   - `{{FORMAT_CMD}}`
+   - `{{LINT_CMD}}` (do NOT use `--silent` — it can swallow lint errors)
+   - `{{TYPECHECK_CMD}}`
+   - `{{TEST_CMD}}`
+   - `python scripts/lint/run_all.py` (project-specific architecture lints)
+3. **Anti-patterns checklist** passes (`anti-patterns-checklist.md`)
+4. **File headers updated** (`file-header-convention.md`)
+
+---
+
+## Prohibited Actions
+
+- ❌ Force push to {{DEFAULT_BRANCH}}
+- ❌ Commit without a corresponding checklist entry
+- ❌ Delete unchecked `[ ]` items from the checklist
+- ❌ Skip `progress.md` updates (update daily)
+- ❌ Skip FIX/CHANGE/REFACTOR records for bug/feature changes
+- ❌ Code before plan + checklist exist
+- ❌ Commit secrets, large binaries, generated files
+- ❌ Scope creep without updating the plan
+
+---
+
+## Common Violation Patterns
+
+| Pattern | Why bad | Fix |
+|---------|---------|-----|
+| Skip plan | Unknown scope → rework | Always plan → checklist → code |
+| Delete `[ ]` items | Hides scope cuts; retro can't diagnose | Only mark `[x]` or note `[blocked]` |
+| Update checklist after sprint | Data quality → estimates useless | Update daily, during work |
+| Skip progress.md | Details lost; weak retro | 10-min daily entry |
+| Vague DoD | Infinite rework | DoD: testable + measurable |
+| Format inconsistency | Hard to navigate | Mirror prior sprint's structure |

--- a/templates/claude-workflow-kit/kit/.claude/settings.json
+++ b/templates/claude-workflow-kit/kit/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git log --oneline -8 && git status -sb"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/templates/claude-workflow-kit/kit/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/claude-workflow-kit/kit/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+# Pull Request
+
+## Summary
+
+<!-- 1-3 sentences. What changed and why? -->
+
+## Sprint linkage
+
+- Sprint plan: `docs/sprints/sprint-XX-Y-plan.md`
+- Sprint checklist: `docs/sprints/sprint-XX-Y-checklist.md`
+- Progress doc: `docs/sprints/sprint-XX-Y/progress.md`
+
+## Anti-Patterns Checklist (.claude/rules/anti-patterns-checklist.md)
+
+- [ ] AP-U1: No orphan / side-track code (traceable from entry point)
+- [ ] AP-U2: No partial features / TODO stubs (works end-to-end + tests)
+- [ ] AP-U3: No cross-directory scattering (one concern, one place)
+- [ ] AP-U4: Name matches behavior (+ negative test)
+- [ ] AP-U5: Mock and real share the same interface
+- [ ] AP-U6: No version suffixes; naming consistent
+<!-- add AP-P* project-specific rows here -->
+
+## Test plan
+
+<!-- How were the changes verified? -->
+
+- [ ]
+- [ ]
+
+## CI Gates
+
+- [ ] `{{FORMAT_CMD}}` (check mode)
+- [ ] `{{LINT_CMD}}`
+- [ ] `{{TYPECHECK_CMD}}`
+- [ ] `{{TEST_CMD}}`
+- [ ] `python scripts/lint/run_all.py`
+
+🤖 Per `.claude/rules/sprint-workflow.md` Before-Commit checklist

--- a/templates/claude-workflow-kit/kit/.github/workflows/ci.yml
+++ b/templates/claude-workflow-kit/kit/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+# CI workflow — bootstrapped from claude-workflow-kit.
+#
+# Gate structure (mirror of the source project's proven order):
+#   format-check -> lint -> type-check -> test -> architecture lints
+#
+# IMPORTANT: uncomment the setup/install block that matches {{PRIMARY_LANGUAGE}}.
+# The kit ships both Python and Node variants commented; pick one, delete the other.
+#
+# Branch-protection note: after first green run, add the job name
+# "ci" to the repo's required status checks (Settings -> Branches).
+
+name: CI
+
+on:
+  push:
+    branches: ["{{DEFAULT_BRANCH}}", "feature/**", "fix/**", "refactor/**", "chore/**"]
+  pull_request:
+
+jobs:
+  ci:
+    name: Lint + Type Check + Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # --- Python variant (default) ----------------------------------------
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install (Python)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -r requirements.txt
+
+      # --- Node variant (uncomment, delete Python block above) -------------
+      # - name: Setup Node
+      #   uses: actions/setup-node@v4
+      #   with:
+      #     node-version: "20"
+      #     cache: "npm"
+      # - name: Install (Node)
+      #   run: npm ci
+
+      - name: Format check
+        run: {{FORMAT_CMD}} --check || {{FORMAT_CMD}}
+
+      - name: Lint
+        run: {{LINT_CMD}}
+
+      - name: Type check
+        run: {{TYPECHECK_CMD}}
+
+      - name: Test
+        run: {{TEST_CMD}}
+
+      - name: Architecture lints (project-specific)
+        run: python scripts/lint/run_all.py

--- a/templates/claude-workflow-kit/kit/CLAUDE.md
+++ b/templates/claude-workflow-kit/kit/CLAUDE.md
@@ -1,0 +1,98 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> Bootstrapped from `claude-workflow-kit` on {{DATE}}. Customize sections marked **TODO** before relying on it.
+
+---
+
+## Project Overview
+
+**{{PROJECT_NAME}}** — {{PROJECT_DESC}}
+
+- **Primary language**: {{PRIMARY_LANGUAGE}}
+- **Default branch**: {{DEFAULT_BRANCH}}
+
+### Mission (TODO)
+
+> One paragraph: what does this project deliver, for whom, and what makes it worth building?
+
+### Core Constraints (TODO)
+
+> The non-negotiable design rules for THIS project. Replace these examples with your own.
+> Examples of the *kind* of constraint to write (not literal — adapt to your domain):
+> 1. <e.g. all business tables carry tenant_id>
+> 2. <e.g. no direct vendor SDK imports in the core layer>
+> 3. <e.g. every feature must be reachable from the main API flow>
+
+---
+
+## Development Commands
+
+```bash
+# Format
+{{FORMAT_CMD}}
+
+# Lint
+{{LINT_CMD}}
+
+# Type check
+{{TYPECHECK_CMD}}
+
+# Test
+{{TEST_CMD}}
+
+# Project-specific architecture lints (one-stop wrapper)
+python scripts/lint/run_all.py
+```
+
+---
+
+## Code Standards — Rule Loading (Hybrid)
+
+Rules are split into two tiers to control session context usage:
+
+**🔴 Always-loaded (`.claude/rules/`)** — auto-loaded every session:
+
+| Rule | Scope |
+|------|-------|
+| `sprint-workflow.md` | 5-step sprint flow + Day-0 verify + workload calibration |
+| `file-header-convention.md` | File header + Modification History |
+| `anti-patterns-checklist.md` | PR self-check list |
+
+**📋 On-demand (`docs/rules-on-demand/`)** — Read manually when the trigger applies. Add project-specific rules here (DB conventions, API style, etc.).
+
+See [`.claude/rules/README.md`](.claude/rules/README.md) for the full loading strategy.
+
+---
+
+## CRITICAL: Sprint Execution Workflow
+
+Every sprint MUST follow this order (see `.claude/rules/sprint-workflow.md` for detail):
+
+```
+Plan → Checklist → Day-0 Verify → Code → Update Checklist → Progress Doc
+```
+
+- **Plan / checklist** live in `docs/sprints/sprint-XX-Y-plan.md` + `-checklist.md`
+- **Progress** lives in `docs/sprints/sprint-XX-Y/progress.md`
+- **Change records** (bug/feature/refactor) live in `claudedocs/4-changes/`
+
+---
+
+## Developer Preferences (TODO — adapt)
+
+### Communication
+- **Language**: <your preferred chat language>
+- **Documentation**: code + design docs in English
+- **Confirmation on Destructive Only**: ask before `git push` / `git reset --hard` / `--force` / deleting production code / changing CI/CD / sending external messages. NOT destructive: Write/Edit/Read within aligned scope, Glob, Grep, read-only Bash.
+
+### Code Style
+- **Comments**: English, explain WHY not WHAT
+- **Git Commit**: commit only when a logical unit is complete
+- **Testing**: new features must ship with unit tests
+
+---
+
+**Last Updated**: {{DATE}} (workflow kit bootstrap)
+**Workflow Kit**: based on `claude-workflow-kit` — see `.claude/rules/` for the methodology

--- a/templates/claude-workflow-kit/kit/claudedocs/1-planning/.gitkeep
+++ b/templates/claude-workflow-kit/kit/claudedocs/1-planning/.gitkeep
@@ -1,0 +1,1 @@
+# keep this directory in git

--- a/templates/claude-workflow-kit/kit/claudedocs/4-changes/bug-fixes/.gitkeep
+++ b/templates/claude-workflow-kit/kit/claudedocs/4-changes/bug-fixes/.gitkeep
@@ -1,0 +1,1 @@
+# keep this directory in git

--- a/templates/claude-workflow-kit/kit/claudedocs/4-changes/feature-changes/.gitkeep
+++ b/templates/claude-workflow-kit/kit/claudedocs/4-changes/feature-changes/.gitkeep
@@ -1,0 +1,1 @@
+# keep this directory in git

--- a/templates/claude-workflow-kit/kit/claudedocs/4-changes/refactoring/.gitkeep
+++ b/templates/claude-workflow-kit/kit/claudedocs/4-changes/refactoring/.gitkeep
@@ -1,0 +1,1 @@
+# keep this directory in git

--- a/templates/claude-workflow-kit/kit/claudedocs/README.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/README.md
@@ -1,0 +1,25 @@
+# claudedocs — AI Assistant Execution Docs
+
+Dynamic execution record shared by the AI assistant and developer, separate from `docs/`.
+
+```
+claudedocs/
+├── 1-planning/          # overall planning
+├── 4-changes/           # change records
+│   ├── bug-fixes/       # FIX-XXX-*.md
+│   ├── feature-changes/ # CHANGE-XXX-*.md
+│   └── refactoring/     # REFACTOR-XXX-*.md
+└── templates/           # record templates (copy these)
+```
+
+## Change record conventions
+
+When fixing a bug or changing a feature, create a record using the matching template in `templates/`:
+
+| Type | Directory | Naming |
+|------|-----------|--------|
+| Bug Fix | `4-changes/bug-fixes/` | `FIX-XXX-description.md` |
+| Feature Change | `4-changes/feature-changes/` | `CHANGE-XXX-description.md` |
+| Refactoring | `4-changes/refactoring/` | `REFACTOR-XXX-description.md` |
+
+See `.claude/rules/sprint-workflow.md` §Change Record Conventions.

--- a/templates/claude-workflow-kit/kit/claudedocs/templates/CHANGE-template.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/templates/CHANGE-template.md
@@ -1,0 +1,17 @@
+# CHANGE-XXX: <Description>
+
+**Date**: YYYY-MM-DD
+**Sprint**: XX.Y
+**Scope**: <module / area>
+
+## Motivation
+<!-- Why is this change needed? -->
+
+## What Changed
+<!-- Behavior before vs after. Code location. PR reference. -->
+
+## Verification
+<!-- Tests / manual steps confirming the new behavior. -->
+
+## Impact & Migration
+<!-- Anything callers / data need to adapt to. -->

--- a/templates/claude-workflow-kit/kit/claudedocs/templates/FIX-template.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/templates/FIX-template.md
@@ -1,0 +1,20 @@
+# FIX-XXX: <Description>
+
+**Date**: YYYY-MM-DD
+**Sprint**: XX.Y
+**Scope**: <module / area>
+
+## Problem
+<!-- 2-3 sentences. What was broken? -->
+
+## Root Cause
+<!-- Why did it happen? -->
+
+## Solution
+<!-- What changed. Code location. PR reference. -->
+
+## Verification
+<!-- How was the fix confirmed? Test name / manual steps. -->
+
+## Impact
+<!-- Scope of the fix. -->

--- a/templates/claude-workflow-kit/kit/claudedocs/templates/REFACTOR-template.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/templates/REFACTOR-template.md
@@ -1,0 +1,17 @@
+# REFACTOR-XXX: <Description>
+
+**Date**: YYYY-MM-DD
+**Sprint**: XX.Y
+**Scope**: <module / area>
+
+## Motivation
+<!-- What smell / debt drove this? Behavior must stay unchanged. -->
+
+## What Changed
+<!-- Structure before vs after. Code location. PR reference. -->
+
+## Behavior-Preservation Evidence
+<!-- How do we know behavior is unchanged? (tests pass, same outputs) -->
+
+## Follow-ups
+<!-- Any deferred cleanup or new opportunities surfaced. -->

--- a/templates/claude-workflow-kit/kit/claudedocs/templates/sprint-checklist-template.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/templates/sprint-checklist-template.md
@@ -1,0 +1,31 @@
+# Sprint XX.Y — Checklist
+
+[Link to plan](./sprint-XX-Y-plan.md)
+
+## Day 0 — Verify
+
+### 0.1 Plan-vs-repo Day-0 verify
+- [ ] **Path verify** — every file in §File Change List confirmed exists / not-exists
+  - Verify: glob each path
+- [ ] **Content verify** — every claim about existing code grepped
+- [ ] **Schema verify** (if DB in scope) — columns / migration number confirmed
+- [ ] **Drift findings catalogued** in progress.md (`D1`, `D2`, …)
+
+## Day 1 — <Task Group>
+
+### 1.1 <Task description>
+- [ ] **<Specific deliverable>**
+  - DoD: <measurable definition of done>
+  - Verify: `<command>`
+
+### 1.2 <Task description>
+- [ ] **<Specific deliverable>**
+  - DoD: …
+  - Verify: …
+
+## Day N — Closeout
+
+### N.1 Retrospective
+- [ ] `actual/committed` ratio computed (verify multiplier)
+- [ ] retrospective.md written
+- [ ] Change records (FIX/CHANGE/REFACTOR) created if applicable

--- a/templates/claude-workflow-kit/kit/claudedocs/templates/sprint-plan-template.md
+++ b/templates/claude-workflow-kit/kit/claudedocs/templates/sprint-plan-template.md
@@ -1,0 +1,39 @@
+# Sprint XX.Y — Plan
+
+**Date**: YYYY-MM-DD
+**Status**: Draft
+
+## Sprint Goal
+
+> One sentence — what does this sprint deliver?
+
+## User Stories
+
+- **US-1**: As a <role>, I want <capability>, so that <benefit>.
+- **US-2**: …
+- **US-3**: …
+
+## Technical Specifications
+
+> Design decisions + rationale. Reference prior sprints / docs where relevant.
+
+## File Change List
+
+| File | Action | Note |
+|------|--------|------|
+| `path/to/file` | create / edit | … |
+
+## Acceptance Criteria
+
+- [ ] Measurable, testable criterion 1
+- [ ] Criterion 2
+
+## Workload
+
+> Bottom-up est ~X hr → calibrated commit ~Y hr (multiplier Z, default 0.6)
+
+## Dependencies & Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| … | low/med/high | … |

--- a/templates/claude-workflow-kit/kit/docs/rules-on-demand/README.md
+++ b/templates/claude-workflow-kit/kit/docs/rules-on-demand/README.md
@@ -1,0 +1,18 @@
+# On-Demand Rules
+
+Place situational rules here. They are **not** auto-loaded into the session — the AI must `Read` a file when its trigger applies (see `.claude/rules/README.md`).
+
+## Why here and not under `.claude/`
+
+Claude Code recursively scans the whole `.claude/` tree into project memory every session. Rules placed under `.claude/` are always loaded, which defeats the "on-demand" intent. Keeping them under `docs/rules-on-demand/` keeps them out of the auto-scan until explicitly Read.
+
+## Suggested starters (create as you need them)
+
+| File | Trigger |
+|------|---------|
+| `git-workflow.md` | commit message format / branch naming |
+| `testing.md` | writing tests / coverage planning |
+| `code-quality.md` | fixing lint / type-check errors |
+| `<your-domain>.md` | DB schema, API style, auth, observability, … |
+
+Each rule file should state its **Trigger** at the top so the AI knows when to load it.

--- a/templates/claude-workflow-kit/kit/scripts/lint/_example_detector.py
+++ b/templates/claude-workflow-kit/kit/scripts/lint/_example_detector.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+File: scripts/lint/_example_detector.py
+Purpose: Reference template for writing a project-specific architecture lint.
+Scope: Workflow kit foundation
+
+Description:
+    This is NOT auto-run (leading underscore -> not matched by check_*.py glob).
+    Copy it to `check_<your_rule>.py` and adapt. It demonstrates the detector
+    contract that run_all.py expects:
+      - exit 0 on pass, non-zero on violations
+      - print a final summary line (run_all.py shows the last line)
+
+    The example below enforces AP-U6 (no version-suffix residue) by scanning
+    tracked filenames for `_v1` / `_v2` / `_old` / `_new` / `_legacy`. It is a
+    text-level check; for deeper rules, parse the AST (Python: `ast` module;
+    TS: a tsc-based or regex pass) instead of matching filenames.
+
+Created: {{DATE}}
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# Directories to scan (adjust to your repo layout)
+SCAN_GLOBS = ["src", "backend/src", "frontend/src", "lib"]
+
+BANNED = re.compile(r"_(v\d+|old|new|legacy)\b", re.IGNORECASE)
+
+
+def tracked_files() -> list[str]:
+    """Use git so we only check committed/staged files, not build artifacts."""
+    out = subprocess.run(
+        ["git", "ls-files", *SCAN_GLOBS],
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def main() -> int:
+    violations = [f for f in tracked_files() if BANNED.search(f)]
+    if violations:
+        print("Version-suffix residue found (AP-U6):")
+        for v in violations:
+            print(f"  - {v}")
+        print(f"FAIL: {len(violations)} file(s) with banned version suffix.")
+        return 1
+    print("OK: no version-suffix residue.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/claude-workflow-kit/kit/scripts/lint/run_all.py
+++ b/templates/claude-workflow-kit/kit/scripts/lint/run_all.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+File: scripts/lint/run_all.py
+Purpose: One-stop wrapper that runs every architecture-lint detector and reports
+         an aggregate pass/fail so CI and pre-commit have a single entry point.
+Scope: Workflow kit foundation
+
+Description:
+    Discovers sibling `check_*.py` detector scripts, runs each as a subprocess,
+    and aggregates results. Exit 0 = all green; non-zero = "<failed>/<total>"
+    with a per-script line summary. Add detectors by dropping a new `check_*.py`
+    next to this file (see `_example_detector.py` for the pattern).
+
+Created: {{DATE}}
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+LINT_DIR = Path(__file__).resolve().parent
+
+
+def discover_detectors() -> list[Path]:
+    """Every check_*.py sibling is a detector. Order is stable (sorted)."""
+    return sorted(p for p in LINT_DIR.glob("check_*.py") if p.is_file())
+
+
+def run_detector(script: Path) -> tuple[bool, str]:
+    """Run one detector; return (passed, last_output_line)."""
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        capture_output=True,
+        text=True,
+    )
+    output = (proc.stdout + proc.stderr).strip()
+    last_line = output.splitlines()[-1] if output else "(no output)"
+    return proc.returncode == 0, last_line
+
+
+def main() -> int:
+    detectors = discover_detectors()
+    if not detectors:
+        print("No detectors found (add check_*.py next to run_all.py). OK.")
+        return 0
+
+    failed = 0
+    for script in detectors:
+        passed, summary = run_detector(script)
+        mark = "OK " if passed else "FAIL"
+        print(f"  [{mark}] {script.name}: {summary}")
+        if not passed:
+            failed += 1
+
+    total = len(detectors)
+    if failed:
+        print(f"\n{failed}/{total} architecture lints FAILED.")
+        return 1
+    print(f"\nAll {total} architecture lints passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a self-contained, transferable starter kit under `templates/claude-workflow-kit/` that extracts this project's **methodology layer** so the sprint workflow + CI gate + rule-loading + change-record discipline can be bootstrapped into any new project.

## What's included (`kit/`, injected into a target repo)

- `.claude/rules/` — generic `sprint-workflow.md` (5-step flow, Day-0 verify, 0.6 calibration default), `file-header-convention.md`, `anti-patterns-checklist.md` (6 universal + project-specific slot), `README.md` (Hybrid loading strategy)
- `.github/` — parameterized PR template + CI gate workflow
- `scripts/lint/` — `run_all.py` one-stop lint wrapper + `_example_detector.py` reference detector
- `claudedocs/` — change-record skeleton + 5 templates (plan / checklist / FIX / CHANGE / REFACTOR)
- `CLAUDE.md` (parameterized) + `.claude/settings.json` (SessionStart hook)

Plus `init-workflow.ps1` (token-replacement bootstrap, non-destructive) and `TEMPLATE-GUIDE.md` (two-layer model + customization steps).

## Deliberately excluded (project-specific content layer)

11+1 categories, LLM provider neutrality, multi-tenant rules, calibration history, domain lint detectors — new projects start from a clean methodology baseline and re-accumulate their own.

## Notes

- Docs/tooling only; no product code touched. Lives at repo root `templates/`, outside `backend/` and `frontend/`, so existing CI scope is unaffected.
- `init-workflow.ps1` parse-verified (PowerShell 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
