### PR TITLE
docs(c11): real-LLM smoke execution result + corrected root-cause + 2 billing gaps

### DIFF
--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -36,6 +36,18 @@
 
 ---
 
+## 🆕 C-11 Real-LLM Execution Findings (2026-06-03 — 本機 smoke 實跑；real-LLM 閉環 LIVE，cost-ledger leg 開放)
+
+C-11 本機 real-LLM smoke 已實跑（用既有 `.env` Azure 憑證、零 GitHub secret、零 code change；詳 `claudedocs/5-status/c11-real-llm-e2e-analysis-20260601.md §8`）。**real-LLM 閉環 = LIVE + 已驗證**（HTTP 200 / `loop_end` / 真實 gpt-4o 回覆 / `audit_log` Δ=1）。`cost_ledger` Δ=0；root-cause 深查**推翻**初判的 streaming code bug（loop 用非串流 `chat()`、adapter usage 實測正常 prompt=12/comp=9、`record_llm_call` 缺 pricing 仍寫 0 成本行、yaml 載入 OK、FIX-022 已 wire）。3 衍生 AD：
+
+1. **`AD-RealLLM-CostLedger-ProcessState-Verify`**（待驗，非 code）— 「完全沒 cost 行」最可能是運行中 backend 進程（PID 28832，起 06-01 16:30）啟動時 pricing loader 沒裝成（cost_ledger=None → `router.py:435` gate 跳過）。確認法：重啟 backend（current code）+ 看啟動 log `main.py:149/151` 的 pricing-loader 行 + 重跑 smoke。若 Δ≥2 → 進程狀態非 bug；若 Δ=0 → 真 bug。~15 min。
+2. **`AD-Cost-Ledger-Model-Pricing-Key-Mismatch`**（確認真實缺口）— deployment=`gpt-5.2` / config `model_name`=`gpt-4o` / `config/llm_pricing.yml` 僅 `gpt-4o-mini` → `get_llm_pricing` None → cost 行 `total_cost_usd=0`（`cost_ledger.py:138-144`「observable anomaly」）。修法：對齊 `model_name`↔真實 deployment + 補 pricing yaml 真實模型條目（gpt-4o / gpt-5.2）。屬 billing 正確性束（B-7/B-8/C-15）。~1-2 hr。
+3. **`AD-Adapter-MaxTokens-NewModel-Param`**（確認真實缺口）— gpt-5.2-class deployment 拒 `max_tokens`（回 400「use `max_completion_tokens`」）；loop 主流量未傳故不撞，但 `e2e-real-llm-smoke.yml` 成本護欄（`MAX_TOKENS_PER_CALL`/`max_tokens` `:132`）+ adapter `chat()`/`_stream_impl:282` 需依 model/api-version 切換 param 名。~1-2 hr。
+
+> CI gate（`e2e-real-llm-smoke.yml`）維持手動/關閉（用戶 policy：secret 不進 GitHub）；本機路徑為實際驗收途徑。
+
+---
+
 ## 🆕 Sprint 57.62 Carryover (2026-05-29 — RateLimits Alerting; durable 80%-threshold alert log captured even when unwatched; Phase 58.x RateLimits arc + alert)
 
 Sprint 57.62 (sequential 2-agent — `rl-alerts-backend` 28th + `rl-alerts-frontend` 29th consecutive; durable 80%-threshold usage alerting closing `AD-RateLimits-Alerting-Phase58`) ✅ **CLOSED**: 2 ADs closed (`AD-RateLimits-Alerting-Phase58` + `AD-AgentDelegate-DevStack-Precheck` applied Day 0) + 8 carryovers (5 NEW + 3 continuing). No PROMOTION reaches codify threshold.

--- a/claudedocs/5-status/c11-real-llm-e2e-analysis-20260601.md
+++ b/claudedocs/5-status/c11-real-llm-e2e-analysis-20260601.md
@@ -7,6 +7,7 @@
 **Status**: Active(analysis;對應 `AD-Cat4-7-8-10-RealLLM-E2E` deferred)
 
 **Modification History (newest-first)**:
+- 2026-06-03: §8 added — 本機 real-LLM smoke 實跑（real-LLM 閉環 LIVE + 已驗證；cost_ledger Δ=0 待釐清）+ root-cause 深查推翻初判 streaming bug + 2 確認 billing 缺口（model/pricing-key 不匹配 $0 成本 + max_tokens 不相容 gpt-5.2）+ 3 衍生 AD。零 code、未重啟。
 - 2026-06-01: Initial creation — C-11 real-LLM e2e(Workflow 並行蒐證 + 主 session 親驗 e2e-real-llm-smoke.yml 全檔)
 
 **Related**:
