### PR TITLE
fix(ci): repair e2e-real-llm-smoke gate — JWT auth + loop_end event (FIX-023)

### DIFF
--- a/.github/workflows/e2e-real-llm-smoke.yml
+++ b/.github/workflows/e2e-real-llm-smoke.yml
@@ -11,9 +11,15 @@
 #   This workflow closes that gap: spins up Postgres + Redis + V2 backend,
 #   posts a single real-LLM chat request via api.main:app, and verifies:
 #     - HTTP 200 (NOT 503)
-#     - SSE stream contains `loop_completed` event
+#     - SSE stream contains `loop_end` event (LoopCompleted; sse.py:199)
 #     - cost_ledger row count delta ≥ 2 (input + output split per 57.2)
 #     - audit_log row count delta ≥ 1 (Sprint 57.6 Day 2 wiring)
+#
+#   Auth: the chat endpoint is NOT in TenantContextMiddleware's exempt list,
+#   so it requires a V2 JWT (the X-Tenant-Id header path was removed in Sprint
+#   52.5 Day 6.1). We mint one via POST /api/v1/auth/dev-login (exempt route,
+#   dev-only, settings.env defaults to "development"), which auto-creates a
+#   dev Tenant + User and sets the v2_jwt cookie the middleware reads.
 #
 # Triggers:
 #   - workflow_dispatch (manual only — always available)
@@ -29,6 +35,12 @@
 #   (negligible vs Phase 56-58 SaaS Stage 1 production budget).
 #
 # Modification History:
+#   - 2026-06-01: Fix two latent bugs (gate never ran green — Azure secrets
+#     unprovisioned — so both sat undetected): (1) auth — replace removed
+#     X-Tenant-Id header path with /auth/dev-login v2_jwt cookie (chat endpoint
+#     requires JWT since 52.5 Day 6.1) + drop broken inline seed (wrong session
+#     sig + wrong Tenant columns); (2) SSE assertion `loop_completed` →
+#     `loop_end` (the real serialized event name, sse.py:199).
 #   - 2026-05-08: Sprint 57.6 US-5 — initial creation (closes AD-Reality-5)
 #
 # Related:
@@ -111,6 +123,8 @@ jobs:
           DB_PORT=5432
           REDIS_HOST=localhost
           REDIS_PORT=6379
