### PR TITLE
fix(sprint-57-80): chat real_llm orphan-tool-message — PromptBuilder tool-call adjacency invariant + pending-tool-turn re-anchor (closes AD-Chat-RealLLM-Orphan-Tool-Message)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Build enterprise AI agent teams that work like **human professional teams** — 
 | Attribute | Value |
 |-----------|-------|
 | **Phase** | V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend ongoing (Phase 57+) |
-| **Current Sprint** | Sprint 57.79 (PR pending) — **C-11 billing-correctness** (closes `AD-Cost-Ledger-Model-Pricing-Key-Mismatch` + `AD-Adapter-MaxTokens-NewModel-Param`): pricing date-suffix normalize (`gpt-5.2-2025-12-11` → base `gpt-5.2`) + gpt-5.x `max_completion_tokens` adapter param. First post-Area-A sprint (user picked C-11 收尾 over carryover/B). Real Azure verified: cost_ledger `unit_cost>0` (vs existing $0 rows) + token-cap no 400; deployment requirement `AZURE_OPENAI_MODEL_NAME=gpt-5.2`. backend mypy 0/331 + pytest 2121 + run_all 10/10; backend-only, no design note. Detail: `memory/project_phase57_79_c11_billing_correctness.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
+| **Current Sprint** | Sprint 57.80 (PR pending) — **chat real_llm orphan-tool-message fix** (closes `AD-Chat-RealLLM-Orphan-Tool-Message`, the 57.79 carryover): builder-level tool-call adjacency invariant (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B) + pending-tool-turn user re-anchor suppression (in-sprint fix C). `LostInMiddleStrategy` orphaned tool results → real_llm 400; fix unblocks the real_llm main flow. Real Azure verified: 200 + `stop_reason=end_turn` (was max_turns) + cost_ledger written. backend mypy 0/331 + pytest 2130 + run_all 10/10; backend-only Cat 5, no design note. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
 | **Sprint History** | See [`memory/MEMORY.md`](memory/MEMORY.md) §Recent Sprints + per-sprint subfile `memory/project_phase57_XX_*.md` + retrospective.md under `docs/03-implementation/agent-harness-execution/phase-57/sprint-57-XX/` |
 | **Pending / Next Phase** | See [`claudedocs/1-planning/next-phase-candidates.md`](claudedocs/1-planning/next-phase-candidates.md) |
 | **Roadmap** | Phase 49-55 V2 ✅ / Phase 56-58 SaaS Stage 1 3/3 ✅ / Phase 57+ Frontend ongoing |
@@ -586,7 +586,7 @@ V1 完整 CLAUDE.md 已保留於 `CLAUDE.backup.md`。如需查閱 V1 架構（M
 
 ---
 
-**Last Updated**: 2026-06-04 (Sprint 57.79 — C-11 billing-correctness: pricing date-suffix normalize + gpt-5.x max_completion_tokens, closes AD-Cost-Ledger-Model-Pricing-Key-Mismatch + AD-Adapter-MaxTokens-NewModel-Param; real Azure verified cost_ledger unit_cost>0 + token-cap no 400; deployment req AZURE_OPENAI_MODEL_NAME=gpt-5.2; backend-only mypy 0/331 + pytest 2121 + run_all 10/10; CHANGE-047; PR pending); see `memory/` for sprint history
+**Last Updated**: 2026-06-04 (Sprint 57.80 — chat real_llm orphan-tool-message fix: builder-level tool-call adjacency invariant + pending-tool-turn user re-anchor suppression, closes AD-Chat-RealLLM-Orphan-Tool-Message; real Azure verified 200 + stop_reason=end_turn; backend-only Cat 5 mypy 0/331 + pytest 2130 + run_all 10/10; FIX-027; PR pending); see `memory/` for sprint history
 **Project Start**: 2025-11-14
 **V2 Authority**: `docs/03-implementation/agent-harness-planning/` (21 docs — 20 規劃 + 1 review)
 **V1 Reference**: `CLAUDE.backup.md` + `docs/07-analysis/V9/00-index.md`

--- a/backend/src/agent_harness/prompt_builder/builder.py
+++ b/backend/src/agent_harness/prompt_builder/builder.py
@@ -36,9 +36,10 @@ Description:
 Owner: 01-eleven-categories-spec.md §範疇 5
 
 Created: 2026-05-01 (Sprint 52.2 Day 1.6)
-Last Modified: 2026-06-03
+Last Modified: 2026-06-04
 
 Modification History (newest-first):
+    - 2026-06-04: Sprint 57.80 — tool-call adjacency invariant after arrange() (orphan-tool 400)
     - 2026-06-03: Sprint 57.75 A-5c — add layer_metadata["memory_accesses"] per-hint detail
     - 2026-06-01: Sprint 57.65 — memory render enrich + token cap + verify_before_use (A-1)
 
@@ -267,6 +268,14 @@ class DefaultPromptBuilder(PromptBuilder):
                 position_strategy if position_strategy is not None else self._default_strategy
             )
             messages = strategy.arrange(sections)
+            # Sprint 57.80: enforce the provider hard-constraint that every
+            # role='tool' message immediately follows its owning assistant
+            # tool_calls. A PositionStrategy (e.g. LostInMiddleStrategy) may
+            # reorder the conversation and split a tool result from its
+            # assistant; this single post-arrange pass re-anchors them so NO
+            # strategy can emit an orphan-tool sequence. Closes the real_llm
+            # chat 400 (AD-Chat-RealLLM-Orphan-Tool-Message).
+            messages = self._enforce_tool_adjacency(messages)
 
             # --- Step 3: cache breakpoints ---
             cache_breakpoints = await self._build_cache_breakpoints(
@@ -321,6 +330,70 @@ class DefaultPromptBuilder(PromptBuilder):
             )
         finally:
             span.end()
+
+    # ------------------------------------------------------------------
+    # Tool-call adjacency invariant (Sprint 57.80)
+    # ------------------------------------------------------------------
+    # Why: OpenAI / Azure / Anthropic all require a role='tool' message to
+    # immediately follow the assistant message bearing the matching tool_calls.
+    # A PositionStrategy is free to reorder the conversation — LostInMiddleStrategy
+    # in particular moves recent assistant messages to the tail while their tool
+    # results stay in mid-history, orphaning the tool (real_llm chat 400
+    # "messages[N] role 'tool' must follow tool_calls"). Rather than make every
+    # strategy tool-aware, the builder enforces the invariant ONCE after arrange()
+    # (AP-8 single enforcement point) so current + future strategies are all safe.
+    # Alternative considered:
+    #   - Fix LostInMiddleStrategy in isolation — rejected: leaves the hard
+    #     constraint unguaranteed; a new strategy could reintroduce the orphan.
+    #   - Stop re-anchoring the user message for tool turns — rejected: user-after-
+    #     tool is valid (not a 400); the re-anchor is the deliberate lost-in-middle
+    #     design. Out of scope for an orphan-tool fix.
+    # Reference: 04-anti-patterns.md §AP-8 / §AP-10 (mock vs real divergence — the
+    #   MockChatClient never validated adjacency, so this was invisible until real
+    #   Azure; Sprint 57.79 Day-3).
+    @staticmethod
+    def _enforce_tool_adjacency(messages: list[Message]) -> list[Message]:
+        """Re-anchor every role='tool' message right after its owning assistant.
+
+        Builds a tool_call_id → emitting-assistant map, then rebuilds the list so
+        each tool message directly follows the assistant whose tool_calls carries
+        the matching id, preserving all other relative order. A tool message whose
+        tool_call_id resolves to no assistant in the list (defensive — does not
+        occur on the loop path, where the assistant is always emitted before its
+        tool) is left in place rather than dropped (never silently lose a message).
+        No-op (returns the same list) when no assistant carries tool_calls or no
+        tool message resolves to an owner — zero overhead for plain chat turns.
+
+        Strategies rearrange the same Message object references (no copy), so the
+        owner lookup by object identity is stable.
+        """
+        owner_by_id: dict[str, Message] = {}
+        for m in messages:
+            if m.role == "assistant" and m.tool_calls:
+                for tc in m.tool_calls:
+                    owner_by_id[tc.id] = m
+        if not owner_by_id:
+            return messages
+
+        held_tools: dict[int, list[Message]] = {}
+        held_ids: set[int] = set()
+        for m in messages:
+            if m.role == "tool" and m.tool_call_id is not None:
+                owner = owner_by_id.get(m.tool_call_id)
+                if owner is not None:
+                    held_tools.setdefault(id(owner), []).append(m)
+                    held_ids.add(id(m))
+        if not held_ids:
+            return messages
+
+        result: list[Message] = []
+        for m in messages:
+            if id(m) in held_ids:
+                continue  # re-emitted right after its owning assistant below
+            result.append(m)
+            if m.role == "assistant" and id(m) in held_tools:
+                result.extend(held_tools[id(m)])
+        return result
 
     # ------------------------------------------------------------------
     # Section builders

--- a/backend/src/agent_harness/prompt_builder/builder.py
+++ b/backend/src/agent_harness/prompt_builder/builder.py
@@ -39,6 +39,7 @@ Created: 2026-05-01 (Sprint 52.2 Day 1.6)
 Last Modified: 2026-06-04
 
 Modification History (newest-first):
+    - 2026-06-04: Sprint 57.80 — pending-tool-turn skips user re-anchor (tool-chat convergence)
     - 2026-06-04: Sprint 57.80 — tool-call adjacency invariant after arrange() (orphan-tool 400)
     - 2026-06-03: Sprint 57.75 A-5c — add layer_metadata["memory_accesses"] per-hint detail
     - 2026-06-01: Sprint 57.65 — memory render enrich + token cap + verify_before_use (A-1)
@@ -255,12 +256,30 @@ class DefaultPromptBuilder(PromptBuilder):
             # are not counted against it.
             memory_layers = self._apply_memory_budget(memory_layers, tools=tools_list)
 
+            # Sprint 57.80 (targeted C): on a PENDING tool turn — the conversation
+            # ends with a tool result awaiting the model's final answer — do NOT
+            # re-anchor the current user message at the tail. It is already in the
+            # conversation in chronological position; re-appending it after the tool
+            # result makes the model treat the request as fresh and re-call the tool
+            # (the real-LLM echo demo looped to max_turns). Keep the full conversation
+            # in order and pass user_message=None so the prompt ends with the tool
+            # result and the model produces its answer. A normal (non-tool / fresh)
+            # turn keeps the lost-in-middle echo + tail re-anchor unchanged.
+            transient_msgs = state.transient.messages
+            pending_tool_turn = bool(transient_msgs) and transient_msgs[-1].role == "tool"
+            if pending_tool_turn:
+                conversation = list(transient_msgs)
+                section_user_msg: Message | None = None
+            else:
+                conversation = self._extract_conversation(state, user_msg)
+                section_user_msg = user_msg
+
             sections = PromptSections(
                 system=self._build_system_section(memory_layers),
                 tools=tools_list,
                 memory_layers=memory_layers,
-                conversation=self._extract_conversation(state, user_msg),
-                user_message=user_msg,
+                conversation=conversation,
+                user_message=section_user_msg,
             )
 
             # --- Step 2: position strategy ---

--- a/backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py
+++ b/backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py
@@ -298,3 +298,60 @@ async def test_loop_without_prompt_builder_emits_no_memory_accessed() -> None:
 
     events = [ev async for ev in loop.run(session_id=uuid4(), user_input="hi")]
     assert not [ev for ev in events if isinstance(ev, MemoryAccessed)]
+
+
+# ===========================================================================
+# Sprint 57.80 (AD-Chat-RealLLM-Orphan-Tool-Message): a 2-turn tool-calling
+# script through loop + DefaultPromptBuilder must assemble a valid sequence —
+# every role='tool' message immediately after its owning assistant(tool_calls).
+# This exercises the FULL Cat1→Cat5 chain on a tool turn (the case that 400s on
+# real Azure before the builder's tool-adjacency invariant). AP-10 closure: the
+# MockChatClient does NOT validate adjacency, so the assertion is structural —
+# on chat_client.last_request.messages (the turn-2 assembly), not the mock.
+# ===========================================================================
+
+
+def _tool_call_response(call_id: str = "c1") -> ChatResponse:
+    return ChatResponse(
+        model="mock",
+        content="",
+        stop_reason=StopReason.TOOL_USE,
+        tool_calls=[ToolCall(id=call_id, name="echo_tool", arguments={"text": "hi"})],
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_builder_tool_turn_keeps_tool_after_assistant() -> None:
+    """real_llm-style path (prompt_builder injected) with a tool turn: the turn-2
+    assembly sent to chat() has the tool message directly after its assistant —
+    the orphan-tool 400 regression guard (fails on the pre-57.80 builder)."""
+    chat_client = MockChatClient(responses=[_tool_call_response("c1"), _final_response()])
+
+    retrieval = MemoryRetrieval(layers={})
+    retrieval.search = AsyncMock(return_value=[])  # type: ignore[method-assign]
+
+    loop = AgentLoopImpl(
+        chat_client=chat_client,
+        output_parser=OutputParserImpl(),
+        tool_executor=_NoopExecutor(),
+        tool_registry=_StubRegistry(),
+        prompt_builder=_make_builder(retrieval),
+    )
+
+    _ = [ev async for ev in loop.run(session_id=uuid4(), user_input="echo hi")]
+
+    # last_request = the final (turn-2) chat() call — the previously-400'ing assembly.
+    sent = chat_client.last_request
+    assert sent is not None
+    messages = sent.messages
+    a_idx = next(
+        i for i, m in enumerate(messages) if m.role == "assistant" and m.tool_calls
+    )
+    t_idx = next(
+        i for i, m in enumerate(messages) if m.role == "tool" and m.tool_call_id == "c1"
+    )
+    assert t_idx == a_idx + 1, (
+        "tool must immediately follow its assistant(tool_calls) in the assembled "
+        f"request; got assistant@{a_idx}, tool@{t_idx} in {[m.role for m in messages]}"
+    )

--- a/backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py
+++ b/backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py
@@ -345,12 +345,8 @@ async def test_loop_builder_tool_turn_keeps_tool_after_assistant() -> None:
     sent = chat_client.last_request
     assert sent is not None
     messages = sent.messages
-    a_idx = next(
-        i for i, m in enumerate(messages) if m.role == "assistant" and m.tool_calls
-    )
-    t_idx = next(
-        i for i, m in enumerate(messages) if m.role == "tool" and m.tool_call_id == "c1"
-    )
+    a_idx = next(i for i, m in enumerate(messages) if m.role == "assistant" and m.tool_calls)
+    t_idx = next(i for i, m in enumerate(messages) if m.role == "tool" and m.tool_call_id == "c1")
     assert t_idx == a_idx + 1, (
         "tool must immediately follow its assistant(tool_calls) in the assembled "
         f"request; got assistant@{a_idx}, tool@{t_idx} in {[m.role for m in messages]}"

--- a/backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py
+++ b/backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py
@@ -139,3 +139,54 @@ async def test_build_through_lost_in_middle_keeps_tool_after_assistant(
         "tool must immediately follow its assistant(tool_calls) after build(); "
         f"got assistant@{a_idx}, tool@{t_idx}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Targeted C (Sprint 57.80): pending-tool-turn must NOT re-anchor the user
+# message at the tail — the prompt must end with the tool result so the model
+# produces its final answer (the real_llm echo demo otherwise looped to
+# max_turns because the re-anchored user query re-triggered the tool every turn).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_pending_tool_turn_ends_with_tool_not_user(
+    builder: DefaultPromptBuilder,
+) -> None:
+    """conversation ends with a tool result → assembled prompt ends with the tool
+    (NOT a re-anchored user message), while the user query stays in the history."""
+    state = make_state(
+        messages=[
+            Message(role="system", content="sys"),
+            Message(role="user", content="echo hello"),
+            _assistant(["c1"]),
+            _tool("c1", "hello"),
+        ]
+    )
+
+    artifact = await builder.build(state=state, tenant_id=uuid4(), tools=[])
+
+    assert artifact.messages[-1].role == "tool", (
+        "pending tool turn must end with the tool result so the model answers; "
+        f"ended with role={artifact.messages[-1].role!r}"
+    )
+    # the user query is still present in the conversation (just not re-anchored).
+    assert any(m.role == "user" for m in artifact.messages)
+
+
+@pytest.mark.asyncio
+async def test_build_fresh_user_turn_still_ends_with_user(
+    builder: DefaultPromptBuilder,
+) -> None:
+    """A normal (non-tool) turn keeps the lost-in-middle tail re-anchor: the
+    prompt ends with the current user message (no regression to the fresh path)."""
+    state = make_state(
+        messages=[
+            Message(role="system", content="sys"),
+            Message(role="user", content="hello there"),
+        ]
+    )
+
+    artifact = await builder.build(state=state, tenant_id=uuid4(), tools=[])
+
+    assert artifact.messages[-1].role == "user"

--- a/backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py
+++ b/backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py
@@ -1,0 +1,141 @@
+"""
+File: tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py
+Purpose: Unit tests for DefaultPromptBuilder._enforce_tool_adjacency (Cat 5) +
+    build()-through-LostInMiddleStrategy tool-turn assembly.
+Category: Tests / Cat 5
+Scope: Sprint 57.80
+
+Description:
+    Regression coverage for AD-Chat-RealLLM-Orphan-Tool-Message. LostInMiddleStrategy
+    moves recent assistant messages to the tail while their tool results stay in
+    mid-history, orphaning the tool (real_llm chat 400 "messages[N] role 'tool' must
+    follow tool_calls"). The builder enforces the provider hard-constraint with a
+    single post-arrange() pass. These tests assert the structural invariant directly
+    (the MockChatClient never validated adjacency → AP-10 gap that hid this until
+    real Azure in Sprint 57.79 Day-3).
+
+Created: 2026-06-04 (Sprint 57.80)
+Modified: 2026-06-04
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from agent_harness._contracts import Message, ToolCall
+from agent_harness.prompt_builder.builder import DefaultPromptBuilder
+from tests.unit.agent_harness.prompt_builder.conftest import make_state
+
+_enforce = DefaultPromptBuilder._enforce_tool_adjacency
+
+
+def _assistant(tool_call_ids: list[str], content: str = "") -> Message:
+    return Message(
+        role="assistant",
+        content=content,
+        tool_calls=[ToolCall(id=i, name="echo_tool", arguments={}) for i in tool_call_ids],
+    )
+
+
+def _tool(tool_call_id: str, content: str = "ok") -> Message:
+    return Message(role="tool", content=content, tool_call_id=tool_call_id)
+
+
+def _idx(messages: list[Message], predicate) -> int:
+    return next(i for i, m in enumerate(messages) if predicate(m))
+
+
+# ---------------------------------------------------------------------------
+# (a)-(e): _enforce_tool_adjacency direct unit cases
+# ---------------------------------------------------------------------------
+
+
+def test_tool_already_after_assistant_unchanged() -> None:
+    """(a) tool already directly after its assistant → order preserved."""
+    sys = Message(role="system", content="s")
+    asst = _assistant(["c1"])
+    tool = _tool("c1")
+    out = _enforce([sys, asst, tool])
+    assert out == [sys, asst, tool]
+
+
+def test_tool_before_assistant_reanchored() -> None:
+    """(b) the bug shape — tool ahead of its assistant → re-anchored after it."""
+    sys = Message(role="system", content="s")
+    asst = _assistant(["c1"])
+    tool = _tool("c1")
+    # LostInMiddle-style: tool stranded in mid-history, assistant at the tail.
+    out = _enforce([sys, tool, asst])
+    a_idx = _idx(out, lambda m: m.role == "assistant")
+    t_idx = _idx(out, lambda m: m.role == "tool")
+    assert t_idx == a_idx + 1
+    assert out[t_idx] is tool and out[a_idx] is asst
+
+
+def test_two_assistants_scrambled_each_tool_after_own_assistant() -> None:
+    """(c) two assistants, tools scrambled → each tool follows its OWN assistant."""
+    asst_a = _assistant(["a1"])
+    asst_b = _assistant(["b1"])
+    tool_a = _tool("a1", "ra")
+    tool_b = _tool("b1", "rb")
+    out = _enforce([asst_a, asst_b, tool_b, tool_a])
+    assert out == [asst_a, tool_a, asst_b, tool_b]
+
+
+def test_orphan_tool_left_in_place() -> None:
+    """(d) a tool whose tool_call_id resolves to no assistant is NOT dropped."""
+    asst = _assistant(["a1"])
+    tool_ok = _tool("a1")
+    orphan = _tool("does-not-exist")
+    out = _enforce([asst, tool_ok, orphan])
+    # valid pair stays adjacent; orphan kept (never silently lose a message)
+    assert asst in out and tool_ok in out and orphan in out
+    assert len(out) == 3
+    a_idx = _idx(out, lambda m: m is asst)
+    assert out[a_idx + 1] is tool_ok
+
+
+def test_no_tool_messages_returns_same_list() -> None:
+    """(e) no tool turn → no-op (same list object, zero overhead for plain chat)."""
+    msgs = [
+        Message(role="system", content="s"),
+        Message(role="user", content="hi"),
+        Message(role="assistant", content="hello"),  # no tool_calls
+    ]
+    out = _enforce(msgs)
+    assert out is msgs
+
+
+# ---------------------------------------------------------------------------
+# build() through the default LostInMiddleStrategy (the real_llm chat path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_through_lost_in_middle_keeps_tool_after_assistant(
+    builder: DefaultPromptBuilder,
+) -> None:
+    """A [system, user, assistant(tool_calls), tool] conversation assembled via the
+    default LostInMiddleStrategy emits a tool message directly after its assistant —
+    the exact case that 400s on real Azure before the fix."""
+    asst = _assistant(["c1"], content="")
+    tool = _tool("c1", "hello")
+    state = make_state(
+        messages=[
+            Message(role="system", content="sys"),
+            Message(role="user", content="echo hello"),
+            asst,
+            tool,
+        ]
+    )
+
+    artifact = await builder.build(state=state, tenant_id=uuid4(), tools=[])
+
+    a_idx = _idx(artifact.messages, lambda m: m.role == "assistant" and m.tool_calls)
+    t_idx = _idx(artifact.messages, lambda m: m.role == "tool")
+    assert t_idx == a_idx + 1, (
+        "tool must immediately follow its assistant(tool_calls) after build(); "
+        f"got assistant@{a_idx}, tool@{t_idx}"
+    )

--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -36,12 +36,22 @@
 
 ---
 
+## 🆕 Sprint 57.80 Carryover (2026-06-04 — chat real_llm orphan-tool-message fix; closes AD-Chat-RealLLM-Orphan-Tool-Message)
+
+**Closed**: `AD-Chat-RealLLM-Orphan-Tool-Message` (the 57.79 carryover) — real_llm `POST /chat` 400'd on every tool turn. Builder-level tool-call adjacency invariant (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B, protects all strategies / LostInMiddle untouched) + pending-tool-turn user re-anchor suppression (fix C, in-sprint extension per the real-LLM finding — B-only gave 200 but `stop_reason=max_turns`; C → `end_turn`). Real Azure (gpt-5.2) verified converged + cost_ledger written. AP-10 (MockChatClient never validated adjacency → invisible until real Azure). backend-only Cat 5; no design note. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md` + retrospective. FIX-027.
+
+### NEW carryovers (this sprint)
+- **Candidate rule fold-in (not yet codified)** — Cat 5 / message-assembly tests must assert the provider structural invariant (tool-call adjacency / ordering) directly, not rely on the mock to reject; and a real-LLM DoD for agent-loop prompt changes should check `stop_reason=end_turn` (convergence), not just no-400 / loop_end present. (Single-data-point; fold into `sprint-workflow.md` if a 2nd sprint hits the same gap.)
+- No blocking carryover. Unrelated bundle remains: **B-7** (ErrorBudget Redis wiring) / **B-8** (Verification default-enable) / **C-15** (DevOps/data-platform billing).
+
+---
+
 ## 🆕 Sprint 57.79 Carryover (2026-06-04 — C-11 billing-correctness; closes AD-Cost-Ledger-Model-Pricing-Key-Mismatch + AD-Adapter-MaxTokens-NewModel-Param)
 
 **Closed**: `AD-Cost-Ledger-Model-Pricing-Key-Mismatch` + `AD-Adapter-MaxTokens-NewModel-Param` — the 2 C-11 billing gaps. First post-Area-A sprint (user picked C-11 收尾 over carryover/B). Gap 1: `get_llm_pricing` strips `-YYYY-MM-DD` on exact-miss → base key (`gpt-5.2-2025-12-11` → `gpt-5.2`); yaml + `gpt-5.2` (1.75/14.00/0.175 user-provided); chose normalize over per-date yaml keys. Gap 2: adapter `_max_tokens_param_name` gpt-5→`max_completion_tokens` (config.model_name keyed). Real Azure verified: cost_ledger DB `unit_cost>0` (direct record path) + token-cap no 400. backend-only; no design note. Detail: `memory/project_phase57_79_c11_billing_correctness.md` + retrospective. CHANGE-047.
 
 ### NEW carryovers (this sprint)