@@ -104,3 +105,57 @@ Workflow 兩個 agent 各漏一半,我親驗後拼出完整圖:
 | 對應 AD? | `AD-Cat4-7-8-10-RealLLM-E2E`(deferred);啟用即可 close |
 
 > 不需 code。建議:用戶提供 Azure key → 設 3 個 GitHub Secrets → 手動 Run "E2E Real-LLM Smoke" → 綠了即 close AD + 解鎖 A/B 驗收。
+
+---
+
+## 8. 執行結果（2026-06-03 本機 real-LLM smoke + root-cause 深查）
+
+> **方法校正**：用戶 policy「secret 不進 GitHub」→ 不走 CI gate（§4 路徑 A），改走**本機路徑**（§4 末行）。本機 `.env` 4 個 `AZURE_OPENAI_*` 全已 set（確認）→ 直接在本機重現 workflow 的 smoke：reuse 既有 running backend（PID 28832，起於 2026-06-01 16:30）→ `POST /auth/dev-login` 取 v2_jwt → `POST /api/v1/chat/` `{mode:real_llm}` → 驗 SSE + DB delta。**全程零 GitHub secret、零 code change**。
+
+### 8.1 Smoke 結果（5 條驗收，3.5 過 / 1 未過）
+
+| 驗收 | 結果 | 證據 |
+|------|------|------|
+| HTTP 200（非 503）| ✅ | real_llm handler 通；Azure 憑證有效 |
+| `event: loop_end` | ✅ | SSE 含 loop_end frame |
+| 真實 LLM 回覆（非 mock）| ✅ | gpt-4o（label）回 `"Hello there, nice to meet you."` |
+| `audit_log` Δ≥1 | ✅ | Δ=1（1166→1167）|
+| **`cost_ledger` Δ≥2** | ❌ | **Δ=0**（2→2，完全沒寫行）|
+
+### 8.2 Root-cause 深查 —— 推翻初判「明確 streaming code bug」
+
+初判（adapter 串流缺 `stream_options.include_usage`）經逐項實證**全部推翻**：
+
+| 假設 | 結果 | 證據（file:line / 實測）|
+|------|------|------|
+| 串流缺 include_usage | ❌ 不成立 | loop 用**非串流** `chat()`（`loop.py:1032`），不是 `stream()` |
+| `response.usage` 沒帶回（tokens=0）| ❌ 不成立 | 直接實測 `AzureOpenAIAdapter.chat()` → `TokenUsage(prompt=12, completion=9, total=21)`（usage 捕捉正常）|
+| `record_llm_call` 因缺 pricing 跳過 | ❌ 不成立 | pricing=None 時走 **zero-cost 分支仍寫 2 行**（`cost_ledger.py:138-184`）|
+| pricing yaml 壞掉觸發 fail-soft | ❌ 不成立 | `PricingLoader().load_from_yaml('config/llm_pricing.yml')` 實測**載入 OK** |
+| pricing loader 沒 wire | ❌ code 已修 | FIX-022 在 lifespan `main.py:167` 呼叫 `_wire_pricing_loader()`；進程起於 06-01（FIX-022 2026-05-31 已在 disk）|
+
+**結論**：real-LLM 關鍵 code 路徑**看來正確**。`cost_ledger Δ=0`（完全沒行）最可能是**正在跑的 backend 進程（PID 28832）在它自身啟動時 pricing loader 沒裝成**（cost_ledger_service 為 None → `router.py:435` gate `cost_ledger is not None` False → 整段跳過）。屬 **process-state，非 code bug**。**唯一確認法**：重啟 backend（current code）+ 看啟動 log「pricing loader wired/not wired」（`main.py:149/151`）+ 重跑 smoke。**本次依用戶指示未重啟、未改 code** → 列為待驗。
+
+### 8.3 但 C-11 揪出 2 個確認的真實 billing 缺口（與 8.2 無關，重啟也不消失）
+
+1. **Model / pricing-key 三方不匹配** → cost 行（即使有寫）為 **$0 成本**：
+   - deployment 實際 = `gpt-5.2`（`AzureOpenAIConfig.deployment_name`）
+   - config `model_name` = `gpt-4o`（→ `ChatResponse.model` → `LoopCompleted.model` → `record_llm_call(model="gpt-4o")`）
+   - `config/llm_pricing.yml` 只有 `azure_openai/gpt-4o-mini`（**無 gpt-4o、無 gpt-5.2**）
+   - → `get_llm_pricing("azure_openai","gpt-4o")` = None → `record_llm_call` zero-cost 分支 → cost 行 `total_cost_usd=0`（`cost_ledger.py:138-144`；程式註解自稱「observable anomaly」）。`router.py:128` 註解本身已點出此 model-vs-pricing-key 落差。
+
+2. **`max_tokens` 與 gpt-5.2-class deployment 不相容**：直接傳 `max_tokens` → Azure 回 **400「'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead」**。loop 主流量未傳 `max_tokens`（`loop.py:1028`）故主路徑不撞；但 **e2e-real-llm-smoke.yml 的成本護欄靠 `MAX_TOKENS_PER_CALL`/`max_tokens`**（`:132`）→ 在此 deployment 會 400。adapter `_stream_impl:282` + `chat()` 都用 `max_tokens` kwarg。
+
+### 8.4 C-11 狀態更新
+
+- **real-LLM 閉環 = LIVE + 已驗證**：HTTP 200 / loop_end / 真實回覆 / audit_log Δ=1。Azure 路徑真實可用（不再「全程 mock」）。
+- **cost-ledger leg 未綠**：受 8.2（待重啟驗）+ 8.3（確認缺口）影響。e2e gate 的 `cost_ledger Δ≥2` 在此環境不會過，直到 8.2 釐清 + 8.3 修正。
+- **CI gate（`e2e-real-llm-smoke.yml`）維持手動/關閉**（用戶 policy：secret 不進 GitHub）；本機路徑為實際驗收途徑。
+
+### 8.5 衍生 AD（記入 `claudedocs/1-planning/next-phase-candidates.md`）
+
+- `AD-RealLLM-CostLedger-ProcessState-Verify`（待驗）— 重啟 backend + 捕捉啟動 pricing-loader log + 重跑 smoke，判定「沒 cost 行」是進程狀態 vs code bug。
+- `AD-Cost-Ledger-Model-Pricing-Key-Mismatch`（確認）— model_name=gpt-4o / deployment=gpt-5.2 / pricing 僅 gpt-4o-mini → cost 行 $0。修法選項：對齊 `model_name` 至真實 deployment 模型 + 補 pricing yaml 真實模型條目（gpt-4o / gpt-5.2）；或讓 `model_name` 反映 deployment。屬 billing 正確性束（B-7/B-8/C-15）。
+- `AD-Adapter-MaxTokens-NewModel-Param`（確認）— gpt-5.2-class deployment 需 `max_completion_tokens`；adapter `chat()`/`_stream_impl` 與 e2e workflow 成本護欄需相容處理（依 model / api-version 切換 param 名）。
+
+> **Verified ratio**：8.1-8.3 每條 claim 對應 file:line 或本機實測指令輸出；8.2 為「推翻初判」的反證集；8.4 狀態為實測導出。本次純文件，無 code change、無重啟。