+          ENV=development
+          COOKIE_SECURE=false
           AZURE_OPENAI_ENDPOINT=${{ secrets.AZURE_OPENAI_ENDPOINT }}
           AZURE_OPENAI_API_KEY=${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_DEPLOYMENT_NAME=${{ secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
@@ -121,26 +135,6 @@ jobs:
       - name: Run Alembic migrations
         working-directory: backend
         run: alembic upgrade head
-
-      - name: Seed default tenant + admin user (smoke setup)
-        working-directory: backend
-        run: |
-          python -c "
-          import asyncio
-          from infrastructure.db.session import get_db_session_with_tenant
-          from infrastructure.db.models.identity import Tenant, User
-          import uuid
-          async def seed():
-              async with get_db_session_with_tenant(tenant_id=None) as db:
-                  t = Tenant(id=uuid.uuid4(), name='smoke-tenant', state='active', plan='enterprise')
-                  db.add(t)
-                  await db.flush()
-                  u = User(id=uuid.uuid4(), tenant_id=t.id, email='smoke@example.com')
-                  db.add(u)
-                  await db.commit()
-                  print(f'TENANT_ID={t.id}')
-          asyncio.run(seed())
-          "
 
       - name: Start backend
         working-directory: backend
@@ -153,9 +147,24 @@ jobs:
             sleep 1
           done
 
+      - name: Authenticate (dev-login → v2_jwt cookie)
+        working-directory: backend
+        run: |
+          # dev-login auto-creates a dev Tenant + User and returns the v2_jwt
+          # cookie the chat endpoint requires (X-Tenant-Id header path removed
+          # in Sprint 52.5 Day 6.1). settings.env=development so the route is
+          # live (404 only in prod). Cookie saved to /tmp/cookies.txt.
+          set -eo pipefail
+          curl -sf -X POST -c /tmp/cookies.txt \
+            "http://localhost:8000/api/v1/auth/dev-login?tenant_code=smoke&email=smoke@example.com" \
+            -o /tmp/devlogin.json
+          grep -q "v2_jwt" /tmp/cookies.txt || (echo "FAIL: dev-login did not set v2_jwt cookie" && cat /tmp/devlogin.json && exit 1)
+
       - name: Capture pre-chat row counts
         working-directory: backend
         run: |
+          # Captured AFTER dev-login so any rows it writes are in the baseline;
+          # the delta then reflects only the chat request below.
           PRE_AUDIT=$(PGPASSWORD=ipa psql -h localhost -U ipa -d ipa_v2_test -tAc "SELECT count(*) FROM audit_log;")
           PRE_COST=$(PGPASSWORD=ipa psql -h localhost -U ipa -d ipa_v2_test -tAc "SELECT count(*) FROM cost_ledger;")
           echo "PRE_AUDIT=$PRE_AUDIT" >> $GITHUB_ENV
@@ -164,13 +173,14 @@ jobs:
       - name: POST /api/v1/chat (real_llm mode, single message, max_tokens guard)
         run: |
           set -eo pipefail
-          curl -sf -N \
+          curl -sf -N -b /tmp/cookies.txt \
             -H "Content-Type: application/json" \
-            -H "X-Tenant-Id: ${{ env.TENANT_ID }}" \
             -d '{"mode":"real_llm","message":"Say hello in 5 words"}' \
             http://localhost:8000/api/v1/chat/ | tee /tmp/sse.log
-          # Verify SSE stream contains loop_completed frame.
-          grep -q "event: loop_completed" /tmp/sse.log || (echo "MISSING loop_completed event" && exit 1)
+          # Verify SSE stream contains the loop-completion frame. The serializer
+          # maps LoopCompleted → `event: loop_end` (sse.py:199), NOT
+          # "loop_completed" — the original assertion would never match.
+          grep -q "event: loop_end" /tmp/sse.log || (echo "MISSING loop_end event" && exit 1)
 
       - name: Capture post-chat row counts + verify deltas
         working-directory: backend

--- a/claudedocs/4-changes/bug-fixes/FIX-023-e2e-real-llm-smoke-jwt-auth.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-023-e2e-real-llm-smoke-jwt-auth.md
@@ -1,0 +1,90 @@
+# FIX-023: e2e-real-llm-smoke.yml two latent bugs (JWT auth + SSE event name)
+
+**Date**: 2026-06-01
+**Sprint**: C-11 (integration-gap follow-up; non-sprint chore)
+**Severity**: Medium (latent — gate never ran green so neither surfaced)
+**Scope**: CI / E2E real-LLM verification
+**Status**: ✅ Fixed + fully proven live (all 5 gate assertions pass against a real Azure call)
+
+## Problem
+
+`.github/workflows/e2e-real-llm-smoke.yml` (Sprint 57.6, the canonical real-LLM
+e2e gate) authenticates its chat POST with only `-H "X-Tenant-Id: <id>"` and no
+JWT. The chat endpoint `/api/v1/chat/` is NOT in `TenantContextMiddleware`'s
+`EXEMPT_PATH_PREFIXES`, and that middleware **dropped X-Tenant-Id support** in
+Sprint 52.5 Day 6.1 (now requires a V2 JWT via Bearer header or `v2_jwt` cookie,
+because header-sourced tenant_id is trivially spoofable). So the request would
+`401` at the middleware **before reaching the LLM** — the gate could never pass.
+
+Secondary: the inline "Seed default tenant + admin user" step called
+`get_db_session_with_tenant(tenant_id=None)` (not its real signature) and
+`Tenant(name=, state=, plan=)` (not its real columns) — it would also crash.
+
+**Bug #2 (SSE event name)**: the stream-content assertion was
+`grep -q "event: loop_completed"`, but the serializer maps `LoopCompleted` →
+`event: loop_end` (`sse.py:199`; documented `sse.py:21`). There is no
+`loop_completed` event — the assertion would fail even with auth fixed and a
+successful LLM call. Confirmed locally: an echo_demo stream emits
+`loop_start … llm_response … loop_end` (no `loop_completed`).
+
+## Root Cause
+
+The workflow was authored Sprint 57.6 (2026-05-08) but **never ran green**: it
+requires `AZURE_OPENAI_*` GitHub Secrets that were never provisioned (AD-CI-6),
+and the `schedule` trigger is commented out. With no green run, the auth drift
+(introduced 52.5 Day 6.1, predating the workflow) and the broken seed step sat
+undetected. Discovered during C-11 analysis when attempting to actually run it.
+
+## Solution
+
+Replace the removed header-auth + broken seed with the real dev auth route:
+
+1. **New "Authenticate (dev-login → v2_jwt cookie)" step**: `POST
+   /api/v1/auth/dev-login?tenant_code=smoke&email=smoke@example.com` (an EXEMPT
+   route, dev-only, `settings.env` defaults to `"development"` so it's live in
+   CI). It auto-creates a dev Tenant + User and sets the `v2_jwt` cookie the
+   middleware reads. Cookie saved to `/tmp/cookies.txt`.
+2. **Removed the broken inline seed step** (dev-login does the create).
+3. **Chat POST**: `-H "X-Tenant-Id: ..."` → `-b /tmp/cookies.txt` (send cookie).
+4. **`.env`**: added `ENV=development` + `COOKIE_SECURE=false` so dev-login is
+   live and sets a non-Secure cookie over plain HTTP in CI.
+5. **Pre-chat row-count capture moved AFTER dev-login** so any rows dev-login
+   writes are in the baseline; the delta then reflects only the chat request.
+
+RLS note: `cost_ledger` (migration 0016) and `audit_log` use `ENABLE` (not
+`FORCE`) ROW LEVEL SECURITY, so the workflow's `psql` `count(*)` (connecting as
+table-owner `ipa`) bypasses RLS — the delta assertions remain valid.
+
+## Verification
+
+Proven LIVE on 2026-06-01 — a fresh backend started from the current tree
+(repo-root `.env` with real Azure key) on port 8001, exercising the exact
+workflow sequence (dev-login cookie → real_llm chat → DB delta), short-lived,
+then killed (the long-running :8000 dev backend was untouched):
+
+- YAML parses (`yaml.safe_load` → OK); step order Authenticate → pre-count → chat → post-count
+- dev-login → `v2_jwt` cookie set (200); echo_demo chat with cookie → 200 (passes the 401 middleware) — **auth fix proven**
+- SSE event names observed: `loop_start … llm_response … loop_end` (no `loop_completed`) — **event-name fix proven**
+- **real_llm call → HTTP 200** (NOT 503); real Azure reply "Hello there, nice to meet you."
+- **SSE contains `loop_end`** ✓
+- **cost_ledger delta = 2** (≥2 ✓) — input+output split, written because the fresh backend wired the FIX-022 PricingLoader at startup (log: "pricing loader wired … llm_pricing.yml")
+- **audit_log delta = 1** (≥1 ✓)
+- Cost: ~$0.005 (two `Say hello in 5 words` calls, max_tokens guard)
+
+Note: the long-running dev backend on :8000 (3-day uptime, started **before**
+FIX-022) showed `cost_ledger=0` — confirming the cost-ledger write depends on
+`_wire_pricing_loader()` at startup (`main.py:165`). The CI workflow always
+starts a fresh backend, so it wires the loader; this was process staleness on
+the dev box, not a workflow flaw.
+
+CI: a real `workflow_dispatch` run still needs `AZURE_OPENAI_*` GitHub Secrets
+(AD-CI-6). This fix makes the gate *correct + locally-proven*, not
+*runnable-without-secrets*.
+
+## Impact
+
+CI-only (single workflow file). No backend/app code changed. Makes the canonical
+real-LLM e2e gate actually pass once Azure secrets are provisioned. Does not by
+itself enable the gate (secrets + uncommenting `schedule` still pending per
+AD-CI-6). Corrects C-11 analysis claim "gate already built" → "gate built but had
+latent auth drift, now fixed".


### PR DESCRIPTION
## 摘要

修復 canonical real-LLM e2e gate（`e2e-real-llm-smoke.yml`）的 **2 個潛伏 bug**。嘗試實際執行 C-11 時發現 —— gate 自 Sprint 57.6 建立後從未綠過（`AZURE_OPENAI_*` secrets 未 provision），所以兩個 bug 一直沒被偵測到。

## 修的 2 個 bug

| # | Bug | 修法 |
|---|-----|------|
| 1 | **Auth drift** — chat 端點自 Sprint 52.5 Day 6.1 起需要 V2 JWT，但 workflow 只送已移除的 `X-Tenant-Id` header → 會 401 進不了 LLM | 改用 `POST /api/v1/auth/dev-login` 取 `v2_jwt` cookie（exempt route, dev-only）+ 移除壞掉的 inline seed step（錯的 session signature + 錯的 Tenant 欄位）|
| 2 | **SSE 事件名錯** — assert `grep "event: loop_completed"`，但序列化器發的是 `loop_end`（`sse.py:199`）→ 永遠 fail | 改 assert `loop_end` |

## 已在本機用真 Azure call 全程驗證（all 5 gate assertions ✅）

從現行 tree 在 :8001 起一個 fresh backend（會 wire FIX-022 PricingLoader），跑 workflow 完整序列，短命後殺掉（不碰長跑的 :8000 dev backend）：

- HTTP **200**（非 503）+ 真 Azure 回覆「Hello there, nice to meet you.」
- SSE 含 **`loop_end`** ✓
- dev-login cookie 過 401 middleware（echo_demo + real_llm 都 200）✓
- **cost_ledger delta = 2**（input+output split）✓
- **audit_log delta = 1** ✓
- 成本 ~$0.005（max_tokens=100 guard）

附帶 root-cause：stale :8000 backend（3 天前啟動、早於 FIX-022）`cost_ledger=0`；fresh backend 啟動 wire 了 PricingLoader → 正常寫 2 row。證明是進程老舊，非 workflow 缺陷。

## ⚠️ 此 PR 不會自動啟用 CI（刻意）

依使用者決定 **Azure key 不上傳 GitHub** —— 改採本機跑驗證。所以 merge 此 PR 後：

- gate 的**正確版本**進 main，取代現有壞版；
- 但 CI 不會自動跑它（`AZURE_OPENAI_*` secrets 未設 + `schedule` 仍註解）。任何 `workflow_dispatch` 手動跑仍需 secrets。

即此 PR 的價值是「把修好、本機已驗證的 gate 存進 main」，不是「啟用 CI 自動驗證」。C-11 核心（證 Cat 8 在 live SSE 路徑真發生）已於本機達成。

## 變更範圍

- `.github/workflows/e2e-real-llm-smoke.yml`（CI-only；無 backend/app code 變更）
- `claudedocs/4-changes/bug-fixes/FIX-023-*.md`（FIX 記錄）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