-- **`AD-Chat-RealLLM-Orphan-Tool-Message`** — chat router real_llm e2e blocked by a pre-existing, UNRELATED message-structure 400 (`messages[3] role 'tool' must follow tool_calls`; orphan tool message). Reproduces on a fresh tenant (messages_count:4 fixed) → prompt-builder/chat-handler assembly issue in real_llm mode, NOT session history, NOT this sprint's fix. cost_ledger e2e verified via direct record path instead. Needs separate investigation into the real_llm prompt assembly.
+- **`AD-Chat-RealLLM-Orphan-Tool-Message`** — ✅ **CLOSED Sprint 57.80 (FIX-027)**. Root cause = `LostInMiddleStrategy.arrange()` moved recent assistant to the tail while the tool result stayed in mid_history → tool preceded its assistant. Fixed builder-level (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B) + pending-tool-turn user re-anchor suppression (fix C, for convergence). Real Azure verified: 200 + `stop_reason=end_turn`. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md`. ~~chat router real_llm e2e blocked by a pre-existing, UNRELATED message-structure 400; needs separate investigation into the real_llm prompt assembly.~~
 - **Deployment requirement: `AZURE_OPENAI_MODEL_NAME`** — prod/other envs using a gpt-5.x deployment MUST set this to the real generation (e.g. `gpt-5.2`). Config default is `gpt-4o` (stale); if unaligned, Gap 2 mis-branches to `max_tokens` → 400 on gpt-5.x. (Gap 1 unaffected — uses response.model.) Deployment/ops note, not a code item.
 
 ### Still-open billing bundle (Sprint 57.80+ candidates)

--- a/claudedocs/4-changes/bug-fixes/FIX-027-chat-real-llm-orphan-tool-message.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-027-chat-real-llm-orphan-tool-message.md
@@ -1,0 +1,32 @@
+# FIX-027: chat real_llm orphan-tool-message 400 + tool-turn non-convergence
+
+**Date**: 2026-06-04
+**Sprint**: 57.80
+**Scope**: 範疇 5 (Prompt Construction) — `DefaultPromptBuilder` (backend-only)
+**Closes**: `AD-Chat-RealLLM-Orphan-Tool-Message`
+
+## Problem
+`POST /api/v1/chat/` in `mode=real_llm` returned a 400 from Azure on any tool-calling turn: **`messages[3] role 'tool' must follow tool_calls`** (orphan tool message). A fresh tenant + clean session reproduced it (`messages_count:4`), so it was a per-turn prompt-assembly defect, not session-history pollution. Surfaced by the Sprint 57.79 Day-3 real-LLM run (which bypassed it via the direct cost_ledger record path). echo_demo mode was unaffected.
+
+## Root Cause
+The real_llm path injects `DefaultPromptBuilder` (keystone Sprint 57.64), so the loop sends `artifact.messages` (`loop.py:1052`) rather than its own correctly-ordered `messages`. The builder's default `LostInMiddleStrategy.arrange()` (`lost_in_middle.py:64-76`) splits the conversation into `recent_assistants` (appended at the tail) vs `mid_history` (everything else, incl. `role='tool'` results, appended before). For a tool turn `[system, user, assistant(tool_calls), tool]` it produced `[new_system, echo, old_system, tool, assistant(tool_calls), user]` — the `tool` (idx 3) precedes its `assistant` (idx 4), violating the provider hard-constraint that a `role='tool'` message must immediately follow the assistant bearing the matching `tool_calls`. `messages[3]=tool` exactly matched the 400.
+
+Invisible until real Azure because the loop+builder integration tests only ran single-turn-no-tool scripts AND `MockChatClient` does not validate adjacency (AP-10 mock-vs-real divergence + AP-4 no negative coverage of the tool-turn assembly).
+
+**Secondary (surfaced once the 400 no longer short-circuited the loop)**: every strategy re-anchors the current user message at the tail (`lost_in_middle.py:79-80`). On a tool turn the assembled prompt therefore ended with the user message (after the tool result) → the model treated the re-anchored request as fresh and re-called the tool every turn → the echo demo looped to `max_turns` (`stop_reason=max_turns total_turns=8`) instead of converging.
+
+## Solution
+Two builder-level changes in `backend/src/agent_harness/prompt_builder/builder.py` (single enforcement point — AP-8; LLM-neutral; no strategy / loop / adapter change):
+
+1. **Tool-call adjacency invariant** — new `_enforce_tool_adjacency(messages)` static method, called in `build()` immediately after `strategy.arrange()`. Maps each `ToolCall.id` → emitting assistant, then rebuilds the list so every `role='tool'` message directly follows its owning assistant, preserving all other order. Orphan tools (no resolved owner — does not occur on the loop path) are left in place (no silent drop). No-op when no tool turn exists.
+
+2. **Pending-tool-turn user re-anchor suppression** (targeted Approach C; in-sprint extension per the Day-3 finding + user decision) — `build()` detects a pending tool turn (`state.transient.messages[-1].role == "tool"`) and passes the full conversation in chronological order + `user_message=None` (no tail re-anchor, no top echo), so the prompt ends with the tool result and the model produces its final answer. Fresh / non-tool turns keep the lost-in-middle echo + tail re-anchor unchanged.
+
+## Verification
+- Unit: `tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py` — 5 `_enforce_tool_adjacency` cases + build()-through-LostInMiddle adjacency + 2 pending-vs-fresh re-anchor cases.
+- Integration: `tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py` — 2-turn tool script asserts `chat_client.last_request.messages` adjacency (AP-10 closure). Regression-guard verified: temporarily disabling the invariant → build() test FAILED `assistant@4, tool@3` (the real Azure `messages[3]` 400 shape) → restored → green.
+- Real Azure (fresh tenant, gpt-5.2): `POST /chat real_llm` → HTTP 200, no `must follow tool_calls`, SSE `loop_end stop_reason=end_turn` (was `max_turns`), final `content="hello"`, last `prompt_built messages_count=5` ending with the tool result; cost_ledger rows written.
+- Gates: `mypy src/` 0 (331) + `pytest` 2130 passed / 4 skipped (+9) + `python scripts/lint/run_all.py` 10/10.
+
+## Impact
+Backend-only (Cat 5). Fixes real_llm chat on all tool-calling turns (the core agent path); echo_demo + non-tool real_llm turns unchanged. No frontend / migration / schema / contract change.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
@@ -109,3 +109,16 @@
 ### Evidence
 - Before C: `stop_reason=max_turns total_turns=8`. After C: `stop_reason=end_turn`, final content `"hello"`, last prompt 5 messages ending with tool.
 - Backend left running (fresh PID, B+C code) pending Day-4 closeout cleanup.
+
+---
+
+## Day 4 — 2026-06-04 — Full sweep + closeout
+
+### Accomplishments
+- **Full sweep**: `mypy src/` 0 (331 files) + `pytest` 2130 passed / 4 skipped (+9 vs baseline 2121) + `run_all.py` 10/10 (check_promptbuilder_usage + check_llm_sdk_leak green; check_rls_policies unchanged — no schema). Backend-only (0 frontend changes).
+- **Cleanup**: stopped both backend processes; freed :8000; removed temp verify script + 2 temp logs. (Test tenants `sk5780`/`sk5780b` + their cost_ledger rows left in the dev `ipa_v2` DB — harmless dev test data.)
+- **Closeout**: FIX-027 (bug fix — orphan-tool is a broken main-flow, classified FIX not CHANGE) + retrospective.md (Q1-Q7) + MEMORY subfile/pointer + CLAUDE.md lean + next-phase-candidates.md (AD CLOSED).
+- No design note (bug fix in Cat 5; no new contract / no 17.md change).
+
+### Status
+`AD-Chat-RealLLM-Orphan-Tool-Message` CLOSED. B (orphan-tool 400) + C (tool-turn convergence) both real-Azure verified. Awaiting push + PR (user-gated).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
@@ -1,0 +1,49 @@
+# Sprint 57.80 Progress — chat real_llm orphan-tool-message fix
+
+**Branch**: `feature/sprint-57-80-orphan-tool-adjacency` (from `main` `88911c95`)
+**Closes**: `AD-Chat-RealLLM-Orphan-Tool-Message`
+
+---
+
+## Day 0 — 2026-06-04 — Plan-vs-Repo Verify + Branch + Decisions
+
+### Accomplishments
+- Root-cause investigation of the Sprint 57.79 carryover (real_llm chat 400 `messages[3] role 'tool' must follow tool_calls`).
+- AskUserQuestion (2026-06-04): fix approach **B** (builder-level adjacency invariant) + real Azure e2e re-verify this sprint.
+- Plan + checklist drafted (mirror 57.79 9-section / Day 0-4 format).
+- Branch created.
+
+### Day-0 verify (Prong 1 path + Prong 2 content; Prong 3 N/A — no schema change)
+- **Prong 1 (path)** ✅ — `prompt_builder/builder.py`, all 4 strategy files + `_abc.py`, `orchestrator_loop/loop.py`, `_contracts/chat.py`, `api/v1/chat/handler.py`, `adapters/_testing/mock_clients.py`, `test_loop_with_prompt_builder.py`, `tests/unit/agent_harness/prompt_builder/` dir all confirmed present.
+- **Prong 2 (content)** ✅ — D-DAY0-1..7 (plan §0):
+  - **D-DAY0-2 (ROOT CAUSE)**: `LostInMiddleStrategy.arrange()` (`lost_in_middle.py:64-76`) splits conversation into `recent_assistants` (appended at tail) vs `mid_history` (incl. `role='tool'` results, appended before). For `[system, user, assistant(tool_calls), tool]` → arranged `[new_system, echo, old_system, tool, assistant(tool_calls), user]` — tool (idx3) BEFORE its assistant (idx4). `messages[3]=tool` exactly matches the 400.
+  - real_llm uses `artifact.messages` (`loop.py:1052`, prompt_builder injected via `handler.py:258`); echo_demo uses loop's correct-order `messages` (`loop.py:982`, no builder) → bug is real_llm-only.
+  - `naive` + `tools_at_end` `result.extend(sections.conversation)` in order → no orphan; bug specific to LostInMiddle (the chat default).
+  - `Message` (`chat.py:76-95`): `tool_calls: list[ToolCall]|None` + `tool_call_id: str|None`; `ToolCall.id: str` → adjacency enforceable by id match; strategies rearrange same Message refs (no copy) → object identity stable.
+  - AP-10 + AP-4: existing loop+builder tests only single-turn-no-tool + MockChatClient doesn't validate adjacency → bug invisible until real Azure (57.79 Day-3).
+  - `MockChatClient.last_request.messages` retains the turn-2 assembly → regression test capture point, no infra change.
+  - config.model_name aligned (57.79 `.env` `AZURE_OPENAI_MODEL_NAME=gpt-5.2`; gpt-5.x token-param + pricing normalize live #245).
+- **Prong 3 (schema)** N/A — no DB table / migration / ORM change.
+
+### Drift findings
+- **D1 (no drift — confirms surgical scope)**: fix is a post-`arrange()` normalization in `build()`; no strategy / loop / adapter change. Approach B (builder single-enforcement) confirmed feasible against real code.
+- **D2 (test capture point confirmed)**: `MockChatClient` has `last_request` (not `last_call_messages`), but `last_request.messages` carries the assembled list → integration assertion needs no test-infra addition.
+- No scope shift (≤20%). GO for Day 1.
+
+### Decisions locked
+- Fix **B**: `_enforce_tool_adjacency` static method in `DefaultPromptBuilder`, called right after `strategy.arrange()`. Protects ALL strategies (AP-8 single enforcement); LostInMiddle untouched.
+- Approach A (fix LostInMiddle only) rejected — doesn't make adjacency a guaranteed invariant; C (also stop user re-anchor) rejected — user-after-tool is valid, out of scope.
+- **parent-direct** (NOT agent-delegated — assembly correctness + real-LLM verify is parent/user collab). agent_factor 1.0.
+- real-LLM Azure verify THIS sprint (user `.env` live key).
+
+### Blockers / dependencies
+- **D1 (live Azure `.env`)**: Day-3 verification needs user env. Confirmed available (`AZURE_OPENAI_MODEL_NAME=gpt-5.2` set 57.79).
+
+### Remaining for Day 1+
+- Day 1: `_enforce_tool_adjacency` + call site in build().
+- Day 2: unit tests (a)-(e) + build()-through-LostInMiddle + integration 2-turn tool script.
+- Day 3: real-LLM Azure verify (clean restart + POST /chat real_llm no-400 + loop_end + cost_ledger write).
+- Day 4: sweep + closeout.
+
+### Notes
+- Bottom-up est ~5.5 hr → calibrated ~4.4 hr (medium-backend 0.80, parent-direct).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/progress.md
@@ -47,3 +47,65 @@
 
 ### Notes
 - Bottom-up est ~5.5 hr → calibrated ~4.4 hr (medium-backend 0.80, parent-direct).
+
+---
+
+## Day 1-2 — 2026-06-04 — Fix + tests
+
+### Accomplishments
+- **Fix (US-1/US-2)**: `DefaultPromptBuilder._enforce_tool_adjacency` static method + call site in `build()` immediately after `strategy.arrange()`. Re-anchors every `role='tool'` after its owning `assistant(tool_calls)` (id match), preserves other order, leaves orphan tools in place, no-op when no tool turn. Builder-level single enforcement (AP-8) — protects all strategies; LostInMiddleStrategy untouched.
+- **Tests (US-3)**: NEW `test_builder_tool_adjacency.py` (5 `_enforce` cases (a)-(e) + build()-through-LostInMiddle) + extended `test_loop_with_prompt_builder.py` with a 2-turn tool-script integration assertion on `chat_client.last_request.messages` (AP-10 closure).
+
+### Verification
+- `pytest tests/unit/agent_harness/prompt_builder/ tests/integration/agent_harness/prompt_builder/` → 69 passed.
+- `mypy src/agent_harness/prompt_builder/builder.py` → clean.
+- **Regression guard CONFIRMED**: temporarily disabled the `_enforce_tool_adjacency` call → `test_build_through_lost_in_middle_keeps_tool_after_assistant` FAILED `assistant@4, tool@3` (exactly the real Azure `messages[3] role 'tool'` 400 shape) → restored → all green.
+
+### Commit
+- `29879147` fix(prompt_builder, sprint-57-80): tool-call adjacency invariant.
+
+---
+
+## Day 3 — 2026-06-04 — real-LLM Azure verification
+
+### Accomplishments
+- **Clean restart (Risk Class E)**: :8000 was free (no stale process); started fresh single no-reload uvicorn (PID 37220). Startup log `pricing loader wired (...llm_pricing.yml)` + `startup complete` confirmed (FIX-022 fired).
+- **real-LLM chat (fresh tenant `sk5780`, clean session — 57.79 repro condition)**: `POST /chat {mode: real_llm, message: "echo hello"}`.
+
+### Result — orphan-tool 400 FIXED ✅
+- `chat status: 200` (not 400/503).
+- **`"must follow tool_calls" in stream: False`** — the orphan-tool 400 is GONE.
+- SSE ran the full tool turn: `tool_call_request` (echo_tool) → `tool_call_result` (result="hello") → ... → `loop_end`. `models seen: ['gpt-5.2']` (real Azure deployment).
+- `cost_ledger` delta=8 (incl. `azure_openai_gpt-5.2-2025-12-11_output` 11 tokens + `echo_tool` rows). Cost rows written.
+- ⇒ **Acceptance criteria met**: HTTP 200 (no orphan-tool 400) + SSE `loop_end` + cost_ledger rows written. `AD-Chat-RealLLM-Orphan-Tool-Message` (the 400) is closed by the structural fix.
+
+### NEW finding (surfaced once the 400 no longer short-circuits the loop)
+- `loop_end` shows **`"stop_reason":"max_turns","total_turns":8`** — the model re-called `echo_tool` every turn and never emitted END_TURN.
+- **Root cause (confirmed by code, not Azure)**: `LostInMiddleStrategy.arrange()` always appends `sections.user_message` at the tail (`lost_in_middle.py:79-80`); `_enforce_tool_adjacency` does not move it ⇒ on a tool turn the assembled prompt ALWAYS ends with the user message (after the tool result). The model sees "echo hello" as the final instruction each turn → re-calls echo_tool → never converges. This is exactly the **user-message re-anchoring (Approach C)** that Sprint plan §9 deferred as "valid, not a 400, out of scope."
+- **Honest reassessment**: the plan under-sold C as cosmetic. The real-LLM run shows C is functionally required for tool-calling real_llm chat to CONVERGE (END_TURN), not just for tidiness. B alone removes the 400 but leaves tool-chat looping to max_turns. (Severity nuance: the DEMO_SYSTEM_PROMPT is a worst case — "echo when asked to echo" + re-anchored "echo hello" → always echo; a real conversational persona may converge despite re-anchoring, but the re-anchor is still wrong for tool turns.)
+- **Decision pending (user)**: extend this sprint with a targeted C fix (don't re-anchor the user message when the conversation ends with a pending tool result → prompt ends with the tool result → model produces the final answer) + re-verify Azure converges; OR close now (AD/acceptance met) + carryover the convergence issue as a focused Approach-C AD.
+
+### Evidence (B-only run, before C)
+- response.model = `gpt-5.2-2025-12-11`; SSE `loop_end stop_reason=max_turns total_turns=8`; cost_ledger delta=8.
+
+### User decision (AskUserQuestion, 2026-06-04)
+- **Extend this sprint with a targeted C fix** (don't re-anchor the user message when the conversation ends with a pending tool result → prompt ends with the tool result → model converges).
+
+---
+
+## Day 3.5 — 2026-06-04 — targeted C fix + real-LLM re-verify
+
+### Accomplishments
+- **Targeted C fix** in `build()`: detect a pending tool turn (`state.transient.messages[-1].role == "tool"`) → use the full conversation in chronological order + `user_message=None` (no tail re-anchor / no top echo) → the prompt ends with the tool result. A normal (non-tool / fresh) turn keeps the lost-in-middle echo + tail re-anchor unchanged. Builder-level (consistent with B's single-enforcement philosophy); LLM-neutral; all strategies benefit.
+- **Tests**: +2 in `test_builder_tool_adjacency.py` — pending tool turn ends with `tool` (not re-anchored user, user still in history); fresh non-tool turn still ends with `user` (no regression). 71 passed (was 69).
+
+### Re-verify — CONVERGED ✅ (clean restart PID killed → fresh PID, `pricing loader wired`)
+- Fresh tenant `sk5780b`, clean session. `POST /chat {mode: real_llm, message: "echo hello"}`:
+  - `chat status: 200`; `"must follow tool_calls": False` (400 still gone).
+  - **`loop_end stop_reason: "end_turn"`** (was `max_turns`) — CONVERGED. Final `llm_response content="hello", tool_calls=[]`.
+  - Final `prompt_built messages_count: 5` = `[new_system, old_system, user, assistant(tool_calls), tool]` — the C-fix arrangement (ends with the tool result, user in chronological position, NOT re-anchored). `models seen: ['gpt-5.2']`. cost_ledger delta=3 (gpt-5.2 input/output + echo_tool).
+- ⇒ **B (orphan-tool 400 removed) + C (tool-chat converges to END_TURN) both verified end-to-end against real Azure.**
+
+### Evidence
+- Before C: `stop_reason=max_turns total_turns=8`. After C: `stop_reason=end_turn`, final content `"hello"`, last prompt 5 messages ending with tool.
+- Backend left running (fresh PID, B+C code) pending Day-4 closeout cleanup.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/retrospective.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-80/retrospective.md
@@ -1,0 +1,55 @@
+# Sprint 57.80 Retrospective — chat real_llm orphan-tool-message fix
+
+**Sprint**: 57.80
+**Closed**: 2026-06-04
+**Branch**: `feature/sprint-57-80-orphan-tool-adjacency`
+**Closes**: `AD-Chat-RealLLM-Orphan-Tool-Message`
+
+---
+
+## Q1. Goal achieved?
+
+✅ Yes, and extended. The orphan-tool 400 is fixed AND the tool-chat now converges:
+- **B (planned)**: `DefaultPromptBuilder._enforce_tool_adjacency` after `strategy.arrange()` — every `role='tool'` message re-anchored after its owning `assistant(tool_calls)`. Closes the real_llm chat 400.
+- **C (in-sprint extension, user-approved)**: pending-tool-turn user re-anchor suppression — when the conversation ends with a tool result, don't re-append the user message at the tail; the prompt ends with the tool result so the model produces its final answer.
+- Real Azure (fresh tenant, gpt-5.2): HTTP 200, no `must follow tool_calls`, `loop_end stop_reason=end_turn` (was `max_turns`), cost_ledger written.
+- Gates: mypy src/ 0 (331) / pytest 2130 (+9) / run_all 10/10.
+
+## Q2. Estimate accuracy
+
+- Plan: bottom-up ~5.5 hr → class-calibrated commit ~4.4 hr (`medium-backend` 0.80, `agent_factor` 1.0 parent-direct).
+- Actual: ~3.5-4 hr. The B fix + tests was small/fast (~1.5 hr). The unplanned C extension (root-cause was already known by code, so the fix itself was ~45 min + 2 tests) + the two real-Azure runs + a clean restart added ~1.5 hr. Closeout ~1 hr.
+- Ratio ~0.85. `medium-backend` 0.80 held for a parent-direct prompt-assembly fix even with the in-sprint C extension. **NOT agent-delegated** → the 16-consecutive-agent-delegated wall-clock caveat does not apply.
+
+## Q3. What went well
+
+- **Day-0 root cause by code read, no Azure needed**: traced the LostInMiddle `recent_assistants` split → `mid_history` tool orphan purely from `lost_in_middle.py` + the loop's `artifact.messages` path. The 400 shape (`messages[3]=tool`) was predicted before any real run.
+- **Regression guard proven, not asserted**: temporarily disabled the invariant → the build()-through-LostInMiddle test FAILED `assistant@4, tool@3` (the exact real Azure 400 shape) → restored. The test demonstrably catches the bug.
+- **Real-LLM caught what no test could**: the C non-convergence (`max_turns` loop) is a behavioral property only observable on the real path — every mock script predetermines `stop_reason`. Running real Azure (per the user's Q2 decision) surfaced it.
+- **Honest reassessment / professional pushback**: the plan framed C as "cosmetic, valid-not-a-400, out of scope". The real-LLM run proved C is functionally required for convergence; I corrected my own framing and surfaced it rather than shipping a 400-fixed-but-unusable chat.
+
+## Q4. Lessons
+
+- **AP-10 is real for prompt assembly**: `MockChatClient` returns scripted responses without validating message adjacency, so a structurally-invalid prompt (orphan tool) passed every loop+builder test until real Azure. Prompt-assembly tests must assert the structural invariant (adjacency / ordering) directly, not rely on the mock to reject — this sprint's new tests do exactly that. (Candidate rule fold-in: "Cat 5 / message-assembly tests assert provider structural constraints, not mock acceptance.")
+- **"Valid but odd" ≠ "harmless" when it touches LLM behavior**: the user-message re-anchor was waved off as cosmetic; it actually broke tool-turn convergence. When a structural oddity feeds the model, verify with real-LLM before declaring it out of scope.
+- **Convergence (`stop_reason`) is only observable on the real path**: no-400 is necessary but not sufficient; a real-LLM DoD for agent-loop prompt changes should check `stop_reason=end_turn` (converges), not just HTTP 200.
+
+## Q5. Improvements next sprint
+
+- When a sprint touches prompt assembly on the agent-loop path, the real-LLM DoD should include a **convergence** check (`stop_reason=end_turn` on a tool turn), not only "no 400 / loop_end present". This sprint's first real-LLM run passed "200 + loop_end" while still looping to max_turns — the convergence signal is the one that mattered.
+
+## Q6. Carryover
+
+- None blocking — the carryover that opened this sprint (`AD-Chat-RealLLM-Orphan-Tool-Message`) is CLOSED, and the 57.79 chat-router e2e leg it blocked is now verified (200 + end_turn + cost rows).
+- B-7 (ErrorBudget Redis) / B-8 (Verification default-enable) / C-15 — billing/verification bundle, unrelated, separate sprints.
+- Compaction × tool-turn interaction (Cat 4 dropping an assistant while keeping its tool) — non-occurring today; the adjacency invariant degrades safely (orphan left in place); not designed here.
+
+## Q7. Risks
+
+- Low. Backend-only, builder-level (Cat 5), LLM-neutral (neutral `Message` contract only), no schema / migration / contract change. The C conditional is gated on a simple signal (`transient.messages[-1].role == "tool"`); the fresh / non-tool path is unchanged (regression-tested: fresh turn still ends with user). Real Azure converged. The adjacency rebuild relies on Message object identity (strategies don't copy) — covered by the build()-through-real-strategy test, which would catch a future copy regression.
+
+---
+
+## Design Note Extract
+
+NO — bug fix in an existing category (Cat 5 PromptBuilder); no new contract / no 17.md change / no new domain.

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
@@ -1,0 +1,93 @@
+# Sprint 57.80 — Checklist (chat real_llm orphan-tool-message fix: PromptBuilder tool-call adjacency invariant)
+
+**Plan**: `sprint-57-80-plan.md`
+**Branch**: `feature/sprint-57-80-orphan-tool-adjacency` (from `main` `88911c95`)
+**Closes**: `AD-Chat-RealLLM-Orphan-Tool-Message`
+
+---
+
+## Day 0 — Plan-vs-Repo Verify + Branch + Decisions
+
+### 0.1 Day-0 verify (parent grep + code read, main `88911c95`)
+- [x] **Prong 1 (path)** — confirm: `prompt_builder/builder.py`, `strategies/lost_in_middle.py` + `naive.py` + `tools_at_end.py` + `_abc.py`, `orchestrator_loop/loop.py`, `_contracts/chat.py`, `api/v1/chat/handler.py`, `adapters/_testing/mock_clients.py`, `tests/.../prompt_builder/test_loop_with_prompt_builder.py`, `tests/unit/agent_harness/prompt_builder/` dir.
+- [x] **Prong 2 (content)** — D-DAY0-1..7 in plan §0 (real_llm uses artifact.messages / LostInMiddle split root cause / naive+tools_at_end preserve order / Message tool_calls+tool_call_id linkage + identity-stable / AP-10+AP-4 why-invisible / last_request.messages capture point / config.model_name aligned 57.79).
+- [x] **Prong 3 (schema)** — N/A (no DB table / migration / ORM change).
+- [x] **go/no-go** — GO; user-locked (AskUserQuestion 2026-06-04): approach B (builder-level adjacency invariant) + real Azure e2e re-verify this sprint. No scope shift (≤20%).
+
+### 0.2 Branch + decisions
+- [x] **Branch created** `feature/sprint-57-80-orphan-tool-adjacency`
+- [x] **Decisions locked**: fix B (`_enforce_tool_adjacency` in builder after `strategy.arrange()`, protects all strategies — NOT a strategy rewrite); parent-direct (NOT agent-delegated — assembly correctness + real-LLM collab); real-LLM verify THIS sprint.
+- [x] **Day-0 commit** plan + checklist + progress.md Day 0
+
+---
+
+## Day 1 — Tool-call adjacency invariant (US-1/US-2)
+
+### 1.1 `_enforce_tool_adjacency` static method
+- [ ] **add `_enforce_tool_adjacency(messages) -> list[Message]`** in `builder.py` (DefaultPromptBuilder)
+  - build `owner_by_id` (ToolCall.id → emitting assistant); no-op return when no assistant carries tool_calls
+  - bucket `role='tool'` msgs (resolved owner) under `id(owner)`, preserve order, mark held; unresolved-owner tool left in place (no silent drop)
+  - rebuild: skip held tools; after each assistant emit its held tools → tool always directly after owning assistant
+  - DoD: mypy clean ✅; docstring states the provider hard-constraint + orphan-left-in-place rationale
+
+### 1.2 call site in build()
+- [ ] **insert `messages = self._enforce_tool_adjacency(messages)`** immediately after `messages = strategy.arrange(sections)` (`builder.py:269`)
+  - DoD: mypy clean; no other build() logic changed; MHist 1-line entry added to builder.py header
+
+### 1.3 read changed code
+- [ ] **re-read** builder.py change — confirm no strategy / loop / adapter touched; LLM-neutral (only neutral `Message` contract used); identity-rebuild correct
+
+---
+
+## Day 2 — Tests (US-3)
+
+### 2.1 unit: `_enforce_tool_adjacency` + build()-through-LostInMiddle
+- [ ] **NEW `test_builder_tool_adjacency.py`** in `tests/unit/agent_harness/prompt_builder/`
+  - (a) tool already after assistant → unchanged; (b) tool before assistant (bug shape) → re-anchored after; (c) 2 assistants × 1 tool scrambled → each tool after own assistant; (d) orphan tool (no owner) → left in place; (e) no tool msgs → unchanged
+  - `build()` through default `LostInMiddleStrategy`: state.transient.messages = `[system, user, assistant(tool_calls), tool]` → assert `artifact.messages` tool immediately after assistant (the case that 400s pre-fix)
+
+### 2.2 integration: loop+builder 2-turn tool script (AP-10 closure)
+- [ ] **extend `test_loop_with_prompt_builder.py`** — 2-turn MockChatClient (turn1 tool_calls → turn2 END_TURN) + tool executor returning a result + registry exposing the tool + prompt_builder injected
+  - after run, assert `chat_client.last_request.messages` (turn-2 assembly) has every `role='tool'` immediately after its owning `assistant(tool_calls)`
+  - DoD: test FAILS on pre-fix builder (regression guard confirmed) → PASSES with fix
+
+### 2.3 regression gate
+- [ ] **targeted pytest** — `pytest tests/unit/agent_harness/prompt_builder/ tests/integration/agent_harness/prompt_builder/` green; confirm pre-existing builder/strategy tests unchanged (LostInMiddle strategy untouched → its own tests still pass)
+
+---
+
+## Day 3 — real-LLM Azure verification (US-4) — user `.env`
+
+### 3.1 clean restart + startup log (Risk Class E)
+- [ ] **clean start backend** — kill stale `--reload` workers on :8000; confirm port sole-owner (no Errno 10048); started fresh
+- [ ] **confirm startup log** `pricing loader wired` (FIX-022 wiring fired)
+
+### 3.2 real-LLM chat main-flow (local `.env`, NOT GitHub secrets)
+- [ ] **dev-login** → v2_jwt cookie (fresh tenant + clean session — the 57.79 repro condition)
+- [ ] **POST /chat real_llm** `{mode: real_llm, message: "echo hello"}` → **HTTP 200, no orphan-tool 400** + SSE contains `loop_end` + real Azure reply
+- [ ] **cost_ledger write** — newest rows written (row-count Δ≥2); evidence captured
+
+### 3.3 evidence
+- [ ] **record** SSE outcome + cost row evidence + the exact `response.model` in progress.md Day 3
+
+---
+
+## Day 4 — Sweep + Closeout
+
+### 4.1 Full sweep
+- [ ] **Backend gates** — `mypy src/` 0 + `pytest` (new + regression, expect +~8) + `python scripts/lint/run_all.py` 10/10 (check_llm_sdk_leak green; check_rls_policies unchanged — no schema)
+- [ ] **No frontend** — 0 frontend changes (backend-only sprint)
+- [ ] **Read all changed code** — builder fix LLM-neutral + identity-rebuild correct; tests assert the structural invariant (not mock-reliant)
+
+### 4.2 Closeout docs
+- [ ] **CHANGE-048** in `claudedocs/4-changes/feature-changes/`
+- [ ] **progress.md** Day 0-4 (incl. Day 3 real-LLM evidence) + **retrospective.md** Q1-Q7
+- [ ] **Checklist** all `[x]` (note any 🚧 carryover with reason)
+- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio)
+- [ ] **AD status**: `AD-Chat-RealLLM-Orphan-Tool-Message` CLOSED; next-phase-candidates.md updated
+- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [ ] **Design note?** — NO (feature-continuation / bug fix; no new contract / no 17.md change)
+
+### 4.3 Ship
+- [ ] **Commit mapping** Day-0 / fix+tests / closeout
+- [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
@@ -59,16 +59,21 @@
 ## Day 3 — real-LLM Azure verification (US-4) — user `.env`
 
 ### 3.1 clean restart + startup log (Risk Class E)
-- [ ] **clean start backend** — kill stale `--reload` workers on :8000; confirm port sole-owner (no Errno 10048); started fresh
-- [ ] **confirm startup log** `pricing loader wired` (FIX-022 wiring fired)
+- [x] **clean start backend** — :8000 was free (no stale process); started fresh single no-reload uvicorn
+- [x] **confirm startup log** `pricing loader wired` (FIX-022 wiring fired)
 
 ### 3.2 real-LLM chat main-flow (local `.env`, NOT GitHub secrets)
-- [ ] **dev-login** → v2_jwt cookie (fresh tenant + clean session — the 57.79 repro condition)
-- [ ] **POST /chat real_llm** `{mode: real_llm, message: "echo hello"}` → **HTTP 200, no orphan-tool 400** + SSE contains `loop_end` + real Azure reply
-- [ ] **cost_ledger write** — newest rows written (row-count Δ≥2); evidence captured
+- [x] **dev-login** → v2_jwt cookie (fresh tenant + clean session — the 57.79 repro condition)
+- [x] **POST /chat real_llm** `{mode: real_llm, message: "echo hello"}` → **HTTP 200, no orphan-tool 400** (`"must follow tool_calls": False`) + SSE contains `loop_end` + real Azure gpt-5.2 reply
+- [x] **cost_ledger write** — newest rows written (delta>0; gpt-5.2 + echo_tool rows); evidence captured
 
 ### 3.3 evidence
-- [ ] **record** SSE outcome + cost row evidence + the exact `response.model` in progress.md Day 3
+- [x] **record** SSE outcome + cost row evidence + the exact `response.model` (gpt-5.2-2025-12-11) in progress.md Day 3
+
+### 3.4 targeted C extension (in-sprint, per Day-3 finding + user decision) — plan §10
+- [x] **targeted C fix** in `build()` — pending tool turn (`transient.messages[-1].role == "tool"`) → full conversation + `user_message=None` → prompt ends with tool result; fresh turn unchanged
+- [x] **+2 unit tests** — pending tool turn ends with `tool` (user still in history); fresh turn still ends with `user` (no regression). 71 passed.
+- [x] **re-verify real Azure CONVERGED** — `loop_end stop_reason=end_turn` (was `max_turns`); final `content="hello"`; last `prompt_built messages_count=5` ends with tool. mypy clean.
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
@@ -80,19 +80,19 @@
 ## Day 4 — Sweep + Closeout
 
 ### 4.1 Full sweep
-- [ ] **Backend gates** — `mypy src/` 0 + `pytest` (new + regression, expect +~8) + `python scripts/lint/run_all.py` 10/10 (check_llm_sdk_leak green; check_rls_policies unchanged — no schema)
-- [ ] **No frontend** — 0 frontend changes (backend-only sprint)
-- [ ] **Read all changed code** — builder fix LLM-neutral + identity-rebuild correct; tests assert the structural invariant (not mock-reliant)
+- [x] **Backend gates** — `mypy src/` 0 (331) + `pytest` 2130 passed / 4 skipped (+9 vs 2121) + `python scripts/lint/run_all.py` 10/10 (check_llm_sdk_leak green; check_promptbuilder_usage green; check_rls_policies unchanged — no schema)
+- [x] **No frontend** — 0 frontend changes (backend-only sprint)
+- [x] **Read all changed code** — builder B (adjacency, LLM-neutral, identity-rebuild) + C (pending-tool-turn re-anchor suppression); tests assert the structural invariant (not mock-reliant); no strategy/loop/adapter touched
 
 ### 4.2 Closeout docs
-- [ ] **CHANGE-048** in `claudedocs/4-changes/feature-changes/`
-- [ ] **progress.md** Day 0-4 (incl. Day 3 real-LLM evidence) + **retrospective.md** Q1-Q7
-- [ ] **Checklist** all `[x]` (note any 🚧 carryover with reason)
-- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio)
-- [ ] **AD status**: `AD-Chat-RealLLM-Orphan-Tool-Message` CLOSED; next-phase-candidates.md updated
-- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
-- [ ] **Design note?** — NO (feature-continuation / bug fix; no new contract / no 17.md change)
+- [x] **FIX-027** in `claudedocs/4-changes/bug-fixes/` (bug fix — orphan-tool is a broken main-flow, not a CHANGE)
+- [x] **progress.md** Day 0-3.5 (incl. Day 3 real-LLM evidence + C re-verify) + **retrospective.md** Q1-Q7
+- [x] **Checklist** all `[x]` (no 🚧 carryover — the e2e leg blocked in 57.79 is now verified)
+- [x] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio in retro Q2)
+- [x] **AD status**: `AD-Chat-RealLLM-Orphan-Tool-Message` CLOSED; next-phase-candidates.md updated
+- [x] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [x] **Design note?** — NO (bug fix; no new contract / no 17.md change)
 
 ### 4.3 Ship
-- [ ] **Commit mapping** Day-0 / fix+tests / closeout
+- [x] **Commit mapping** Day-0 (`7f8f152a`) / B fix+tests (`29879147`) / Day-3 + C fix (`37591545`) / closeout (pending)
 - [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-checklist.md
@@ -24,35 +24,35 @@
 ## Day 1 — Tool-call adjacency invariant (US-1/US-2)
 
 ### 1.1 `_enforce_tool_adjacency` static method
-- [ ] **add `_enforce_tool_adjacency(messages) -> list[Message]`** in `builder.py` (DefaultPromptBuilder)
+- [x] **add `_enforce_tool_adjacency(messages) -> list[Message]`** in `builder.py` (DefaultPromptBuilder)
   - build `owner_by_id` (ToolCall.id → emitting assistant); no-op return when no assistant carries tool_calls
   - bucket `role='tool'` msgs (resolved owner) under `id(owner)`, preserve order, mark held; unresolved-owner tool left in place (no silent drop)
   - rebuild: skip held tools; after each assistant emit its held tools → tool always directly after owning assistant
   - DoD: mypy clean ✅; docstring states the provider hard-constraint + orphan-left-in-place rationale
 
 ### 1.2 call site in build()
-- [ ] **insert `messages = self._enforce_tool_adjacency(messages)`** immediately after `messages = strategy.arrange(sections)` (`builder.py:269`)
-  - DoD: mypy clean; no other build() logic changed; MHist 1-line entry added to builder.py header
+- [x] **insert `messages = self._enforce_tool_adjacency(messages)`** immediately after `messages = strategy.arrange(sections)` (`builder.py:269`)
+  - DoD: mypy clean ✅; no other build() logic changed; MHist 1-line entry added to builder.py header
 
 ### 1.3 read changed code
-- [ ] **re-read** builder.py change — confirm no strategy / loop / adapter touched; LLM-neutral (only neutral `Message` contract used); identity-rebuild correct
+- [x] **re-read** builder.py change — confirm no strategy / loop / adapter touched; LLM-neutral (only neutral `Message` contract used); identity-rebuild correct
 
 ---
 
 ## Day 2 — Tests (US-3)
 
 ### 2.1 unit: `_enforce_tool_adjacency` + build()-through-LostInMiddle
-- [ ] **NEW `test_builder_tool_adjacency.py`** in `tests/unit/agent_harness/prompt_builder/`
+- [x] **NEW `test_builder_tool_adjacency.py`** in `tests/unit/agent_harness/prompt_builder/`
   - (a) tool already after assistant → unchanged; (b) tool before assistant (bug shape) → re-anchored after; (c) 2 assistants × 1 tool scrambled → each tool after own assistant; (d) orphan tool (no owner) → left in place; (e) no tool msgs → unchanged
-  - `build()` through default `LostInMiddleStrategy`: state.transient.messages = `[system, user, assistant(tool_calls), tool]` → assert `artifact.messages` tool immediately after assistant (the case that 400s pre-fix)
+  - `build()` through default `LostInMiddleStrategy`: state.transient.messages = `[system, user, assistant(tool_calls), tool]` → assert `artifact.messages` tool immediately after assistant (the case that 400s pre-fix). 6 pass.
 
 ### 2.2 integration: loop+builder 2-turn tool script (AP-10 closure)
-- [ ] **extend `test_loop_with_prompt_builder.py`** — 2-turn MockChatClient (turn1 tool_calls → turn2 END_TURN) + tool executor returning a result + registry exposing the tool + prompt_builder injected
+- [x] **extend `test_loop_with_prompt_builder.py`** — 2-turn MockChatClient (turn1 tool_calls → turn2 END_TURN) + tool executor returning a result + registry exposing the tool + prompt_builder injected
   - after run, assert `chat_client.last_request.messages` (turn-2 assembly) has every `role='tool'` immediately after its owning `assistant(tool_calls)`
-  - DoD: test FAILS on pre-fix builder (regression guard confirmed) → PASSES with fix
+  - DoD: ✅ regression guard CONFIRMED — temporarily disabled the `_enforce_tool_adjacency` call → build() test FAILED `assistant@4, tool@3` (exactly the real Azure `messages[3]` 400 shape) → restored → PASSES
 
 ### 2.3 regression gate
-- [ ] **targeted pytest** — `pytest tests/unit/agent_harness/prompt_builder/ tests/integration/agent_harness/prompt_builder/` green; confirm pre-existing builder/strategy tests unchanged (LostInMiddle strategy untouched → its own tests still pass)
+- [x] **targeted pytest** — `pytest tests/unit/agent_harness/prompt_builder/ tests/integration/agent_harness/prompt_builder/` 69 passed; pre-existing builder/strategy tests unchanged (LostInMiddle strategy untouched → its own tests still pass)
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
@@ -1,0 +1,164 @@
+# Sprint 57.80 Plan — chat real_llm orphan-tool-message fix (PromptBuilder tool-call adjacency invariant) (closes AD-Chat-RealLLM-Orphan-Tool-Message)
+
+**Branch**: `feature/sprint-57-80-orphan-tool-adjacency` (from `main` `88911c95`)
+**Closes**: `AD-Chat-RealLLM-Orphan-Tool-Message` — the pre-existing real_llm chat 400 surfaced by the Sprint 57.79 Day-3 real-LLM run (it blocked the chat-router e2e leg; 57.79 bypassed it via the direct cost_ledger record path).
+**Scope**: Backend (Cat 5 PromptBuilder tool-call adjacency invariant) + real-LLM Azure verification (user `.env` has live key). NOT frontend; NOT a strategy rewrite.
+
+---
+
+## 0. Background
+
+Sprint 57.79 Day-3 real-LLM run found that `POST /api/v1/chat/` in `mode=real_llm` returns a 400 from Azure: **`messages[3] role 'tool' must follow tool_calls`** (orphan tool message). A fresh tenant + clean session reproduces it (`messages_count:4`), proving it is NOT session-history pollution — it is a per-turn prompt-assembly defect on the real_llm path. 57.79 logged it as carryover `AD-Chat-RealLLM-Orphan-Tool-Message` and bypassed it (the billing fix was verified at the DB level via the direct `CostLedgerService.record_llm_call` path instead of the full chat router). This sprint fixes the root cause and re-verifies the chat main-flow against real Azure.
+
+**User decision (AskUserQuestion, 2026-06-04)**: fix approach **B** (builder-level tool-call adjacency invariant) AND run real Azure e2e re-verification of the chat main flow this sprint.
+
+### Day-0 ground-truth (parent grep + code read, main `88911c95`)
+- **D-DAY0-1 (real_llm uses artifact.messages, echo_demo does not)**: the loop sends `chat_messages = list(messages)` when no prompt_builder (`loop.py:982`), but `chat_messages = list(artifact.messages)` (`loop.py:1052`) when a prompt_builder is injected. `build_real_llm_handler` injects `DefaultPromptBuilder` (`handler.py:258`, keystone Sprint 57.64); `build_echo_demo_handler` does NOT. ⇒ the bug is real_llm-only (echo_demo bypasses the builder and keeps the loop's correct chronological order) — matches the carryover's "real_llm mode" note.
+- **D-DAY0-2 (root cause — LostInMiddleStrategy splits assistant from its tool result)**: `DefaultPromptBuilder.build()` (`builder.py:269`) calls `strategy.arrange(sections)`; the default strategy is `LostInMiddleStrategy` (`builder.py:200`). Its `arrange()` (`lost_in_middle.py:64-76`) splits the conversation into `recent_assistants` (last N assistant messages, appended at the **tail**) vs `mid_history` (everything else, incl. the `role='tool'` results, appended **before** the recent assistants). For a tool-calling turn `[system, user, assistant(tool_calls), tool]` this yields `[new_system, echo, old_system, tool, assistant(tool_calls), user]` — the `tool` (idx 3) precedes its `assistant` (idx 4), violating the OpenAI/Azure hard constraint that a `role='tool'` message MUST immediately follow the `assistant` bearing the matching `tool_calls`. `messages[3]=tool` exactly matches the reported 400.
+- **D-DAY0-3 (other strategies preserve order)**: `NaiveStrategy` (`naive.py:32`) + `ToolsAtEndStrategy` (`tools_at_end.py:37`) both `result.extend(sections.conversation)` in original order ⇒ they do NOT orphan tool results. The bug is specific to `LostInMiddleStrategy` (the default on the chat path). (The user-message re-anchor-to-tail is shared by all three, but `user` after `tool` is valid for OpenAI — not a 400; out of scope per approach B.)
+- **D-DAY0-4 (Message contract carries the linkage)**: `Message` (`_contracts/chat.py:76-95`) has `tool_calls: list[ToolCall] | None` (on assistant) + `tool_call_id: str | None` (on tool); `ToolCall.id: str` (`chat.py:67-72`). The loop builds `Message(role="assistant", tool_calls=parsed.tool_calls)` (`loop.py:1329-1335`) and `Message(role="tool", tool_call_id=tc.id, ...)` (`loop.py:1373-1379`). ⇒ adjacency can be enforced by matching `tool_msg.tool_call_id` → `assistant.tool_calls[*].id`. Strategies rearrange the same Message object references (no copy), so object identity is stable for the rebuild.
+- **D-DAY0-5 (why invisible until real Azure — AP-10 + AP-4)**: the existing loop+builder integration tests (`test_loop_with_prompt_builder.py`) only run **single-turn, no-tool** scripts (`_final_response()` returns END_TURN immediately) AND use `MockChatClient`, which returns scripted responses **without validating message adjacency** (`mock_clients.py:93-109`). So the malformed turn-2 ordering was never assembled in a test, and even if it were, the mock would not reject it. Only the real Azure adapter enforces the constraint. Classic AP-10 (mock vs real divergence) + AP-4 (no negative coverage of the tool-turn assembly).
+- **D-DAY0-6 (test capture point exists)**: `MockChatClient.last_request: ChatRequest` (`mock_clients.py:88,101`) retains the most recent call; `ChatRequest.messages` carries the assembled list. After a 2-turn (tool then final) run, `last_request.messages` = the turn-2 assembly (the one that 400s today) ⇒ a regression test can assert adjacency on it with NO test-infra change.
+- **D-DAY0-7 (config.model_name already aligned)**: Sprint 57.79 added `.env` `AZURE_OPENAI_MODEL_NAME=gpt-5.2` (deployment returns `gpt-5.2-2025-12-11`); the gpt-5.x `max_completion_tokens` adapter param + pricing normalize are already live (#245). ⇒ Day-3 real-LLM verify of the chat router should now exercise the full corrected path (no 400 from this fix, no 400 from token cap, cost_ledger priced).
+
+---
+
+## 1. Sprint Goal
+
+Make tool-call adjacency a hard invariant of `DefaultPromptBuilder.build()` so that no PositionStrategy (current or future) can emit a `role='tool'` message that does not immediately follow its owning `assistant(tool_calls)` — closing the real_llm chat 400 — then re-verify the chat main flow against real Azure (no 400 + `loop_end` + cost_ledger priced).
+
+---
+
+## 2. User Stories
+
+- **US-1** — 作為平台使用者，我希望 `POST /chat` 在 `real_llm` 模式下的多輪工具呼叫不再回 400，以便 real_llm 聊天主流量真正可用（不再被 orphan-tool message 擋住）。
+- **US-2** — 作為 Cat 5 維護者，我希望 tool-call 相鄰性是 PromptBuilder 的不變式（單一強制點），以便任何 PositionStrategy（含未來新增）都不會破壞 provider 的硬約束。
+- **US-3** — 作為 QA，我希望 unit + 整合測試覆蓋「tool-turn 經 builder 組裝後 tool 緊跟其 assistant」，以便回歸保護（關閉 AP-10/AP-4 測試缺口：既有測試從不跑 tool-turn 經 builder，且 mock 不驗 adjacency）。
+- **US-4** — 作為 release owner，我希望實際 real-LLM Azure 驗證 chat router `real_llm` 端到端（無 400 + SSE `loop_end` + cost_ledger 寫入），以便確認 orphan-tool 修好後 chat 主流量真的通（非僅 mock）。
+
+---
+
+## 3. Technical Specifications
+
+### 3.0 Architecture
+Single backend fix in Cat 5 (`prompt_builder/builder.py`) + a real-LLM verification leg. The fix is a post-`arrange()` normalization pass inside `build()` — a single enforcement point (AP-8 philosophy) that protects ALL strategies. It does NOT modify any PositionStrategy (LostInMiddle stays a pure "lost-in-middle" arranger; the builder corrects the tool-adjacency it cannot know about). LLM-neutral: operates only on the neutral `Message` contract (no provider import). Does NOT touch `loop.py`, the adapters layer, or the strategies.
+
+### 3.1 Tool-call adjacency invariant (US-1/US-2) — `prompt_builder/builder.py`
+- New private static method `_enforce_tool_adjacency(messages: list[Message]) -> list[Message]`:
+  - Build `tool_calls_by_id: dict[str, Message]` mapping each `ToolCall.id` → the assistant message that emitted it (scan `m.role == "assistant" and m.tool_calls`).
+  - If no assistant carries tool_calls → return `messages` unchanged (no tool turn; zero overhead for plain chat).
+  - Bucket every `role='tool'` message (with a non-None `tool_call_id` that resolves to an owner) under `id(owner_assistant)`, preserving their relative order; mark them "held".
+  - A tool message whose `tool_call_id` resolves to no owner (defensive — should not happen on the loop path; e.g. an assistant dropped by future compaction) is left in place (NOT dropped — never silently lose a message).
+  - Rebuild: iterate the arranged list; skip held tool messages; after appending each assistant, immediately append its held tool messages. ⇒ every tool ends up directly after its owning assistant, all other ordering preserved.
+  ```python
+  @staticmethod
+  def _enforce_tool_adjacency(messages: list[Message]) -> list[Message]:
+      owner_by_id: dict[str, Message] = {}
+      for m in messages:
+          if m.role == "assistant" and m.tool_calls:
+              for tc in m.tool_calls:
+                  owner_by_id[tc.id] = m
+      if not owner_by_id:
+          return messages
+      held_tools: dict[int, list[Message]] = {}
+      held_ids: set[int] = set()
+      for m in messages:
+          if m.role == "tool" and m.tool_call_id is not None:
+              owner = owner_by_id.get(m.tool_call_id)
+              if owner is not None:
+                  held_tools.setdefault(id(owner), []).append(m)
+                  held_ids.add(id(m))
+      if not held_ids:
+          return messages
+      result: list[Message] = []
+      for m in messages:
+          if id(m) in held_ids:
+              continue
+          result.append(m)
+          if m.role == "assistant" and id(m) in held_tools:
+              result.extend(held_tools[id(m)])
+      return result
+  ```
+- Call site: in `build()` immediately after `messages = strategy.arrange(sections)` (`builder.py:269`):
+  ```python
+  messages = strategy.arrange(sections)
+  messages = self._enforce_tool_adjacency(messages)
+  ```
+- **Design rationale**: builder-level (single enforcement) chosen over fixing LostInMiddleStrategy in isolation (Approach A) — tool-call adjacency is a hard provider constraint that NO strategy should be able to violate; enforcing once centrally protects current + future strategies and matches AP-8 (centralized prompt assembly). Approach C (also stop the user-message re-anchor for tool turns) rejected for scope: `user` after `tool` is valid for OpenAI (not a 400) and the re-anchor is the deliberate lost-in-middle design — out of scope for an orphan-tool 400 fix.
+
+### 3.2 Tests (US-3) — NEW `test_builder_tool_adjacency.py` + extend integration test
+- NEW `backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py`:
+  - `_enforce_tool_adjacency` direct unit cases: (a) tool already after its assistant → unchanged; (b) tool reordered before its assistant (the bug shape) → re-anchored after; (c) two assistants each with one tool, interleaved/scrambled → each tool ends after its own assistant; (d) orphan tool (tool_call_id with no owner) → left in place; (e) no tool messages → unchanged (identity / same list).
+  - `build()` end-to-end through `LostInMiddleStrategy`: feed a `LoopState` whose `transient.messages` = `[system, user, assistant(tool_calls), tool]`; assert the returned `artifact.messages` has the `tool` immediately after the `assistant(tool_calls)` (this is the case that 400s today before the fix).
+- EXTEND `backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py`:
+  - NEW test: a 2-turn `MockChatClient` script — turn 1 returns a `tool_calls` response (echo-style), turn 2 returns END_TURN — run the loop with `prompt_builder` injected + a tool executor that returns a result + a registry exposing the tool. After the run, assert `chat_client.last_request.messages` (the turn-2 assembly) has every `role='tool'` immediately after its owning `assistant(tool_calls)`. This is the AP-10 closure: it exercises the FULL Cat1→Cat5 chain on a tool turn and asserts the structural invariant (not relying on the mock to reject).
+
+### 3.3 real-LLM verification (US-4) — manual, user `.env`
+- Clean restart backend (Risk Class E — kill stale `--reload` workers on :8000 first; confirm startup log `pricing loader wired`).
+- `POST /api/v1/auth/dev-login` → v2_jwt cookie → `POST /api/v1/chat/` `{mode: real_llm, message: "echo hello"}` (the DEMO_SYSTEM_PROMPT instructs `echo_tool` use → triggers a tool turn → the previously-400'ing turn-2 assembly).
+- Assert: HTTP 200 (no 400), SSE contains `loop_end`, real Azure reply, `cost_ledger` newest rows written (row-count Δ≥2). Fresh tenant + clean session (the 57.79 repro condition).
+- Record the SSE outcome + cost row evidence in progress.md Day 3.
+
+### 3.4 Lint / validation
+`mypy src/` + `pytest` (new + regression) + `python scripts/lint/run_all.py` (10/10 — no schema change, no LLM-SDK leak: the fix uses only the neutral `Message` contract). NO frontend / migration / wire-schema / ORM change.
+
+---
+
+## 4. File Change List
+
+**NEW (1)**
+- `backend/tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py` (adjacency unit + build()-through-LostInMiddle case)
+
+**EDIT (2)**
+- `backend/src/agent_harness/prompt_builder/builder.py` (`_enforce_tool_adjacency` static method + 1 call site in `build()` after `strategy.arrange()`)
+- `backend/tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py` (NEW 2-turn tool-script test asserting `last_request.messages` adjacency)
+
+**NO frontend / migration / wire-schema / ORM / strategy / loop / adapter change.**
+
+---
+
+## 5. Acceptance Criteria
+
+- `_enforce_tool_adjacency` re-anchors every `role='tool'` message immediately after its owning `assistant(tool_calls)`, preserves all other order, leaves orphan tools in place, and is a no-op when no tool turn exists — verified by unit tests (a)-(e).
+- `DefaultPromptBuilder.build()` through `LostInMiddleStrategy` emits a valid sequence (tool after assistant) for a `[system, user, assistant(tool_calls), tool]` conversation.
+- The loop+builder integration test (2-turn tool script) asserts `chat_client.last_request.messages` has tool-after-assistant adjacency; the test would FAIL on the pre-fix builder (regression guard).
+- real-LLM chat (`mode=real_llm`, fresh tenant): HTTP 200 (no orphan-tool 400), SSE `loop_end`, cost_ledger rows written.
+- Gates: backend mypy 0 + pytest (new + regression) green + run_all 10/10. No frontend.
+
+---
+
+## 6. Deliverables
+
+- [ ] `_enforce_tool_adjacency` static method + call site in `build()` after `strategy.arrange()`
+- [ ] Unit tests: `_enforce_tool_adjacency` (a)-(e) + `build()`-through-LostInMiddle tool-turn case
+- [ ] Integration test: loop+builder 2-turn tool script asserting `last_request.messages` adjacency (AP-10 closure)
+- [ ] real-LLM Azure verification (clean restart + `pricing loader wired` + `POST /chat` real_llm no-400 + SSE loop_end + cost_ledger write) — evidence in progress.md Day 3
+- [ ] All gates green; closeout (CHANGE-048 + progress + retro + MEMORY + CLAUDE lean; AD CLOSED → chat real_llm main-flow unblocked)
+
+---
+
+## 7. Workload Calibration
+
+Scope class `medium-backend` (0.80 — one focused Cat 5 fix + tests + real-LLM verification leg; same shape as 57.79). **Agent-delegated: no** (parent-direct — message-assembly correctness needs care + real-LLM verification is a parent/user collaboration). `agent_factor` = 1.0 → 3-segment form.
+
+Bottom-up est ~5.5 hr (fix ~1.5 + unit tests ~1.5 + integration test ~0.5 + real-LLM verify ~1 + closeout ~1) → class-calibrated commit ~4.4 hr (mult 0.80).
+
+---
+
+## 8. Dependencies & Risks
+
+- **Dependency D1 (live Azure `.env`)**: real-LLM verification (§3.3) needs the user's local `.env` with a working `AZURE_OPENAI_*` key + `AZURE_OPENAI_MODEL_NAME=gpt-5.2` (added Sprint 57.79). User confirmed available.
+- **Risk Class E (stale `--reload` masks the fix)**: real-LLM verify must clean-restart backend (kill stale reloader+worker on :8000, confirm `pricing loader wired` startup log) — a stale process running pre-fix code gives a false negative. Per `sprint-workflow.md §Common Risk Classes E`.
+- **Risk: object-identity rebuild assumption**: `_enforce_tool_adjacency` matches owners by `id(message)`. This holds because strategies rearrange the same Message references (no copy) — verified D-DAY0-4. If a future strategy deep-copies messages, identity breaks; mitigation: the unit test feeds the real `LostInMiddleStrategy` output (catches a copy regression), and the fallback (tool with unresolved owner left in place) degrades safely rather than crashing.
+- **Risk: orphan tool left in place could still 400**: if a tool's owning assistant is genuinely absent (not the loop's normal flow), leaving it in place keeps the 400. Accepted: the loop always emits the assistant before its tool (D-DAY0-4), so this cannot occur on the main path; dropping a message silently would be worse (AP — no silent data loss). Documented in the method docstring.
+- **Risk: real-LLM verify hits a DIFFERENT pre-existing issue**: if the chat router 400 had a second cause beyond ordering, the real run would still fail. Mitigation: the unit + integration tests prove the assembly is now valid independently; if real Azure still 400s for another reason, that is a new finding (logged separately) and the structural fix still stands.
+- **Dependency**: PromptBuilder keystone wiring (Sprint 57.64) + real_llm handler + cost_ledger record path (56.3) all live (#245). No new infra.
+
+---
+
+## 9. Out of Scope (this sprint; carryover)
+
+- **PositionStrategy user-message re-anchor for tool turns** (Approach C) — `user` after `tool` is valid (not a 400); the re-anchor is the deliberate lost-in-middle design. Not changed this sprint.
+- **B-7 ErrorBudget Redis wiring** / **B-8 Verification default-enable** / **C-15 DevOps billing** — the billing/verification bundle; separate sprints.
+- **GitHub Secrets + scheduled e2e gate** (`AD-CI-6`) — real-LLM CI stays manual workflow_dispatch + local `.env`; production-launch concern.
+- **Conversation compaction interaction with tool turns** — Cat 4 compaction dropping an assistant while keeping its tool is a separate (currently non-occurring) concern; the adjacency invariant degrades safely if it ever happens, but compaction-aware tool grouping is not designed here.

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
@@ -133,7 +133,7 @@ Single backend fix in Cat 5 (`prompt_builder/builder.py`) + a real-LLM verificat
 - [ ] Unit tests: `_enforce_tool_adjacency` (a)-(e) + `build()`-through-LostInMiddle tool-turn case
 - [ ] Integration test: loop+builder 2-turn tool script asserting `last_request.messages` adjacency (AP-10 closure)
 - [ ] real-LLM Azure verification (clean restart + `pricing loader wired` + `POST /chat` real_llm no-400 + SSE loop_end + cost_ledger write) — evidence in progress.md Day 3
-- [ ] All gates green; closeout (CHANGE-048 + progress + retro + MEMORY + CLAUDE lean; AD CLOSED → chat real_llm main-flow unblocked)
+- [ ] All gates green; closeout (FIX-027 [bug fix, not CHANGE — orphan-tool is a broken main-flow] + progress + retro + MEMORY + CLAUDE lean; AD CLOSED → chat real_llm main-flow unblocked)
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-80-plan.md
@@ -162,3 +162,19 @@ Bottom-up est ~5.5 hr (fix ~1.5 + unit tests ~1.5 + integration test ~0.5 + real
 - **B-7 ErrorBudget Redis wiring** / **B-8 Verification default-enable** / **C-15 DevOps billing** — the billing/verification bundle; separate sprints.
 - **GitHub Secrets + scheduled e2e gate** (`AD-CI-6`) — real-LLM CI stays manual workflow_dispatch + local `.env`; production-launch concern.
 - **Conversation compaction interaction with tool turns** — Cat 4 compaction dropping an assistant while keeping its tool is a separate (currently non-occurring) concern; the adjacency invariant degrades safely if it ever happens, but compaction-aware tool grouping is not designed here.
+
+---
+
+## 10. In-Sprint Scope Extension — targeted C (added 2026-06-04, supersedes §9 "Approach C out of scope" for the pending-tool-turn slice)
+
+**Trigger**: Day-3 real-LLM run found that B alone (the adjacency invariant) removed the 400 but the chat then looped to `max_turns` (`stop_reason=max_turns total_turns=8`) — the model re-called echo_tool every turn and never converged. **Root cause (confirmed by code)**: every PositionStrategy appends `sections.user_message` at the tail (`lost_in_middle.py:79-80` etc.) and `_enforce_tool_adjacency` does not move it, so on a tool turn the assembled prompt ALWAYS ends with the user message (after the tool result). The model treats the re-anchored "echo hello" as a fresh request each turn → re-calls the tool. §9's framing of C as "valid, not a 400, cosmetic" was an under-assessment: the re-anchor is functionally required for tool-calling chat to CONVERGE.
+
+**User decision (AskUserQuestion, 2026-06-04)**: extend this sprint with a targeted C fix.
+
+**Targeted C fix** (`builder.py` `build()`, builder-level — same single-enforcement philosophy as B): detect a PENDING tool turn (`state.transient.messages[-1].role == "tool"`) → pass the full conversation in chronological order + `user_message=None` (no tail re-anchor, no top echo) so the prompt ends with the tool result and the model produces its final answer. A normal (non-tool / fresh) turn is unchanged (keeps the lost-in-middle echo + tail re-anchor). No strategy / loop / adapter change.
+
+**Verification**: re-ran real Azure (fresh tenant) → `loop_end stop_reason=end_turn` (was `max_turns`), final `llm_response content="hello" tool_calls=[]`, last `prompt_built messages_count=5` = `[new_system, old_system, user, assistant(tool_calls), tool]` (ends with tool). Tests +2 (pending-tool-turn ends with tool; fresh turn still ends with user).
+
+**File change delta vs §4**: still only `builder.py` (EDIT — the C conditional added alongside the B method) + `test_builder_tool_adjacency.py` (EDIT — +2 C tests). No new files beyond §4.
+
+**Remaining out of scope**: B-7 / B-8 / C-15 billing bundle; GitHub Secrets e2e gate; compaction×tool-turn interaction.


### PR DESCRIPTION
## Summary
Closes `AD-Chat-RealLLM-Orphan-Tool-Message` (the Sprint 57.79 carryover). `POST /api/v1/chat/` in `mode=real_llm` returned a 400 from Azure on every tool-calling turn — **`messages[3] role 'tool' must follow tool_calls`** (orphan tool message) — blocking the real_llm chat main flow.

## Root cause
The real_llm path injects `DefaultPromptBuilder` (keystone 57.64), so the loop sends `artifact.messages` (`loop.py:1052`), not its own ordered `messages`. The default `LostInMiddleStrategy.arrange()` splits the conversation into `recent_assistants` (appended at the tail) vs `mid_history` (incl. `role='tool'` results, appended before) → for `[system, user, assistant(tool_calls), tool]` it produced `[…, tool, assistant(tool_calls), user]`, putting the tool before its owning assistant. `naive` / `tools_at_end` preserve order → unaffected; echo_demo has no builder → unaffected.

Invisible until real Azure: the loop+builder tests only ran single-turn-no-tool scripts AND `MockChatClient` does not validate adjacency (**AP-10** mock-vs-real divergence + **AP-4** no negative coverage of the tool-turn assembly).

## Fix (backend-only, Cat 5, builder-level single enforcement — AP-8, LLM-neutral)
- **B** — `DefaultPromptBuilder._enforce_tool_adjacency(messages)`, called in `build()` right after `strategy.arrange()`: re-anchors every `role='tool'` message immediately after its owning `assistant(tool_calls)` (matched by `tool_call_id`), preserves all other order, leaves an orphan tool in place (no silent drop), no-op when no tool turn. Protects all strategies (current + future); `LostInMiddleStrategy` untouched.
- **C** (in-sprint extension, user-approved) — pending-tool-turn user re-anchor suppression: when the conversation ends with a tool result (`transient.messages[-1].role == "tool"`), pass the full conversation in order + `user_message=None` so the prompt ends with the tool result and the model produces its final answer. Fresh / non-tool turns unchanged.

The real-LLM run forced C: B-only returned 200 but `stop_reason=max_turns` (the model re-called the tool every turn because the re-anchored user message sat at the tail); C makes it converge.

## Verification
- **Real Azure** (gpt-5.2, fresh tenant): HTTP 200, no `must follow tool_calls`, SSE `loop_end stop_reason=end_turn` (was `max_turns`), last `prompt_built messages_count=5` ending with the tool result, cost_ledger rows written.
- **Regression guard proven**: temporarily disabling the invariant → the build()-through-LostInMiddle test FAILED `assistant@4, tool@3` (the exact real Azure 400 shape) → restored.
- **Gates**: `mypy src/` 0 (331) + `pytest` 2130 passed / 4 skipped (+9) + `python scripts/lint/run_all.py` 10/10. No frontend / migration / schema / contract change.

## Tests
- NEW `tests/unit/agent_harness/prompt_builder/test_builder_tool_adjacency.py` (5 `_enforce` cases + build()-through-LostInMiddle adjacency + 2 pending-vs-fresh re-anchor).
- Extended `tests/integration/agent_harness/prompt_builder/test_loop_with_prompt_builder.py` (2-turn tool script asserts `last_request.messages` adjacency — AP-10 closure).

Change record: `claudedocs/4-changes/bug-fixes/FIX-027-chat-real-llm-orphan-tool-message.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)