### PR DESCRIPTION
## C-11 Real-LLM Execution Findings (docs-only)

Ran the **C-11 local real-LLM smoke** (existing local `.env` Azure creds, zero GitHub secret, zero code change, per the user's no-secrets-in-GitHub policy).

### Result
- ✅ **real-LLM closed loop is LIVE + verified** — `POST /api/v1/chat/` `{mode:real_llm}` → HTTP 200 / `event: loop_end` / real gpt-4o reply (`"Hello there, nice to meet you."`) / `audit_log` Δ=1. The A-area wiring is no longer "mock-only".
- ⚠️ `cost_ledger` Δ=0 — deep root-cause **refuted** the initial streaming-bug guess:
  - loop uses **non-streaming** `chat()` (`loop.py:1032`), not `stream()`
  - real `AzureOpenAIAdapter.chat()` **does** return usage (`prompt=12/comp=9/total=21`)
  - `record_llm_call` writes 2 zero-cost rows even when pricing is None (`cost_ledger.py:138-184`)
  - `config/llm_pricing.yml` loads cleanly; FIX-022 wires the loader in lifespan (`main.py:167`)
  - → most likely the **running backend process didn't install the pricing loader at its startup** (process-state, to verify by restart), **NOT a confirmed code bug**.

### 2 confirmed billing gaps (independent of the above)
1. **Model / pricing-key mismatch** → cost rows at **\$0**: deployment `gpt-5.2` / config `model_name` `gpt-4o` / pricing yaml only `gpt-4o-mini` → `get_llm_pricing` None → zero-cost branch.
2. **`max_tokens` incompatible** with the gpt-5.2-class deployment (400 "use `max_completion_tokens`"); main loop doesn't pass it, but the e2e workflow cost-guard does.

### Docs changed
- `claudedocs/5-status/c11-real-llm-e2e-analysis-20260601.md` — §8 execution result + root-cause + gaps + status + 3 ADs
- `claudedocs/1-planning/next-phase-candidates.md` — C-11 findings + 3 ADs (`RealLLM-CostLedger-ProcessState-Verify`, `Cost-Ledger-Model-Pricing-Key-Mismatch`, `Adapter-MaxTokens-NewModel-Param`)

**No code change. Backend not restarted.** Cheapest next step: `AD-RealLLM-CostLedger-ProcessState-Verify` (restart backend + re-run smoke, ~15 min) to settle whether "no cost rows" is process-state vs a real bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)