### PR TITLE
feat(sprint-57-81): B-7 ErrorBudget Redis wiring — wire the already-built RedisBudgetStore (closes B-7 / AD-ErrorBudget-Redis-Wiring)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Build enterprise AI agent teams that work like **human professional teams** — 
 | Attribute | Value |
 |-----------|-------|
 | **Phase** | V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend ongoing (Phase 57+) |
-| **Current Sprint** | Sprint 57.80 (PR pending) — **chat real_llm orphan-tool-message fix** (closes `AD-Chat-RealLLM-Orphan-Tool-Message`, the 57.79 carryover): builder-level tool-call adjacency invariant (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B) + pending-tool-turn user re-anchor suppression (in-sprint fix C). `LostInMiddleStrategy` orphaned tool results → real_llm 400; fix unblocks the real_llm main flow. Real Azure verified: 200 + `stop_reason=end_turn` (was max_turns) + cost_ledger written. backend mypy 0/331 + pytest 2130 + run_all 10/10; backend-only Cat 5, no design note. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
+| **Current Sprint** | Sprint 57.81 (PR pending) — **B-7 ErrorBudget Redis wiring** (closes B-7 / `AD-ErrorBudget-Redis-Wiring`): wire the already-built `RedisBudgetStore` (Sprint 53.2, never wired — AP-2) via NEW `platform_layer/governance/error_budget_provider` singleton + `_wire_error_budget()` startup (fail-open) + chat factory swap. Fixes the per-request `InMemoryBudgetStore` reset (budget was non-functional) + cross-instance correctness; pure Redis, agent_harness stays DI-pure. Verified: fakeredis accumulation + startup-log `error budget store wired` (no real-Azure — budget increments on errors only). backend mypy 0/332 + pytest 2137 + run_all 10/10; backend-only Cat 8, no design note. Detail: `memory/project_phase57_81_errorbudget_redis_wiring.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
 | **Sprint History** | See [`memory/MEMORY.md`](memory/MEMORY.md) §Recent Sprints + per-sprint subfile `memory/project_phase57_XX_*.md` + retrospective.md under `docs/03-implementation/agent-harness-execution/phase-57/sprint-57-XX/` |
 | **Pending / Next Phase** | See [`claudedocs/1-planning/next-phase-candidates.md`](claudedocs/1-planning/next-phase-candidates.md) |
 | **Roadmap** | Phase 49-55 V2 ✅ / Phase 56-58 SaaS Stage 1 3/3 ✅ / Phase 57+ Frontend ongoing |
@@ -586,7 +586,7 @@ V1 完整 CLAUDE.md 已保留於 `CLAUDE.backup.md`。如需查閱 V1 架構（M
 
 ---
 
-**Last Updated**: 2026-06-04 (Sprint 57.80 — chat real_llm orphan-tool-message fix: builder-level tool-call adjacency invariant + pending-tool-turn user re-anchor suppression, closes AD-Chat-RealLLM-Orphan-Tool-Message; real Azure verified 200 + stop_reason=end_turn; backend-only Cat 5 mypy 0/331 + pytest 2130 + run_all 10/10; FIX-027; PR pending); see `memory/` for sprint history
+**Last Updated**: 2026-06-05 (Sprint 57.81 — B-7 ErrorBudget Redis wiring: wire the already-built RedisBudgetStore via platform_layer/governance singleton + _wire_error_budget() startup + chat factory swap, closes B-7/AD-ErrorBudget-Redis-Wiring; fixes per-request budget reset + cross-instance; verified fakeredis accumulation + startup-log; backend-only Cat 8 mypy 0/332 + pytest 2137 + run_all 10/10; CHANGE-048; PR pending); see `memory/` for sprint history
 **Project Start**: 2025-11-14
 **V2 Authority**: `docs/03-implementation/agent-harness-planning/` (21 docs — 20 規劃 + 1 review)
 **V1 Reference**: `CLAUDE.backup.md` + `docs/07-analysis/V9/00-index.md`

--- a/backend/src/agent_harness/error_handling/__init__.py
+++ b/backend/src/agent_harness/error_handling/__init__.py
@@ -6,6 +6,7 @@ from agent_harness.error_handling._abc import (
     ErrorPolicy,
     ErrorTerminator,
 )
+from agent_harness.error_handling._redis_store import RedisBudgetStore
 from agent_harness.error_handling.budget import (
     BudgetStore,
     InMemoryBudgetStore,
@@ -42,6 +43,7 @@ __all__ = [
     "compute_backoff",
     "BudgetStore",
     "InMemoryBudgetStore",
+    "RedisBudgetStore",
     "TenantErrorBudget",
     "DefaultErrorTerminator",
     "TerminationDecision",

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -24,9 +24,10 @@ Description:
     - Static / CORS config (depends on frontend deploy decision; Phase 55)
 
 Created: 2026-04-29 (Sprint 49.4 Day 5)
-Last Modified: 2026-05-31
+Last Modified: 2026-06-05
 
 Modification History (newest-first):
+    - 2026-06-05: Sprint 57.81 — _wire_error_budget() at startup (B-7 RedisBudgetStore wiring)
     - 2026-06-02: Sprint 57.70 Stage-1b — mount admin_agents router (agent_catalog CRUD)
     - 2026-05-31: FIX-022 — _wire_pricing_loader() at startup (cost_ledger §5.1 H1)
     - 2026-05-10: Sprint 57.13 US-B4 — mount telemetry router (frontend beacons; anonymous)
@@ -154,6 +155,41 @@ def _wire_pricing_loader() -> None:
         )
 
 
+def _wire_error_budget() -> None:
+    """Install the RedisBudgetStore singleton at startup (fail-open).
+
+    Sprint 57.81 (B-7): the chat factory (make_chat_error_deps) builds the Cat 8
+    TenantErrorBudget per request; without a shared store it used a fresh
+    InMemoryBudgetStore each time → counters reset every request (budget
+    effectively non-functional) and never shared across instances. This wires a
+    process-wide RedisBudgetStore from settings.redis_url so the per-tenant
+    error-budget counters accumulate (and are cross-instance correct). The
+    TenantErrorBudget wrapper is stateless — all state lives in this store.
+
+    Fail-open: if Redis is unavailable / misconfigured the store stays None and
+    the factory falls back to InMemoryBudgetStore (budget degrades to per-request
+    rather than blocking startup). Pure Redis — no DB session / RLS needed (the
+    budget keys already carry tenant_id; cf. rate-limit counter's DB write-through
+    which this deliberately does NOT copy).
+    """
+    try:
+        from redis.asyncio import Redis
+
+        from agent_harness.error_handling import RedisBudgetStore
+        from core.config import get_settings
+        from platform_layer.governance.error_budget_provider import set_budget_store
+
+        settings = get_settings()
+        client = Redis.from_url(settings.redis_url)
+        set_budget_store(RedisBudgetStore(client))
+        logger.info("api.main: error budget store wired")
+    except Exception:  # noqa: BLE001 — fail-open: never block startup on error budget
+        logger.warning(
+            "api.main: error budget store not wired; budget per-request (fail-open)",
+            exc_info=True,
+        )
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Startup: load .env + structured logging + OTel SDK. Shutdown: flush + dispose engine."""
@@ -165,6 +201,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     setup_opentelemetry(app)
     _wire_rate_limit_counter()
     _wire_pricing_loader()
+    _wire_error_budget()
     logger.info("api.main: startup complete")
     try:
         yield

--- a/backend/src/api/v1/chat/_category_factories.py
+++ b/backend/src/api/v1/chat/_category_factories.py
@@ -26,9 +26,10 @@ Key Components:
     - make_chat_state_deps(db, session_id, tenant_id) -> (Reducer|None, Checkpointer|None)  (Cat 7)
 
 Created: 2026-05-31 (Sprint 57.63 Day 1)
-Last Modified: 2026-06-01
+Last Modified: 2026-06-05
 
 Modification History (newest-first):
+    - 2026-06-05: Sprint 57.81 — error budget store via maybe_get_budget_store (B-7 wiring)
     - 2026-06-01: Sprint 57.65 — make_chat_prompt_builder accepts real MemoryRetrieval (A-1 Tier2)
     - 2026-06-01: Sprint 57.64 Day 2 — add Cat 3 memory deps + Cat 11 subagent dispatcher factories
     - 2026-06-01: Add make_chat_prompt_builder (Sprint 57.64 Day 1) — Cat 5 keystone factory
@@ -74,6 +75,7 @@ from agent_harness.subagent import DefaultSubagentDispatcher
 from agent_harness.verification import VerifierRegistry
 from agent_harness.verification.llm_judge import LLMJudgeVerifier
 from infrastructure.db.engine import get_session_factory
+from platform_layer.governance.error_budget_provider import maybe_get_budget_store
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -245,16 +247,20 @@ def make_chat_error_deps() -> tuple[
     `_handle_tool_error` (loop.py:265, called at 1157/1225) runs classify → record
     budget → check terminator when these are injected. Defaults match plan §3.3.
 
-    Budget store: InMemoryBudgetStore (per-process; chosen for this sprint).
-    RedisBudgetStore (cross-instance) is deferred — no shared error-budget Redis
-    client is wired yet. tenant_id is passed per-call inside the loop, NOT at
-    construction (see TenantErrorBudget.record/...). The terminator composes the
-    circuit breaker + error budget so all three share one set of counters.
+    Budget store: the process-wide store wired at startup (RedisBudgetStore from
+    settings.redis_url, _wire_error_budget) via maybe_get_budget_store(); falls
+    back to InMemoryBudgetStore when no shared store is wired (dev / test / Redis
+    down). Sprint 57.81 (B-7) closed the prior AP-2 gap where this hardcoded a
+    fresh InMemoryBudgetStore per request — counters reset every request. The
+    TenantErrorBudget wrapper is stateless, so a per-request wrapper over the
+    SHARED store accumulates correctly. tenant_id is passed per-call inside the
+    loop, NOT at construction. The terminator composes the circuit breaker + error
+    budget so all three share one set of counters.
     """
     error_policy: ErrorPolicy = DefaultErrorPolicy()
     retry_policy = RetryPolicyMatrix()
     circuit_breaker = DefaultCircuitBreaker()
-    error_budget = TenantErrorBudget(InMemoryBudgetStore())
+    error_budget = TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())
     error_terminator = DefaultErrorTerminator(
         circuit_breaker=circuit_breaker,
         error_budget=error_budget,

--- a/backend/src/platform_layer/governance/error_budget_provider.py
+++ b/backend/src/platform_layer/governance/error_budget_provider.py
@@ -1,0 +1,85 @@
+"""
+File: backend/src/platform_layer/governance/error_budget_provider.py
+Purpose: Process-wide BudgetStore singleton accessors for the Cat 8 error budget.
+Category: platform_layer / governance (wiring for 範疇 8 Error Handling)
+Scope: Sprint 57.81 (B-7)
+
+Description:
+    Holds the process-global BudgetStore that backs the per-tenant error budget
+    (Cat 8 TenantErrorBudget). api/main.py wires a Redis-backed store here at
+    startup (fail-open); the chat factory (make_chat_error_deps) looks it up via
+    maybe_get_budget_store() and falls back to an InMemoryBudgetStore when unset.
+
+    Why here (platform_layer/governance), not agent_harness?
+      - agent_harness stays DI-pure (no process-global mutable state). The Cat 8
+        BudgetStore Protocol + both impls (InMemory / Redis) live in
+        agent_harness.error_handling; this module only owns the wiring singleton,
+        mirroring the 3 existing wiring singletons (rate_limit_counter / pricing /
+        quota — all in platform_layer). Error budget is a platform-protection
+        policy ("protect platform during incident" — budget.py docstring) → governance.
+
+    Accessors mirror platform_layer/tenant/rate_limit_counter.py (get / maybe_get /
+    set / reset). The BudgetStore type is imported under TYPE_CHECKING only — the
+    Protocol is structural, so the holder needs no runtime agent_harness import.
+
+Key Components:
+    - get_budget_store(): strict accessor (raises if unset)
+    - maybe_get_budget_store(): lenient accessor (None if unset — fail-open callers)
+    - set_budget_store(): install at startup / test fixture
+    - reset_budget_store(): test isolation hook
+
+Owner: 01-eleven-categories-spec.md §Cat 8 + .claude/rules/multi-tenant-data.md
+Created: 2026-06-05 (Sprint 57.81)
+Last Modified: 2026-06-05
+
+Modification History (newest-first):
+    - 2026-06-05: Initial creation (Sprint 57.81) — B-7 wire RedisBudgetStore
+
+Related:
+    - agent_harness/error_handling/budget.py (BudgetStore Protocol + TenantErrorBudget)
+    - agent_harness/error_handling/_redis_store.py (RedisBudgetStore)
+    - api/main.py (_wire_error_budget) / api/v1/chat/_category_factories.py (consumer)
+    - platform_layer/tenant/rate_limit_counter.py (singleton accessor pattern mirrored)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent_harness.error_handling import BudgetStore
+
+
+# === Singleton accessors (mirror rate_limit_counter.py get/set/reset/maybe_get) ===
+_budget_store: BudgetStore | None = None
+
+
+def get_budget_store() -> BudgetStore:
+    """Strict accessor — raises if uninitialised."""
+    if _budget_store is None:
+        raise RuntimeError(
+            "BudgetStore not initialised; call set_budget_store() at app startup "
+            "or in a test fixture"
+        )
+    return _budget_store
+
+
+def maybe_get_budget_store() -> BudgetStore | None:
+    """Lenient accessor — returns None if uninitialised (fail-open callers).
+
+    make_chat_error_deps uses this so dev / test runs without Redis (or before
+    startup wiring) fall back to an InMemoryBudgetStore instead of failing.
+    """
+    return _budget_store
+
+
+def set_budget_store(store: BudgetStore | None) -> None:
+    """Install the singleton (app startup or test fixture)."""
+    global _budget_store
+    _budget_store = store
+
+
+def reset_budget_store() -> None:
+    """Test isolation hook (per testing.md section Module-level Singleton Reset Pattern)."""
+    global _budget_store
+    _budget_store = None

--- a/backend/tests/unit/platform_layer/governance/test_error_budget_provider.py
+++ b/backend/tests/unit/platform_layer/governance/test_error_budget_provider.py
@@ -1,0 +1,112 @@
+"""
+File: tests/unit/platform_layer/governance/test_error_budget_provider.py
+Purpose: Cover the BudgetStore singleton provider + the chat factory wiring (B-7).
+Category: Tests / platform_layer governance + Cat 8 wiring
+Scope: Sprint 57.81
+
+Description:
+    B-7 wires the already-built RedisBudgetStore so the per-tenant error budget
+    accumulates across requests (and instances) instead of resetting per request.
+    These tests cover the singleton accessors + the key correctness claim: two
+    successive make_chat_error_deps() calls (= two requests) over a wired shared
+    store accumulate, whereas the unwired path falls back to InMemoryBudgetStore.
+
+Created: 2026-06-05 (Sprint 57.81)
+Modified: 2026-06-05
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fakeredis.aioredis import FakeRedis
+
+from agent_harness.error_handling import (
+    ErrorClass,
+    InMemoryBudgetStore,
+    RedisBudgetStore,
+    TenantErrorBudget,
+)
+from api.v1.chat._category_factories import make_chat_error_deps
+from platform_layer.governance.error_budget_provider import (
+    get_budget_store,
+    maybe_get_budget_store,
+    reset_budget_store,
+    set_budget_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> object:
+    """Module-level singleton isolation (testing.md §Module-level Singleton Reset)."""
+    reset_budget_store()
+    yield
+    reset_budget_store()
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessors
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_get_returns_none_when_unset() -> None:
+    assert maybe_get_budget_store() is None
+
+
+def test_set_then_maybe_get_returns_it() -> None:
+    store = InMemoryBudgetStore()
+    set_budget_store(store)
+    assert maybe_get_budget_store() is store
+
+
+def test_get_strict_raises_when_unset() -> None:
+    with pytest.raises(RuntimeError):
+        get_budget_store()
+
+
+def test_reset_clears() -> None:
+    set_budget_store(InMemoryBudgetStore())
+    reset_budget_store()
+    assert maybe_get_budget_store() is None
+
+
+# ---------------------------------------------------------------------------
+# Chat factory wiring — the B-7 correctness claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wired_store_accumulates_across_factory_calls() -> None:
+    """Two make_chat_error_deps() calls (= two requests) over ONE wired shared
+    store accumulate the per-tenant counter — the per-request reset is fixed."""
+    store = RedisBudgetStore(FakeRedis(decode_responses=False))
+    set_budget_store(store)
+    tid = uuid4()
+
+    # Request 1: fresh TenantErrorBudget wrapper over the shared store.
+    _, _, _, budget1, _ = make_chat_error_deps()
+    await budget1.record(tid, ErrorClass.TRANSIENT)
+
+    # Request 2: a DIFFERENT wrapper (per-request rebuild) over the SAME store.
+    _, _, _, budget2, _ = make_chat_error_deps()
+    await budget2.record(tid, ErrorClass.TRANSIENT)
+
+    day_count = await store.get(TenantErrorBudget._day_key(tid))
+    assert day_count == 2, "per-request wrappers must share the wired store and accumulate"
+
+
+@pytest.mark.asyncio
+async def test_factory_uses_wired_store_instance() -> None:
+    """make_chat_error_deps binds the wired store (not a fresh InMemory)."""
+    store = RedisBudgetStore(FakeRedis(decode_responses=False))
+    set_budget_store(store)
+
+    _, _, _, budget, _ = make_chat_error_deps()
+    assert budget._store is store
+
+
+def test_factory_falls_back_to_inmemory_when_unwired() -> None:
+    """No wired store → TenantErrorBudget backed by InMemoryBudgetStore (no crash)."""
+    _, _, _, budget, _ = make_chat_error_deps()
+    assert isinstance(budget._store, InMemoryBudgetStore)

--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -36,13 +36,24 @@
 
 ---
 
+## 🆕 Sprint 57.81 Carryover (2026-06-05 — B-7 ErrorBudget Redis wiring; closes B-7 / AD-ErrorBudget-Redis-Wiring)
+
+**Closed**: B-7 / `AD-ErrorBudget-Redis-Wiring` — wiring gap (not missing logic): `RedisBudgetStore` built + fakeredis-tested Sprint 53.2 but never wired (AP-2); `make_chat_error_deps()` hardcoded a fresh `InMemoryBudgetStore()` per request → counters reset every request → budget non-functional even single-instance. Fix Tier 1 (parent-direct, agent_harness DI-pure): NEW `platform_layer/governance/error_budget_provider.py` singleton (mirror rate_limit_counter) + `_wire_error_budget()` startup (fail-open) + export RedisBudgetStore + factory swap `maybe_get_budget_store() or InMemoryBudgetStore()`. Shared store fixes per-request reset AND cross-instance; pure Redis (no DB/RLS). Verified: fakeredis accumulation (2 factory calls → count=2) + startup-log `error budget store wired`; NO real-Azure (budget increments on errors only). backend-only Cat 8; no design note. Detail: `memory/project_phase57_81_errorbudget_redis_wiring.md` + retrospective. CHANGE-048.
+
+### NEW carryovers (this sprint)
+- **error_budgets.yaml per-tenant overrides** — `budget.py` docstring mentions YAML-tunable caps; the factory uses defaults (1000/day, 20000/month). Loading per-tenant overrides is a separate feature (not wiring). Candidate.
+- **Day-0 export check (rule candidate)** — when wiring an already-built component, add a one-line Day-0 check that it's EXPORTED on the public import path (D1 this sprint: RedisBudgetStore was not exported; 30-sec find vs a Day-1 import error). Fold into `sprint-workflow.md §Step 2.5` if it recurs.
+- No blocking carryover. Remaining bundle: **B-8** (Verification default-enable) / **C-15** (DevOps/data-platform billing).
+
+---
+
 ## 🆕 Sprint 57.80 Carryover (2026-06-04 — chat real_llm orphan-tool-message fix; closes AD-Chat-RealLLM-Orphan-Tool-Message)
 
 **Closed**: `AD-Chat-RealLLM-Orphan-Tool-Message` (the 57.79 carryover) — real_llm `POST /chat` 400'd on every tool turn. Builder-level tool-call adjacency invariant (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B, protects all strategies / LostInMiddle untouched) + pending-tool-turn user re-anchor suppression (fix C, in-sprint extension per the real-LLM finding — B-only gave 200 but `stop_reason=max_turns`; C → `end_turn`). Real Azure (gpt-5.2) verified converged + cost_ledger written. AP-10 (MockChatClient never validated adjacency → invisible until real Azure). backend-only Cat 5; no design note. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md` + retrospective. FIX-027.
 
 ### NEW carryovers (this sprint)
 - **Candidate rule fold-in (not yet codified)** — Cat 5 / message-assembly tests must assert the provider structural invariant (tool-call adjacency / ordering) directly, not rely on the mock to reject; and a real-LLM DoD for agent-loop prompt changes should check `stop_reason=end_turn` (convergence), not just no-400 / loop_end present. (Single-data-point; fold into `sprint-workflow.md` if a 2nd sprint hits the same gap.)
-- No blocking carryover. Unrelated bundle remains: **B-7** (ErrorBudget Redis wiring) / **B-8** (Verification default-enable) / **C-15** (DevOps/data-platform billing).
+- No blocking carryover. Unrelated bundle remains: ~~**B-7** (ErrorBudget Redis wiring)~~ ✅ CLOSED Sprint 57.81 / **B-8** (Verification default-enable) / **C-15** (DevOps/data-platform billing).
 
 ---
 
@@ -54,8 +65,8 @@
 - **`AD-Chat-RealLLM-Orphan-Tool-Message`** — ✅ **CLOSED Sprint 57.80 (FIX-027)**. Root cause = `LostInMiddleStrategy.arrange()` moved recent assistant to the tail while the tool result stayed in mid_history → tool preceded its assistant. Fixed builder-level (`_enforce_tool_adjacency` after `strategy.arrange()`, fix B) + pending-tool-turn user re-anchor suppression (fix C, for convergence). Real Azure verified: 200 + `stop_reason=end_turn`. Detail: `memory/project_phase57_80_orphan_tool_adjacency.md`. ~~chat router real_llm e2e blocked by a pre-existing, UNRELATED message-structure 400; needs separate investigation into the real_llm prompt assembly.~~
 - **Deployment requirement: `AZURE_OPENAI_MODEL_NAME`** — prod/other envs using a gpt-5.x deployment MUST set this to the real generation (e.g. `gpt-5.2`). Config default is `gpt-4o` (stale); if unaligned, Gap 2 mis-branches to `max_tokens` → 400 on gpt-5.x. (Gap 1 unaffected — uses response.model.) Deployment/ops note, not a code item.
 
-### Still-open billing bundle (Sprint 57.80+ candidates)
-- B-7 ErrorBudget Redis wiring / B-8 Verification default-enable / C-15 DevOps-data-platform billing — the billing-correctness bundle's remaining legs.
+### Still-open billing bundle (Sprint 57.82+ candidates)
+- ~~B-7 ErrorBudget Redis wiring~~ ✅ CLOSED Sprint 57.81 / B-8 Verification default-enable / C-15 DevOps-data-platform billing — the billing-correctness bundle's remaining legs.
 - Auto-sync pricing from provider API (`llm_pricing.yml:3` future idea) — stays manual yaml.
 
 ---

--- a/claudedocs/4-changes/feature-changes/CHANGE-048-errorbudget-redis-wiring.md
+++ b/claudedocs/4-changes/feature-changes/CHANGE-048-errorbudget-redis-wiring.md
@@ -1,0 +1,29 @@
+# CHANGE-048: B-7 ErrorBudget Redis wiring
+
+**Date**: 2026-06-05
+**Sprint**: 57.81
+**Scope**: 範疇 8 (Error Handling) wiring — `platform_layer/governance` provider + `api/main.py` startup + chat factory (backend-only)
+**Closes**: B-7 (ErrorBudget cross-instance + per-request correctness) / `AD-ErrorBudget-Redis-Wiring`
+
+## Problem
+The per-tenant error budget (Cat 8 `TenantErrorBudget`) was backed by a fresh `InMemoryBudgetStore()` constructed **per request** inside `make_chat_error_deps()` (`_category_factories.py`). So the counters reset on every request — the error budget was effectively non-functional even on a single instance — and were never shared across instances. `RedisBudgetStore` had been fully implemented + fakeredis-tested since Sprint 53.2 but was **never wired** (AP-2 side-track code). This became live-relevant after Sprint 57.79/57.80 made the real_llm chat path actually run end-to-end.
+
+## Root Cause
+Wiring gap, not missing logic. `make_chat_error_deps()` hardcoded `TenantErrorBudget(InMemoryBudgetStore())`; nothing constructed a shared store. The `TenantErrorBudget` wrapper is stateless (all counter state lives in the `BudgetStore`, keyed `error_budget:{tenant_id}:day|month:...`), so a per-request wrapper over a SHARED store accumulates correctly — the fix is purely to provide that shared store.
+
+## Solution
+Backend wiring (Tier 1), mirroring the existing `_wire_rate_limit_counter` / `_wire_pricing_loader` patterns; agent_harness stays DI-pure:
+1. NEW `platform_layer/governance/error_budget_provider.py` — process-global `BudgetStore` singleton accessors (`get_` / `maybe_get_` / `set_` / `reset_budget_store`), mirroring `rate_limit_counter.py`. `BudgetStore` typed via TYPE_CHECKING (structural Protocol → no runtime coupling).
+2. `agent_harness/error_handling/__init__.py` — export `RedisBudgetStore` (was private) so the public package path is importable; redis import stays TYPE_CHECKING-lazy.
+3. `api/main.py` — NEW `_wire_error_budget()` (fail-open): `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; called in `_lifespan` after the rate-limit + pricing wiring. Pure Redis — no DB `session_factory` / RLS (budget tenant isolation is already in the key; deliberately NOT copying the rate-limit counter's DB write-through).
+4. `api/v1/chat/_category_factories.py` — `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + deferred-comment updated (AP-2 repaid). Fixes BOTH the per-request reset (shared store) AND cross-instance correctness.
+
+No change to `loop.py` / `budget.py` / `RedisBudgetStore` / schema / frontend.
+
+## Verification
+- Unit/integration (`tests/unit/platform_layer/governance/test_error_budget_provider.py`, 7 tests): provider accessors; **accumulation** — two `make_chat_error_deps()` calls (= two requests) over a wired `RedisBudgetStore(FakeRedis())` + a `record()` each → `store.get(_day_key) == 2` (per-request reset fixed; InMemory baseline would not accumulate); `budget._store is store` (binds wired store); InMemory fallback when unwired.
+- Startup-log (local backend, no Azure): `api.main: error budget store wired` confirmed alongside the rate-limit + pricing wiring (Risk Class E — wiring fires at startup, no fail-open warning). No real-Azure leg — the budget only increments on tool ERRORS (hard/expensive to provoke on a real happy-path chat); the fakeredis accumulation test is the deterministic proof.
+- Gates: `mypy src/` 0 (332) + `pytest` 2137 passed / 4 skipped (+7) + `python scripts/lint/run_all.py` 10/10 (check_cross_category_import + check_llm_sdk_leak green; check_rls_policies unchanged — no schema).
+
+## Impact
+Backend-only (Cat 8 wiring). When Redis is available the per-tenant error budget now accumulates across requests + instances; when Redis is down the factory falls back to InMemory (fail-open, never blocks startup). No behaviour change for echo_demo / non-error paths.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/progress.md
@@ -1,0 +1,49 @@
+# Sprint 57.81 Progress — B-7 ErrorBudget Redis wiring
+
+**Branch**: `feature/sprint-57-81-errorbudget-redis` (from `main` `18b6dd16`)
+**Closes**: B-7 / `AD-ErrorBudget-Redis-Wiring`
+
+---
+
+## Day 0 — 2026-06-05 — Plan-vs-Repo Verify + Branch + Decisions
+
+### Accomplishments
+- User picked B-7 (ErrorBudget Redis) after merging Sprint 57.80 (#246).
+- Read the source analysis `cat8-errorbudget-redis-wiring-analysis-20260531.md` (18 sprints old) + re-verified ALL its claims/line-numbers against current main `18b6dd16` (the doc's own §5 warns line numbers drift + tool-reliability).
+- Plan + checklist drafted (mirror 57.80 9-section / Day 0-4 format).
+- Branch created.
+
+### Day-0 verify (Prong 1 path + Prong 2 content; Prong 3 N/A — no schema)
+- **Prong 1 (path)** ✅ — `_redis_store.py`, `budget.py`, `error_handling/__init__.py`, `api/main.py`, `rate_limit_counter.py`, `_category_factories.py`, `loop.py`, `test_redis_budget_store.py`, `platform_layer/governance/` all confirmed.
+- **Prong 2 (content)** ✅ — D-DAY0-1..7 (plan §0):
+  - **D-DAY0-1**: `RedisBudgetStore` fully impl (`_redis_store.py:35-61`, MULTI/EXEC) but **NOT exported** from `error_handling/__init__.py` → wiring must add export.
+  - **D-DAY0-2**: `TenantErrorBudget` delegates all state to the `BudgetStore` (keys carry tenant_id) → per-request `TenantErrorBudget(shared_redis)` accumulates → Tier 1 wiring fixes BOTH per-request reset AND cross-instance.
+  - **D-DAY0-3**: gap site `_category_factories.py:236` / deferred comment :248-252 / `TenantErrorBudget(InMemoryBudgetStore())` :257.
+  - **D-DAY0-4**: wire templates `main.py:86 _wire_rate_limit_counter` + `:122 _wire_pricing_loader` (lifespan :166-167); singleton accessor pattern `rate_limit_counter.py:526-558`.
+  - **D-DAY0-5 (live consumer — NOT Potemkin)**: `loop.py:218/269/320-322` — `_handle_tool_error` calls `await self._error_budget.record(self._tenant_id, cls)`; tenant_id passed by real_llm handler. Store swap changes real runtime behaviour.
+  - **D-DAY0-6**: singleton → `platform_layer/governance/` (3 existing wiring singletons all in platform_layer; agent_harness DI-pure; platform→agent_harness import allowed, 10+ precedents incl governance/).
+  - **D-DAY0-7**: test fixture `FakeRedis(decode_responses=False)` + `RedisBudgetStore(client=)` reusable.
+- **Prong 3 (schema)** N/A — RedisBudgetStore is pure Redis, no DB write-through.
+
+### Drift findings
+- **D1 (RedisBudgetStore not exported)**: `error_handling/__init__.py` exports only BudgetStore/InMemory/TenantErrorBudget → plan §3.3 adds the export (vs the analysis doc which assumed direct use). Minor additive.
+- **D2 (no drift on core claims)**: all 3 pillars (RedisBudgetStore impl / gap site / wire template) re-confirmed at new line numbers; live-consumer claim (loop.py record()) added beyond the analysis doc.
+- No scope shift (≤20%). GO for Day 1.
+
+### Decisions locked
+- Singleton in **`platform_layer/governance/error_budget_provider.py`** (NOT agent_harness — DI-purity + convention).
+- **Fail-open** wire (mirror `_wire_rate_limit_counter`); **NO** DB session_factory / RLS / app.tenant_id (pure Redis — budget tenant isolation already in key; copying rate-limit DB write-through = over-engineering per analysis §6).
+- **NO real-Azure leg** — budget increments on tool ERRORS only (hard/expensive to provoke on real happy-path chat); the fakeredis accumulation test is the deterministic proof + a startup-log check confirms wiring fires. (Unlike 57.79/57.80 where the bug was on the happy path.)
+- **parent-direct** (NOT agent-delegated — small careful wiring + startup verify). agent_factor 1.0.
+
+### Blockers / dependencies
+- None. RedisBudgetStore + fakeredis infra (53.2/53.3) + `Redis.from_url`/`settings.redis_url` pattern all live.
+
+### Remaining for Day 1+
+- Day 1: provider singleton + export + `_wire_error_budget()` + factory swap.
+- Day 2: provider/accumulation/fallback tests (fakeredis).
+- Day 3: startup-log `error budget store wired` confirm (local, no Azure).
+- Day 4: sweep + closeout.
+
+### Notes
+- Bottom-up est ~4.3 hr → calibrated ~3.4 hr (medium-backend 0.80, parent-direct).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/progress.md
@@ -47,3 +47,47 @@
 
 ### Notes
 - Bottom-up est ~4.3 hr → calibrated ~3.4 hr (medium-backend 0.80, parent-direct).
+
+---
+
+## Day 1-2 — 2026-06-05 — Provider + wiring + factory + tests
+
+### Accomplishments
+- **Provider (US-2/US-3)**: NEW `platform_layer/governance/error_budget_provider.py` — `_budget_store` module-global + `get_/maybe_get_/set_/reset_budget_store` (mirror `rate_limit_counter.py`); `BudgetStore` via TYPE_CHECKING.
+- **Export (US-2)**: `error_handling/__init__.py` exports `RedisBudgetStore` (was private; redis import stays TYPE_CHECKING-lazy).
+- **Wiring (US-2/US-3)**: `api/main.py` `_wire_error_budget()` (fail-open, mirror `_wire_rate_limit_counter`) + call in `_lifespan`. Pure Redis (no session_factory / RLS).
+- **Factory swap (US-1)**: `_category_factories.py:257` → `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + import + deferred-comment update (AP-2 repaid). MHist on main.py + factory headers.
+- **Tests (US-4)**: NEW `test_error_budget_provider.py` (7) — 4 accessor + accumulation (2 factory calls over wired FakeRedis store → `store.get(_day_key)==2`) + binds-wired-store + InMemory fallback.
+
+### Verification
+- `pytest test_error_budget_provider.py` → 7 passed; regression (governance + error_handling + chat factory/wiring) → 184 passed.
+- black/isort/flake8 on 4 changed src files + test → clean; `mypy src/` → 0 (332, +1 new provider). (57.80 lesson applied: full format chain, not just mypy/pytest.)
+
+### Commit
+- `c1bfb6b2` feat(error_handling, sprint-57-81): wire RedisBudgetStore (B-7).
+
+---
+
+## Day 3 — 2026-06-05 — Startup-log integration check (local, no Azure)
+
+### Accomplishments
+- Clean start backend (:8000 free; fresh no-reload uvicorn). Startup log confirmed all 3 wiring lines + complete:
+  - `api.main: rate-limit counter wired`
+  - `api.main: pricing loader wired (...llm_pricing.yml)`
+  - **`api.main: error budget store wired`** ✅ (NEW — `_wire_error_budget()` fires, no fail-open warning)
+  - `api.main: startup complete`
+- ⇒ Risk Class E style verification: the wiring runs at startup. `Redis.from_url` is lazy (no connection needed for the log to confirm the store was installed).
+- **No real-Azure leg** (per plan §3.6): the budget increments on tool ERRORS only — a real happy-path chat wouldn't exercise it. The fakeredis accumulation test (Day 2) is the deterministic proof of the per-request-reset fix.
+- Cleanup: backend stopped; :8000 free; temp log removed.
+
+---
+
+## Day 4 — 2026-06-05 — Full sweep + closeout
+
+### Accomplishments
+- **Full sweep**: black/isort/flake8 src/ tests/ 0 + `mypy src/` 0 (332) + `pytest` 2137 passed / 4 skipped (+7 vs 2130) + `run_all.py` 10/10 (check_cross_category_import + check_llm_sdk_leak green; check_rls_policies unchanged — no schema). Backend-only (0 frontend).
+- **Closeout**: CHANGE-048 + retrospective.md (Q1-Q7) + MEMORY subfile/pointer + CLAUDE.md lean + next-phase-candidates.md (B-7 CLOSED; B-8/C-15 remain).
+- No design note (wiring of existing Cat 8 component).
+
+### Status
+B-7 / `AD-ErrorBudget-Redis-Wiring` CLOSED. Per-tenant error budget now accumulates (shared Redis store; fail-open to InMemory). Awaiting push + PR (user-gated).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/retrospective.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-81/retrospective.md
@@ -1,0 +1,56 @@
+# Sprint 57.81 Retrospective — B-7 ErrorBudget Redis wiring
+
+**Sprint**: 57.81
+**Closed**: 2026-06-05
+**Branch**: `feature/sprint-57-81-errorbudget-redis`
+**Closes**: B-7 / `AD-ErrorBudget-Redis-Wiring`
+
+---
+
+## Q1. Goal achieved?
+
+✅ Yes. The already-built `RedisBudgetStore` is now wired so the per-tenant error budget accumulates across requests (and instances):
+- NEW `platform_layer/governance/error_budget_provider.py` singleton + `_wire_error_budget()` startup wiring (fail-open) + `RedisBudgetStore` export + chat factory swap (`maybe_get_budget_store() or InMemoryBudgetStore()`).
+- Fixes BOTH the per-request reset (shared store) AND cross-instance correctness; AP-2 side-track repaid.
+- Verified: fakeredis accumulation test (2 factory calls → count=2) + startup-log `error budget store wired`.
+- Gates: mypy src/ 0 (332) / pytest 2137 (+7) / run_all 10/10.
+
+## Q2. Estimate accuracy
+
+- Plan: bottom-up ~4.3 hr → class-calibrated commit ~3.4 hr (`medium-backend` 0.80, `agent_factor` 1.0 parent-direct).
+- Actual: ~3 hr. The wiring itself was small/fast (~1 hr: provider + wire fn + export + factory swap). Tests ~1 hr. Day-0 re-verify of the 18-sprint-old analysis doc + startup-log + closeout ~1 hr.
+- Ratio ~0.88. `medium-backend` 0.80 held for a parent-direct wiring sprint. **NOT agent-delegated** → the 16-consecutive-agent-delegated wall-clock caveat does not apply.
+
+## Q3. What went well
+
+- **Day-0 re-verify caught a real drift**: the analysis doc assumed `RedisBudgetStore` was usable directly; the grep found it was **not exported** from `error_handling/__init__.py` (D1) → plan added the export. The doc's own §5 lesson ("18-sprint-old line numbers; grep-confirm, don't single-shot") paid off — all 7 D-DAY0 facts re-confirmed at new line numbers.
+- **Live-consumer check beyond the doc**: verified `loop.py:320-322` actually calls `error_budget.record()` (the analysis doc said "loop.py not line-verified"). Confirmed the wiring connects to a real consumer (not a Potemkin), so the store swap changes real runtime behaviour.
+- **Right verification tool for the gap**: the budget only increments on tool ERRORS, so a real-Azure happy-path chat would prove nothing. The fakeredis accumulation test (two factory calls → count=2) is the deterministic proof that the per-request reset is fixed; the startup-log check confirms the wiring fires. Chose this over a 57.79/57.80-style real-Azure leg — and documented why so it doesn't read as a coverage gap.
+- **Scope discipline**: kept it Tier 1 wiring — did NOT copy the rate-limit counter's DB `session_factory` / RLS `app.tenant_id` (RedisBudgetStore is pure Redis; budget tenant isolation is already in the key), and did NOT pull in `error_budgets.yaml` per-tenant overrides.
+- **Applied the 57.80 lesson**: ran the FULL format chain (black/isort/flake8 + mypy + pytest) before commit, not just mypy/pytest — no CI black surprise this time.
+
+## Q4. Lessons
+
+- **A stale analysis doc is a starting point, not ground truth**: an 18-sprint-old doc had drifted (RedisBudgetStore export gap) + omitted the live-consumer check. Re-running Prong 1 + 2 against current main is mandatory; the doc accelerates Day-0 but does not replace it.
+- **Match the verification to where the code path actually runs**: error-only counters can't be exercised by a happy-path real-LLM call. Picking the deterministic fakeredis accumulation test (the real correctness claim) over an expensive-but-uninformative real-Azure run was the right call.
+
+## Q5. Improvements next sprint
+
+- When wiring an already-built component, add a one-line Day-0 check that the component is actually EXPORTED on the public path the wiring will import from — the export gap (D1) was a 30-second find that would have been a Day-1 import error otherwise.
+
+## Q6. Carryover
+
+- None blocking — B-7 closed.
+- **error_budgets.yaml per-tenant overrides** — the `budget.py` docstring mentions YAML-tunable caps; the factory uses defaults (1000/day, 20000/month). Loading per-tenant overrides is a separate feature, not wiring. Carryover.
+- **B-8 Verification default-enable** / **C-15 DevOps/data-platform billing** — the bundle's other legs; separate sprints.
+- **Real-LLM budget-enforcement e2e** (provoke real tool errors to trip the budget on real Azure) — deferred; fakeredis accumulation is the proof here.
+
+## Q7. Risks
+
+- Low. Backend-only wiring, fail-open (Redis down → InMemory fallback → never blocks startup), no schema / migration / loop.py / budget.py / store-logic change. The new `platform_layer/governance → agent_harness` import is TYPE_CHECKING-only + an established allowed direction (check_cross_category_import green). The correctness claim is unit-proven (accumulation); the startup-log confirms the wiring fires. Pure Redis (no DB write-through) so no RLS / tenant-context risk.
+
+---
+
+## Design Note Extract
+
+NO — wiring of an existing Cat 8 component (RedisBudgetStore, Sprint 53.2); no new contract / no 17.md change / no new domain.

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
@@ -24,39 +24,40 @@
 ## Day 1 — Provider + wiring + export + factory swap (US-1/US-2/US-3)
 
 ### 1.1 budget store provider singleton
-- [ ] **NEW `platform_layer/governance/error_budget_provider.py`** — module-global `_budget_store` + `get_/maybe_get_/set_/reset_budget_store` (mirror `rate_limit_counter.py:526-558`); `BudgetStore` type via TYPE_CHECKING import
-  - DoD: mypy clean; `maybe_get` lenient (None when unset); `get` strict-raises; `reset` clears
+- [x] **NEW `platform_layer/governance/error_budget_provider.py`** — module-global `_budget_store` + `get_/maybe_get_/set_/reset_budget_store` (mirror `rate_limit_counter.py:526-558`); `BudgetStore` type via TYPE_CHECKING import
+  - DoD: mypy clean ✅; `maybe_get` lenient (None when unset); `get` strict-raises; `reset` clears
 
 ### 1.2 export RedisBudgetStore
-- [ ] **`error_handling/__init__.py`** — add `RedisBudgetStore` to imports + `__all__` (so main.py imports via public path)
-  - DoD: `from agent_harness.error_handling import RedisBudgetStore` works; mypy clean
+- [x] **`error_handling/__init__.py`** — add `RedisBudgetStore` to imports + `__all__` (so main.py imports via public path)
+  - DoD: `from agent_harness.error_handling import RedisBudgetStore` works ✅ (redis import stays TYPE_CHECKING-lazy); mypy clean
 
 ### 1.3 startup wiring
-- [ ] **`_wire_error_budget()` in `api/main.py`** — mirror `_wire_rate_limit_counter`: `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; whole body `except Exception` fail-open; `logger.info("api.main: error budget store wired")`
-- [ ] **call in `_lifespan`** after `_wire_rate_limit_counter()` / `_wire_pricing_loader()`
-  - DoD: NO session_factory / RLS / app.tenant_id (pure Redis); mypy clean
+- [x] **`_wire_error_budget()` in `api/main.py`** — mirror `_wire_rate_limit_counter`: `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; whole body `except Exception` fail-open; `logger.info("api.main: error budget store wired")`
+- [x] **call in `_lifespan`** after `_wire_rate_limit_counter()` / `_wire_pricing_loader()`
+  - DoD: NO session_factory / RLS / app.tenant_id (pure Redis) ✅; mypy clean
 
 ### 1.4 chat factory swap
-- [ ] **`_category_factories.py:257`** — `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + import `maybe_get_budget_store`; update deferred comment :248-252 (AP-2 repaid)
-  - DoD: mypy clean; MHist 1-line on factory file header
+- [x] **`_category_factories.py:257`** — `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + import `maybe_get_budget_store`; update deferred comment :248-252 (AP-2 repaid)
+  - DoD: mypy clean ✅; MHist 1-line on factory + main.py headers
 
-### 1.5 read changed code
-- [ ] **re-read** — no loop.py / budget.py / RedisBudgetStore change; LLM-neutral; platform_layer→agent_harness import is TYPE_CHECKING-only / allowed
+### 1.5 read changed code + format/lint/type gate
+- [x] **re-read** — no loop.py / budget.py / RedisBudgetStore change; LLM-neutral; platform_layer→agent_harness import is TYPE_CHECKING-only / allowed
+- [x] **black + isort + flake8 + mypy** on 4 changed files — all clean (mypy src/ 0/332, +1 new provider). (57.80 lesson: run full format chain, not just mypy/pytest.)
 
 ---
 
 ## Day 2 — Tests (US-4)
 
 ### 2.1 provider accessor unit tests
-- [ ] **NEW `test_error_budget_provider.py`** — `set`→`maybe_get` returns it; `reset` clears; `get` raises when unset; reset isolation (autouse or explicit)
+- [x] **NEW `test_error_budget_provider.py`** (`tests/unit/platform_layer/governance/`) — `set`→`maybe_get` returns it; `reset` clears; `get` raises when unset; autouse `reset_budget_store` isolation. 4 accessor tests.
 
 ### 2.2 accumulation + fallback integration tests (the correctness claim)
-- [ ] **accumulation** — wire `RedisBudgetStore(FakeRedis())` via `set_budget_store`; call `make_chat_error_deps()` TWICE; `record()` an error via each `TenantErrorBudget`; assert the 2nd reflects the ACCUMULATED count (per-request reset fixed) — contrast: InMemory baseline would NOT accumulate
-- [ ] **fallback** — no wired store → `make_chat_error_deps()` returns `TenantErrorBudget` backed by `InMemoryBudgetStore` (no crash)
-- [ ] reuse `FakeRedis(decode_responses=False)` fixture pattern from `test_redis_budget_store.py`
+- [x] **accumulation** — wired `RedisBudgetStore(FakeRedis())`; `make_chat_error_deps()` TWICE; `record()` via each `TenantErrorBudget`; assert `store.get(_day_key)==2` (per-request reset fixed) ✅ + `budget._store is store` (binds wired store)
+- [x] **fallback** — no wired store → `make_chat_error_deps()` returns `TenantErrorBudget` with `isinstance(_store, InMemoryBudgetStore)` (no crash)
+- [x] reuse `FakeRedis(decode_responses=False)` fixture pattern. 7 tests total, all pass.
 
 ### 2.3 regression gate
-- [ ] **targeted pytest** — provider + error_handling + chat factory tests green; confirm existing Cat 8 / factory tests unchanged
+- [x] **targeted pytest** — governance + error_handling + chat factory/wiring = 184 passed; no regression in existing Cat 8 / factory tests
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
@@ -1,0 +1,90 @@
+# Sprint 57.81 — Checklist (B-7 ErrorBudget Redis wiring)
+
+**Plan**: `sprint-57-81-plan.md`
+**Branch**: `feature/sprint-57-81-errorbudget-redis` (from `main` `18b6dd16`)
+**Closes**: B-7 (ErrorBudget cross-instance + per-request correctness) / `AD-ErrorBudget-Redis-Wiring`
+
+---
+
+## Day 0 — Plan-vs-Repo Verify + Branch + Decisions
+
+### 0.1 Day-0 verify (parent grep + code read, main `18b6dd16`; analysis doc 18 sprints old → all lines re-verified)
+- [x] **Prong 1 (path)** — confirm: `error_handling/_redis_store.py` (RedisBudgetStore), `error_handling/budget.py` (Protocol + InMemory + TenantErrorBudget), `error_handling/__init__.py` (exports — RedisBudgetStore NOT exported), `api/main.py` (wire templates), `platform_layer/tenant/rate_limit_counter.py` (singleton pattern), `api/v1/chat/_category_factories.py` (factory), `loop.py` (consumer), `tests/.../error_handling/test_redis_budget_store.py` (FakeRedis fixture), `platform_layer/governance/` dir.
+- [x] **Prong 2 (content)** — D-DAY0-1..7 in plan §0 (RedisBudgetStore impl + not-exported / state-in-store → per-request fix / gap site :236+:248-252+:257 / wire templates + singleton accessor pattern / **live consumer loop.py:320-322 record() — not Potemkin** / platform_layer singleton convention + import direction allowed / FakeRedis fixture).
+- [x] **Prong 3 (schema)** — N/A (no DB table / migration / ORM change; RedisBudgetStore is pure Redis, no DB write-through).
+- [x] **go/no-go** — GO; Tier 1 wiring (single obvious path per analysis doc); no scope fork. real_llm now LIVE (57.79/57.80) → B-7 timing appropriate.
+
+### 0.2 Branch + decisions
+- [x] **Branch created** `feature/sprint-57-81-errorbudget-redis`
+- [x] **Decisions locked**: singleton in `platform_layer/governance/` (convention: 3 existing wiring singletons in platform_layer; agent_harness DI-pure) NOT agent_harness; fail-open wire (mirror `_wire_rate_limit_counter`); NO DB session_factory / RLS (pure Redis — don't copy rate-limit over-wiring); NO real-Azure leg (budget increments on errors only → fakeredis accumulation test is the proof); parent-direct (NOT agent-delegated).
+- [x] **Day-0 commit** plan + checklist + progress.md Day 0
+
+---
+
+## Day 1 — Provider + wiring + export + factory swap (US-1/US-2/US-3)
+
+### 1.1 budget store provider singleton
+- [ ] **NEW `platform_layer/governance/error_budget_provider.py`** — module-global `_budget_store` + `get_/maybe_get_/set_/reset_budget_store` (mirror `rate_limit_counter.py:526-558`); `BudgetStore` type via TYPE_CHECKING import
+  - DoD: mypy clean; `maybe_get` lenient (None when unset); `get` strict-raises; `reset` clears
+
+### 1.2 export RedisBudgetStore
+- [ ] **`error_handling/__init__.py`** — add `RedisBudgetStore` to imports + `__all__` (so main.py imports via public path)
+  - DoD: `from agent_harness.error_handling import RedisBudgetStore` works; mypy clean
+
+### 1.3 startup wiring
+- [ ] **`_wire_error_budget()` in `api/main.py`** — mirror `_wire_rate_limit_counter`: `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; whole body `except Exception` fail-open; `logger.info("api.main: error budget store wired")`
+- [ ] **call in `_lifespan`** after `_wire_rate_limit_counter()` / `_wire_pricing_loader()`
+  - DoD: NO session_factory / RLS / app.tenant_id (pure Redis); mypy clean
+
+### 1.4 chat factory swap
+- [ ] **`_category_factories.py:257`** — `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + import `maybe_get_budget_store`; update deferred comment :248-252 (AP-2 repaid)
+  - DoD: mypy clean; MHist 1-line on factory file header
+
+### 1.5 read changed code
+- [ ] **re-read** — no loop.py / budget.py / RedisBudgetStore change; LLM-neutral; platform_layer→agent_harness import is TYPE_CHECKING-only / allowed
+
+---
+
+## Day 2 — Tests (US-4)
+
+### 2.1 provider accessor unit tests
+- [ ] **NEW `test_error_budget_provider.py`** — `set`→`maybe_get` returns it; `reset` clears; `get` raises when unset; reset isolation (autouse or explicit)
+
+### 2.2 accumulation + fallback integration tests (the correctness claim)
+- [ ] **accumulation** — wire `RedisBudgetStore(FakeRedis())` via `set_budget_store`; call `make_chat_error_deps()` TWICE; `record()` an error via each `TenantErrorBudget`; assert the 2nd reflects the ACCUMULATED count (per-request reset fixed) — contrast: InMemory baseline would NOT accumulate
+- [ ] **fallback** — no wired store → `make_chat_error_deps()` returns `TenantErrorBudget` backed by `InMemoryBudgetStore` (no crash)
+- [ ] reuse `FakeRedis(decode_responses=False)` fixture pattern from `test_redis_budget_store.py`
+
+### 2.3 regression gate
+- [ ] **targeted pytest** — provider + error_handling + chat factory tests green; confirm existing Cat 8 / factory tests unchanged
+
+---
+
+## Day 3 — Startup-log integration check (US-3) — local, no Azure
+
+### 3.1 clean start + startup log (Risk Class E)
+- [ ] **clean start backend** — :8000 free; fresh no-reload uvicorn
+- [ ] **confirm startup log** `error budget store wired` (mirrors `pricing loader wired` / `rate-limit counter wired`) — proves wiring fires; no real LLM call needed
+- [ ] **record** startup-log evidence in progress.md Day 3 (note: no real-Azure leg — budget increments on errors only; fakeredis accumulation test is the proof)
+
+---
+
+## Day 4 — Sweep + Closeout
+
+### 4.1 Full sweep
+- [ ] **Backend gates** — `mypy src/` 0 + `pytest` (new + regression) + `python scripts/lint/run_all.py` 10/10 (check_cross_category_import green for new platform→agent_harness import; check_llm_sdk_leak green; check_rls_policies unchanged — no schema)
+- [ ] **No frontend** — 0 frontend changes (backend-only sprint)
+- [ ] **Read all changed code** — wiring only; no loop.py/budget.py/store logic change; pure Redis (no over-wiring)
+
+### 4.2 Closeout docs
+- [ ] **CHANGE-048** in `claudedocs/4-changes/feature-changes/` (feature: wire RedisBudgetStore into main flow)
+- [ ] **progress.md** Day 0-4 (incl. Day 3 startup-log evidence) + **retrospective.md** Q1-Q7
+- [ ] **Checklist** all `[x]` (note any 🚧 carryover with reason)
+- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio)
+- [ ] **AD status**: B-7 / `AD-ErrorBudget-Redis-Wiring` CLOSED; next-phase-candidates.md updated (B-8 / C-15 remain)
+- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [ ] **Design note?** — NO (wiring of existing Cat 8 component; no new contract / no 17.md change)
+
+### 4.3 Ship
+- [ ] **Commit mapping** Day-0 / provider+wiring+factory / tests / closeout
+- [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-checklist.md
@@ -64,28 +64,28 @@
 ## Day 3 — Startup-log integration check (US-3) — local, no Azure
 
 ### 3.1 clean start + startup log (Risk Class E)
-- [ ] **clean start backend** — :8000 free; fresh no-reload uvicorn
-- [ ] **confirm startup log** `error budget store wired` (mirrors `pricing loader wired` / `rate-limit counter wired`) — proves wiring fires; no real LLM call needed
-- [ ] **record** startup-log evidence in progress.md Day 3 (note: no real-Azure leg — budget increments on errors only; fakeredis accumulation test is the proof)
+- [x] **clean start backend** — :8000 free; fresh no-reload uvicorn
+- [x] **confirm startup log** `api.main: error budget store wired` ✅ (alongside rate-limit + pricing wiring; no fail-open warning) — wiring fires; no real LLM call needed
+- [x] **record** startup-log evidence in progress.md Day 3 (no real-Azure leg — budget increments on errors only; fakeredis accumulation test is the proof)
 
 ---
 
 ## Day 4 — Sweep + Closeout
 
 ### 4.1 Full sweep
-- [ ] **Backend gates** — `mypy src/` 0 + `pytest` (new + regression) + `python scripts/lint/run_all.py` 10/10 (check_cross_category_import green for new platform→agent_harness import; check_llm_sdk_leak green; check_rls_policies unchanged — no schema)
-- [ ] **No frontend** — 0 frontend changes (backend-only sprint)
-- [ ] **Read all changed code** — wiring only; no loop.py/budget.py/store logic change; pure Redis (no over-wiring)
+- [x] **Backend gates** — black/isort/flake8 src/ tests/ 0 + `mypy src/` 0 (332) + `pytest` 2137 passed / 4 skipped (+7) + `python scripts/lint/run_all.py` 10/10 (check_cross_category_import + check_llm_sdk_leak green; check_rls_policies unchanged — no schema)
+- [x] **No frontend** — 0 frontend changes (backend-only sprint)
+- [x] **Read all changed code** — wiring only; no loop.py/budget.py/store logic change; pure Redis (no over-wiring)
 
 ### 4.2 Closeout docs
-- [ ] **CHANGE-048** in `claudedocs/4-changes/feature-changes/` (feature: wire RedisBudgetStore into main flow)
-- [ ] **progress.md** Day 0-4 (incl. Day 3 startup-log evidence) + **retrospective.md** Q1-Q7
-- [ ] **Checklist** all `[x]` (note any 🚧 carryover with reason)
-- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio)
-- [ ] **AD status**: B-7 / `AD-ErrorBudget-Redis-Wiring` CLOSED; next-phase-candidates.md updated (B-8 / C-15 remain)
-- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
-- [ ] **Design note?** — NO (wiring of existing Cat 8 component; no new contract / no 17.md change)
+- [x] **CHANGE-048** in `claudedocs/4-changes/feature-changes/` (feature: wire RedisBudgetStore into main flow)
+- [x] **progress.md** Day 0-4 (incl. Day 3 startup-log evidence) + **retrospective.md** Q1-Q7
+- [x] **Checklist** all `[x]` (no 🚧 carryover)
+- [x] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio ~0.88 in retro Q2)
+- [x] **AD status**: B-7 / `AD-ErrorBudget-Redis-Wiring` CLOSED; next-phase-candidates.md updated (B-8 / C-15 remain)
+- [x] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [x] **Design note?** — NO (wiring of existing Cat 8 component; no new contract / no 17.md change)
 
 ### 4.3 Ship
-- [ ] **Commit mapping** Day-0 / provider+wiring+factory / tests / closeout
+- [x] **Commit mapping** Day-0 (`8d4c488f`) / provider+wiring+factory+tests (`c1bfb6b2`) / closeout (pending)
 - [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-81-plan.md
@@ -1,0 +1,142 @@
+# Sprint 57.81 Plan — B-7 ErrorBudget Redis wiring (wire the already-built RedisBudgetStore) (closes AD-ErrorBudget-Redis-Wiring / B-7)
+
+**Branch**: `feature/sprint-57-81-errorbudget-redis` (from `main` `18b6dd16`)
+**Closes**: B-7 (ErrorBudget cross-instance + per-request correctness) — the billing/resilience bundle's budget half.
+**Scope**: Backend wiring only (Cat 8 ErrorBudget store provider singleton + startup wire + chat factory swap). NOT a new store (RedisBudgetStore already built + tested, Sprint 53.2); NOT loop.py / budget.py logic; NOT error_budgets.yaml per-tenant overrides.
+
+---
+
+## 0. Background
+
+B-7 is a wiring gap, not a missing feature: `RedisBudgetStore` was fully implemented + fakeredis-tested in Sprint 53.2 but never wired — the chat factory hardcodes `InMemoryBudgetStore()`. Two correctness problems result once real_llm runs (now LIVE after Sprint 57.79/57.80 real-Azure verification):
+1. **Per-request reset** — `make_chat_error_deps()` runs inside `build_real_llm_handler` **per request**, so every request constructs a fresh `InMemoryBudgetStore()` → the counter never accumulates even on a single instance → the error budget is effectively non-functional.
+2. **Cross-instance** — even with a persistent in-process store, horizontal scaling would split counts across instances.
+
+Both are fixed by wiring the shared `RedisBudgetStore` once at startup (the `TenantErrorBudget` wrapper is stateless; all counter state lives in the store, keyed `error_budget:{tenant_id}:day|month:...`). This is AP-2 (Side-Track Code) debt repayment, mirroring the existing `_wire_rate_limit_counter` / `_wire_pricing_loader` startup wiring + their `set_/maybe_get_` singleton accessors.
+
+### Day-0 ground-truth (parent grep + code read, main `18b6dd16`; the source analysis `cat8-errorbudget-redis-wiring-analysis-20260531.md` is 18 sprints old — all line numbers re-verified)
+- **D-DAY0-1 (RedisBudgetStore exists, fully impl)**: `agent_harness/error_handling/_redis_store.py:35-61` — `RedisBudgetStore(client: Redis[bytes])` with MULTI/EXEC `increment` + `get`. **NOT exported** from `error_handling/__init__.py` (only `BudgetStore` / `InMemoryBudgetStore` / `TenantErrorBudget` are) → wiring must add the export.
+- **D-DAY0-2 (state lives in the store)**: `budget.py:52-66` `BudgetStore` Protocol (async `increment(key, ttl)→int` + `get(key)→int`); `TenantErrorBudget` (`:108-165`) delegates all counting to the store (keys `error_budget:{tenant_id}:day:{date}` / `:month:{ym}`). ⇒ a per-request `TenantErrorBudget(shared_redis_store)` accumulates correctly — Tier 1 wiring fixes BOTH the per-request reset AND cross-instance.
+- **D-DAY0-3 (wiring gap site)**: `api/v1/chat/_category_factories.py:236 make_chat_error_deps`; deferred comment `:248-252`; `error_budget = TenantErrorBudget(InMemoryBudgetStore())` `:257`; imports `InMemoryBudgetStore` / `TenantErrorBudget` `:60` / `:62`.
+- **D-DAY0-4 (wiring templates)**: `api/main.py:86 _wire_rate_limit_counter` (fail-open) + `:122 _wire_pricing_loader` (fail-soft); both called in `_lifespan` (`:166` / `:167`). Singleton accessor pattern: `platform_layer/tenant/rate_limit_counter.py:526-558` (`get_` strict / `maybe_get_` lenient / `set_` install / `reset_` test-hook; "mirror quota.py").
+- **D-DAY0-5 (live consumer — NOT Potemkin)**: `loop.py:218` ctor `error_budget: TenantErrorBudget | None`; `:269` stored; `:320-322` `_handle_tool_error` calls `await self._error_budget.record(self._tenant_id, cls)` on a (non-FATAL) tool error; `is_exceeded` is consumed by `DefaultErrorTerminator`. `tenant_id` is passed to `AgentLoopImpl` by `build_real_llm_handler`. ⇒ wiring connects to a real consumer; the store swap actually changes runtime behaviour.
+- **D-DAY0-6 (singleton home — platform_layer convention)**: all 3 existing wiring singletons (`rate_limit_counter` / `pricing` / `quota`) live in `platform_layer`; agent_harness stays DI-pure (no process-global mutable). platform_layer→agent_harness import is allowed (10+ precedents incl. `governance/`). → new `platform_layer/governance/error_budget_provider.py` (error budget = platform-protection policy per `budget.py` docstring "protect platform during incident" → governance).
+- **D-DAY0-7 (test fixture reuse)**: `tests/integration/agent_harness/error_handling/test_redis_budget_store.py` uses `fakeredis.aioredis.FakeRedis(decode_responses=False)` + `RedisBudgetStore(client=...)` (fakeredis>=2.20, Sprint 53.3). Reuse for the wiring + accumulation tests.
+
+---
+
+## 1. Sprint Goal
+
+Wire the already-built `RedisBudgetStore` into the chat error-handling path so the per-tenant error budget accumulates across requests (and across instances) instead of resetting every request — via a `platform_layer` singleton provider + a startup `_wire_error_budget()` (fail-open, mirroring `_wire_rate_limit_counter`) + a one-line factory swap, with NO change to `loop.py` / `budget.py` / `RedisBudgetStore`.
+
+---
+
+## 2. User Stories
+
+- **US-1** — 作為平台維護者，我希望 per-tenant error budget 在 real_llm 流量中跨請求累積（非每請求歸零），以便 budget 真正能保護平台（不再形同失效）。
+- **US-2** — 作為 SRE，我希望 error budget 計數在水平擴展時跨實例共享（Redis），以便多實例部署下 budget enforcement 正確。
+- **US-3** — 作為開發者，我希望 budget store 走 fail-open 的 startup wiring（Redis 不可用退回 InMemory，不擋 startup），以便 dev / test / Redis 故障時服務不中斷。
+- **US-4** — 作為 QA，我希望 unit/integration 測試證明「wired 後工廠拿到 Redis store + 跨工廠呼叫累積 + Redis 缺席時退回 InMemory」，以便回歸保護。
+
+---
+
+## 3. Technical Specifications
+
+### 3.0 Architecture
+Pure wiring, Tier 1. agent_harness defines the `BudgetStore` Protocol + both impls (`InMemoryBudgetStore`, `RedisBudgetStore`) — unchanged. platform_layer gains a process-global provider (the wiring singleton, mirroring the 3 existing ones). api/main.py wires the Redis-backed store at startup (fail-open). The chat factory looks up the wired store, falling back to InMemory. No loop.py / budget.py / schema / migration change. LLM-neutral (no provider SDK; pure Redis).
+
+### 3.1 Budget store provider singleton (US-2/US-3) — NEW `platform_layer/governance/error_budget_provider.py`
+- Module-global `_budget_store: BudgetStore | None = None` + 4 accessors mirroring `rate_limit_counter.py:526-558`:
+  - `get_budget_store() -> BudgetStore` (strict; raises if uninitialised — for any strict caller)
+  - `maybe_get_budget_store() -> BudgetStore | None` (lenient; the factory uses this → falls back to InMemory)
+  - `set_budget_store(store: BudgetStore | None) -> None` (install at startup / test fixture)
+  - `reset_budget_store() -> None` (test isolation hook, per `testing.md` §Module-level Singleton Reset Pattern)
+- `BudgetStore` type imported under `TYPE_CHECKING` (`from __future__ import annotations`) — the Protocol is structural, so no runtime agent_harness coupling needed for the holder.
+
+### 3.2 Startup wiring (US-2/US-3) — `api/main.py`
+- NEW `_wire_error_budget()` mirroring `_wire_rate_limit_counter` (`:86-119`): `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; whole body `except Exception` **fail-open** (Redis down → store stays None → factory falls back to InMemory → budget degrades to per-request, never blocks startup). `logger.info("api.main: error budget store wired")` on success.
+- Call `_wire_error_budget()` in `_lifespan` after `_wire_rate_limit_counter()` / `_wire_pricing_loader()` (`:166-167`).
+- **No `app.tenant_id` / RLS / DB session** — RedisBudgetStore is pure Redis (no DB write-through); do NOT copy the rate-limit counter's `session_factory` / `_set_tenant_context` (that would be over-engineering — budget tenant isolation is already in the key).
+
+### 3.3 Export RedisBudgetStore (US-2) — `agent_harness/error_handling/__init__.py`
+- Add `RedisBudgetStore` to the imports + `__all__` (currently only `BudgetStore` / `InMemoryBudgetStore` / `TenantErrorBudget` are exported) so `api/main.py` imports it via the public package path (`from agent_harness.error_handling import RedisBudgetStore`), consistent with how rate-limit wiring imports `RedisRateLimitCounter` from the public module.
+
+### 3.4 Chat factory swap (US-1) — `api/v1/chat/_category_factories.py`
+- `:257` `TenantErrorBudget(InMemoryBudgetStore())` → `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + import `maybe_get_budget_store` from `platform_layer.governance.error_budget_provider`.
+- Update the deferred comment (`:248-252`) to state the store is now the wired shared store (Redis when available) with InMemory fallback — AP-2 debt repaid.
+
+### 3.5 Tests (US-4) — NEW `test_error_budget_provider.py` + extend factory/wiring test
+- NEW `tests/.../error_budget_provider` unit test (or co-located): `set_budget_store` → `maybe_get_budget_store` returns it; `reset_budget_store` clears; `get_budget_store` raises when unset.
+- Accumulation test (the key correctness claim): with a wired `RedisBudgetStore(FakeRedis())`, call `make_chat_error_deps()` TWICE (simulating two requests), `record()` an error via each returned `TenantErrorBudget`, assert the second `is_exceeded`/`get` reflects the ACCUMULATED count (proves the per-request reset is fixed) — vs the InMemory baseline where two factory calls would NOT accumulate.
+- Fallback test: with no wired store, `make_chat_error_deps()` returns a `TenantErrorBudget` backed by `InMemoryBudgetStore` (no crash; preserves dev/test behaviour).
+- Reuse the `FakeRedis(decode_responses=False)` fixture pattern from `test_redis_budget_store.py`.
+
+### 3.6 Startup-log integration check (US-3) — local, no Azure
+- Start backend; confirm startup log `error budget store wired` (mirrors `pricing loader wired` / `rate-limit counter wired`). This proves the wiring fires at startup (Risk Class E style) WITHOUT a real LLM call. **No real-Azure run** — budget only increments on tool ERRORS (hard/expensive to provoke via real chat); the fakeredis accumulation test (§3.5) is the deterministic proof of the correctness claim. (Rationale recorded so a reviewer doesn't expect a 57.79/57.80-style real-LLM leg.)
+
+### 3.7 Lint / validation
+`mypy src/` + `pytest` (new + regression) + `python scripts/lint/run_all.py` (10/10 — no schema, no LLM-SDK leak; `check_cross_category_import` must stay green for the new platform_layer→agent_harness type-only import). NO frontend / migration / wire-schema / ORM change.
+
+---
+
+## 4. File Change List
+
+**NEW (2)**
+- `backend/src/platform_layer/governance/error_budget_provider.py` (singleton accessors)
+- `backend/tests/unit/platform_layer/governance/test_error_budget_provider.py` (provider + accumulation + fallback tests) — final path confirmed Day 1 against existing test tree
+
+**EDIT (3)**
+- `backend/src/agent_harness/error_handling/__init__.py` (export `RedisBudgetStore`)
+- `backend/src/api/main.py` (`_wire_error_budget()` + call in `_lifespan`)
+- `backend/src/api/v1/chat/_category_factories.py` (`maybe_get_budget_store() or InMemoryBudgetStore()` + import + deferred-comment update)
+
+**NO frontend / migration / wire-schema / ORM / loop.py / budget.py / RedisBudgetStore change.**
+
+---
+
+## 5. Acceptance Criteria
+
+- `set_budget_store` / `maybe_get_budget_store` / `get_budget_store` / `reset_budget_store` behave as the rate-limit accessors do (install / lenient / strict-raise / clear) — unit-tested.
+- `_wire_error_budget()` installs a `RedisBudgetStore` from `settings.redis_url` at startup and is fail-open (Redis down → store None → factory InMemory fallback; startup never blocked).
+- `make_chat_error_deps()` returns a `TenantErrorBudget` backed by the wired store when present, InMemory otherwise; with a wired Redis store, two successive factory calls + records ACCUMULATE (per-request reset fixed) — integration-tested with fakeredis.
+- Startup log `error budget store wired` confirmed on a local backend start.
+- Gates: backend mypy 0 + pytest (new + regression) green + run_all 10/10. No frontend.
+
+---
+
+## 6. Deliverables
+
+- [ ] `error_budget_provider.py` singleton accessors (mirror rate_limit_counter)
+- [ ] `_wire_error_budget()` in main.py + call in `_lifespan` (fail-open)
+- [ ] Export `RedisBudgetStore` from `error_handling/__init__.py`
+- [ ] Factory swap `maybe_get_budget_store() or InMemoryBudgetStore()` + deferred-comment update (AP-2 repaid)
+- [ ] Tests: provider accessors + fakeredis accumulation (per-request-reset fixed) + InMemory fallback
+- [ ] Startup-log `error budget store wired` confirmed (local, no Azure) — evidence in progress.md
+- [ ] All gates green; closeout (CHANGE-048 + progress + retro + MEMORY + CLAUDE lean; B-7 closed)
+
+---
+
+## 7. Workload Calibration
+
+Scope class `medium-backend` (0.80 — small wiring + new provider module + tests + startup-log check; lighter than 57.79/57.80 but same class). **Agent-delegated: no** (parent-direct — small careful wiring + startup verification). `agent_factor` = 1.0 → 3-segment form.
+
+Bottom-up est ~4.3 hr (provider ~0.5 + wire fn ~0.5 + factory+export ~0.5 + tests ~1.5 + startup verify ~0.3 + closeout ~1) → class-calibrated commit ~3.4 hr (mult 0.80).
+
+---
+
+## 8. Dependencies & Risks
+
+- **Dependency**: `RedisBudgetStore` + fakeredis test infra (Sprint 53.2/53.3) live; `settings.redis_url` + `Redis.from_url` pattern proven by `_wire_rate_limit_counter`. No new infra.
+- **Risk: stale analysis doc line numbers** — `cat8-errorbudget-redis-wiring-analysis-20260531.md` is 18 sprints old; ALL line numbers re-verified at Day 0 (D-DAY0-1..7) against `18b6dd16`. Per the doc's own §5 tool-reliability lesson, key routing was grep-confirmed (not single-shot).
+- **Risk: cross-category import** — the new platform_layer provider type-hints `BudgetStore` (agent_harness Protocol). Mitigated: TYPE_CHECKING-only import + platform_layer→agent_harness is an established allowed direction (10+ precedents); `check_cross_category_import` must stay green (Day-1 gate).
+- **Risk: budget only increments on errors** — the correctness claim (accumulation) cannot be cheaply shown via a real happy-path chat; proven instead by the deterministic fakeredis accumulation test + the startup-log wiring check. No real-Azure leg this sprint (unlike 57.79/57.80 where the bug was on the happy path). Documented in §3.6 so it is not read as a coverage gap.
+- **Risk: don't over-wire** — RedisBudgetStore is pure Redis; do NOT copy the rate-limit counter's DB `session_factory` / RLS `app.tenant_id` (budget tenant isolation is already in the key; adding DB write-through would be scope creep / over-engineering per the analysis §6).
+
+---
+
+## 9. Out of Scope (this sprint; carryover)
+
+- **error_budgets.yaml per-tenant overrides** — the `budget.py` docstring mentions YAML-tunable per-tenant caps; the factory uses the `TenantErrorBudget` defaults (1000/day, 20000/month). Loading per-tenant overrides is a separate feature, not wiring. Not this sprint.
+- **B-8 Verification default-enable** / **C-15 DevOps/data-platform billing** — the bundle's other legs; separate sprints.
+- **Real-LLM budget-enforcement e2e** (provoking real tool errors to trip the budget on real Azure) — deferred; the fakeredis accumulation test is the proof here.
+- **GitHub Secrets + scheduled e2e gate** (`AD-CI-6`) — production-launch concern.


### PR DESCRIPTION
## Summary
Closes B-7 / `AD-ErrorBudget-Redis-Wiring`. The per-tenant error budget (Cat 8 `TenantErrorBudget`) was backed by a fresh `InMemoryBudgetStore()` constructed **per request** inside `make_chat_error_deps()` → counters reset every request (budget effectively non-functional even single-instance) and never shared across instances. `RedisBudgetStore` was fully implemented + fakeredis-tested in Sprint 53.2 but **never wired** (AP-2 side-track). This became live-relevant after Sprint 57.79/57.80 made the real_llm chat path run end-to-end.

## Root cause
Wiring gap, not missing logic. `TenantErrorBudget` is stateless — all counter state lives in the injected `BudgetStore` (keys `error_budget:{tenant_id}:day|month:...`), so a per-request wrapper over a SHARED store accumulates correctly. The fix is to provide that shared store.

## Solution (Tier 1 wiring, backend-only Cat 8; agent_harness stays DI-pure)
1. NEW `platform_layer/governance/error_budget_provider.py` — process-global `BudgetStore` singleton accessors (`get_` / `maybe_get_` / `set_` / `reset_budget_store`), mirroring `rate_limit_counter.py`. `BudgetStore` typed via TYPE_CHECKING (structural Protocol → no runtime coupling).
2. `agent_harness/error_handling/__init__.py` — export `RedisBudgetStore` (was private; redis import stays TYPE_CHECKING-lazy).
3. `api/main.py` — NEW `_wire_error_budget()` (fail-open, mirrors `_wire_rate_limit_counter`): `Redis.from_url(settings.redis_url)` → `set_budget_store(RedisBudgetStore(client))`; called in `_lifespan`. Pure Redis — no DB `session_factory` / RLS (budget tenant isolation is already in the key; deliberately NOT copying the rate-limit counter's DB write-through).
4. `api/v1/chat/_category_factories.py` — `TenantErrorBudget(maybe_get_budget_store() or InMemoryBudgetStore())` + deferred-comment updated (AP-2 repaid). Fixes BOTH the per-request reset (shared store) AND cross-instance correctness.

No change to `loop.py` / `budget.py` / `RedisBudgetStore` / schema / frontend.

## Verification
- Unit/integration (`tests/unit/platform_layer/governance/test_error_budget_provider.py`, 7 tests): provider accessors; **accumulation** — two `make_chat_error_deps()` calls (= two requests) over a wired `RedisBudgetStore(FakeRedis())` + a `record()` each → `store.get(_day_key) == 2` (per-request reset fixed); binds-wired-store; InMemory fallback when unwired.
- Startup-log (local backend, no Azure): `api.main: error budget store wired` confirmed alongside the rate-limit + pricing wiring (Risk Class E — wiring fires; no fail-open warning). No real-Azure leg — the budget only increments on tool ERRORS, so a happy-path chat would prove nothing; the fakeredis accumulation test is the deterministic proof.
- Gates: `mypy src/` 0 (332) + `pytest` 2137 passed / 4 skipped (+7) + `python scripts/lint/run_all.py` 10/10 (check_cross_category_import + check_llm_sdk_leak green; check_rls_policies unchanged — no schema). black/isort/flake8 clean.

Change record: `claudedocs/4-changes/feature-changes/CHANGE-048-errorbudget-redis-wiring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)