### PR TITLE
feat(sprint-57-84): C-15 transactional billing Outbox — durable cost events + idempotent drain (closes C-15 billing-write-atomicity leg / AD-Cost-Ledger-Outbox-Atomicity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Build enterprise AI agent teams that work like **human professional teams** — 
 | Attribute | Value |
 |-----------|-------|
 | **Phase** | V2 22/22 ✅ + SaaS Stage 1 3/3 ✅ + SaaS Frontend ongoing (Phase 57+) |
-| **Current Sprint** | Sprint 57.83 (PR pending) — **B-8 leg-2: general judge + real-LLM e2e + flip default** (closes B-8 / `AD-Cat10-Wire-1-Production` — **完整 B-8 epic COMPLETE**): NEW lightweight `output_quality` judge (clearly-failed-only) + default template swap; a real-Azure measurement data-gated the flip (fail-on-any judge FP ~75% → DO-NOT-FLIP → re-tuned lightweight → FP 0% → FLIP) → flipped `chat_verification_mode` default `disabled`→`enabled`. Final-output verification now ON by default for `real_llm` chat (env-overridable rollback). backend+docs mypy 0/332 + pytest 2150 + run_all 10/10; CHANGE-050; measurement artifact in `claudedocs/5-status/`. Detail: `memory/project_phase57_83_verification_default_enable.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
+| **Current Sprint** | Sprint 57.84 (PR pending) — **C-15 transactional billing Outbox** (closes C-15 billing-write-atomicity leg / `AD-Cost-Ledger-Outbox-Atomicity` → billing key-chain ② C-11+B-7+B-8+C-15-billing closed): NEW `billing_outbox` table (migration 0025, RLS + system-sentinel drainer escape) + `BillingOutboxService.enqueue` (atomic, ON CONFLICT idempotent — no 漏扣) + `BillingOutboxDrainer.drain_once` (per-row txn, exactly-once via existing CostLedgerService — no 雙扣) + lifespan poller; **router flipped** chat cost-write → billing_outbox enqueue. real-Azure smoke ✅ (gpt-5.2 chain chat→enqueue→drain→cost_ledger). IaC/DR/Analytics deferred (external-blocked). mypy 0/335 + pytest 2161 + run_all 10/10; CHANGE-051. Detail: `memory/project_phase57_84_billing_outbox.md`. Next: `claudedocs/1-planning/next-phase-candidates.md`. |
 | **Sprint History** | See [`memory/MEMORY.md`](memory/MEMORY.md) §Recent Sprints + per-sprint subfile `memory/project_phase57_XX_*.md` + retrospective.md under `docs/03-implementation/agent-harness-execution/phase-57/sprint-57-XX/` |
 | **Pending / Next Phase** | See [`claudedocs/1-planning/next-phase-candidates.md`](claudedocs/1-planning/next-phase-candidates.md) |
 | **Roadmap** | Phase 49-55 V2 ✅ / Phase 56-58 SaaS Stage 1 3/3 ✅ / Phase 57+ Frontend ongoing |
@@ -586,7 +586,7 @@ V1 完整 CLAUDE.md 已保留於 `CLAUDE.backup.md`。如需查閱 V1 架構（M
 
 ---
 
-**Last Updated**: 2026-06-05 (Sprint 57.83 — B-8 leg-2: general output_quality judge + real-LLM measurement + flip chat_verification_mode default→enabled, closes B-8/AD-Cat10-Wire-1-Production = 完整 B-8 epic COMPLETE; data-gated flip (fail-on-any FP ~75% → lightweight FP 0%); final-output verification ON by default for real_llm chat; backend+docs mypy 0/332 + pytest 2150 + run_all 10/10; CHANGE-050; PR pending); see `memory/` for sprint history
+**Last Updated**: 2026-06-06 (Sprint 57.84 — C-15 transactional billing Outbox: billing_outbox table + migration 0025 (RLS + sentinel drainer escape) + enqueue (atomic, idempotent — no 漏扣) + drainer (per-row txn, exactly-once — no 雙扣) + lifespan poller; router flipped chat cost-write → billing_outbox enqueue; real-Azure smoke ✅; closes C-15 billing-write-atomicity leg → billing key-chain ② closed; IaC/DR/Analytics deferred; mypy 0/335 + pytest 2161 + run_all 10/10; CHANGE-051; PR pending); see `memory/` for sprint history
 **Project Start**: 2025-11-14
 **V2 Authority**: `docs/03-implementation/agent-harness-planning/` (21 docs — 20 規劃 + 1 review)
 **V1 Reference**: `CLAUDE.backup.md` + `docs/07-analysis/V9/00-index.md`

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -51,9 +51,11 @@ Related:
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator
 
 from dotenv import load_dotenv
 from fastapi import FastAPI
@@ -80,6 +82,9 @@ from platform_layer.observability import (
     setup_opentelemetry,
     shutdown_opentelemetry,
 )
+
+if TYPE_CHECKING:
+    from platform_layer.billing.billing_outbox import BillingOutboxDrainer
 
 logger = logging.getLogger(__name__)
 
@@ -190,6 +195,103 @@ def _wire_error_budget() -> None:
         )
 
 
+def _wire_billing_outbox() -> None:
+    """Install the BillingOutboxService enqueue singleton at startup (fail-soft).
+
+    Sprint 57.84 (C-15): the chat observer enqueues durable billing events via
+    maybe_get_billing_outbox() (atomic with the request txn — replaces the
+    best-effort direct cost_ledger write). The service is stateless (db passed
+    per call) so this just registers a process-wide instance. Fail-soft: if
+    registration fails, the chat observer's enqueue is skipped (degrade, like
+    the pricing loader).
+    """
+    try:
+        from platform_layer.billing.billing_outbox import (
+            BillingOutboxService,
+            set_billing_outbox,
+        )
+
+        set_billing_outbox(BillingOutboxService())
+        logger.info("api.main: billing outbox enqueue service wired")
+    except Exception:  # noqa: BLE001 — fail-soft: never block startup on the outbox
+        logger.warning(
+            "api.main: billing outbox enqueue service not wired (fail-soft)",
+            exc_info=True,
+        )
+
+
+async def _billing_outbox_poll_loop(
+    drainer: BillingOutboxDrainer,
+    interval_s: int,
+    stop_event: asyncio.Event,
+) -> None:
+    """Drain the billing outbox every interval_s until stop_event is set.
+
+    Fail-open: a drain-cycle exception is logged and the loop continues (a
+    transient DB flake must never kill the poller). Shutdown is prompt — the
+    interval sleep is interrupted by stop_event.
+    """
+    while not stop_event.is_set():
+        try:
+            stats = await drainer.drain_once()
+            if stats.materialized or stats.failed or stats.dead_lettered:
+                logger.info(
+                    "api.main: billing outbox drain — materialized=%d failed=%d dead=%d",
+                    stats.materialized,
+                    stats.failed,
+                    stats.dead_lettered,
+                )
+        except Exception:  # noqa: BLE001 — fail-open: a flake must not kill the poller
+            logger.exception("api.main: billing outbox drain cycle failed")
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_s)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass  # interval elapsed → next cycle
+
+
+async def _start_billing_outbox_drainer(app: FastAPI) -> None:
+    """Start the background billing-outbox drainer poll loop (fail-open).
+
+    Sprint 57.84 (C-15): drains billing_outbox → cost_ledger every
+    settings.billing_outbox_poll_interval_s. Disabled via env
+    BILLING_OUTBOX_DRAINER_ENABLED=false (tests + ops kill switch; read as a
+    plain env flag to dodge the get_settings() lru_cache timing trap). Needs the
+    pricing loader (wired above); if absent the drainer is not started. The task
+    + stop event are stored on app.state for shutdown cancellation.
+    """
+    if os.environ.get("BILLING_OUTBOX_DRAINER_ENABLED", "true").lower() != "true":
+        logger.info("api.main: billing outbox drainer disabled (env)")
+        return
+    try:
+        from core.config import get_settings
+        from infrastructure.db.engine import get_session_factory
+        from platform_layer.billing.billing_outbox import BillingOutboxDrainer
+        from platform_layer.billing.pricing import maybe_get_pricing_loader
+
+        pricing = maybe_get_pricing_loader()
+        if pricing is None:
+            logger.warning(
+                "api.main: billing outbox drainer not started; pricing loader unavailable"
+            )
+            return
+        settings = get_settings()
+        drainer = BillingOutboxDrainer(
+            get_session_factory(),
+            pricing,
+            batch=settings.billing_outbox_batch,
+            max_retry=settings.billing_outbox_max_retry,
+        )
+        stop_event = asyncio.Event()
+        task = asyncio.create_task(
+            _billing_outbox_poll_loop(drainer, settings.billing_outbox_poll_interval_s, stop_event)
+        )
+        app.state.billing_outbox_stop = stop_event
+        app.state.billing_outbox_task = task
+        logger.info("api.main: billing outbox drainer started")
+    except Exception:  # noqa: BLE001 — fail-open: never block startup on the drainer
+        logger.warning("api.main: billing outbox drainer not started (fail-open)", exc_info=True)
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Startup: load .env + structured logging + OTel SDK. Shutdown: flush + dispose engine."""
@@ -202,10 +304,23 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     _wire_rate_limit_counter()
     _wire_pricing_loader()
     _wire_error_budget()
+    _wire_billing_outbox()
+    await _start_billing_outbox_drainer(app)
     logger.info("api.main: startup complete")
     try:
         yield
     finally:
+        # Sprint 57.84 (C-15): stop the billing-outbox drainer BEFORE OTel +
+        # engine teardown (the poller uses the DB engine).
+        _stop_event = getattr(app.state, "billing_outbox_stop", None)
+        _drainer_task = getattr(app.state, "billing_outbox_task", None)
+        if _stop_event is not None:
+            _stop_event.set()
+        if _drainer_task is not None:
+            try:
+                await asyncio.wait_for(_drainer_task, timeout=10)
+            except (TimeoutError, asyncio.TimeoutError, asyncio.CancelledError):
+                _drainer_task.cancel()
         await shutdown_opentelemetry()
         await dispose_engine()
         logger.info("api.main: shutdown complete")

--- a/backend/src/api/v1/chat/router.py
+++ b/backend/src/api/v1/chat/router.py
@@ -38,6 +38,7 @@ Created: 2026-04-30 (Sprint 50.2 Day 1.5)
 Last Modified: 2026-06-05
 
 Modification History (newest-first):
+    - 2026-06-05: Sprint 57.84 — C-15: chat cost-write → billing_outbox enqueue + drainer
     - 2026-06-05: Sprint 57.82 — record verification judge LLM cost + count vs quota (B-8 leg-1)
     - 2026-06-02: Sprint 57.71 — thread real tracer into build_handler (A-4 Tier 0)
     - 2026-06-02: Sprint 57.69 A-3b — pass parent_context to boot_handoff (carry parent convo)
@@ -89,10 +90,11 @@ from core.config import get_settings
 from infrastructure.db.audit_helper import append_audit
 from infrastructure.db.repositories import SessionRepository, ToolCallRepository
 from infrastructure.db.session import get_db_session
-from platform_layer.billing import (
-    CostLedgerService,
-    PricingLoader,
-    maybe_get_pricing_loader,
+from platform_layer.billing.billing_outbox import (
+    BillingOutboxService,
+    llm_idempotency_key,
+    maybe_get_billing_outbox,
+    tool_idempotency_key,
 )
 from platform_layer.governance.service_factory import (
     ServiceFactory,
@@ -142,7 +144,6 @@ async def chat(
     db: AsyncSession = Depends(get_db_session),
     quota_enforcer: QuotaEnforcer | None = Depends(maybe_get_quota_enforcer),
     sla_recorder: SLAMetricRecorder | None = Depends(maybe_get_sla_recorder),
-    pricing_loader: PricingLoader | None = Depends(maybe_get_pricing_loader),
     tracer: Tracer = Depends(get_tracer),
 ) -> StreamingResponse:
     """Run an agent loop and stream LoopEvents as SSE.
@@ -286,13 +287,14 @@ async def chat(
     # per-tenant Redis sliding window via SLAMetricRecorder.
     chat_start_time = time.monotonic()
 
-    # Sprint 56.3 Day 3 (US-4 — Cost Ledger auto-record):
-    # Construct CostLedgerService per-request when pricing_loader is wired.
-    # CostLedgerService writes use the same `db` session as BusinessServiceFactory
-    # (kept alive by FastAPI for the StreamingResponse iterator's lifetime).
-    cost_ledger_service: CostLedgerService | None = None
-    if pricing_loader is not None:
-        cost_ledger_service = CostLedgerService(db=db, pricing_loader=pricing_loader)
+    # Sprint 57.84 (C-15 billing-Outbox flip): the chat observer now ENQUEUES a
+    # durable billing event into billing_outbox (atomic with the request txn)
+    # instead of writing cost_ledger best-effort. A background drainer (wired in
+    # api/main.py) materializes cost_ledger from the outbox idempotently — pricing
+    # is resolved by the drainer (single-source), so the router no longer needs the
+    # PricingLoader. maybe_get_billing_outbox() is None only if startup wiring
+    # failed → enqueue is skipped (degrade, same best-effort spirit as before).
+    billing_outbox = maybe_get_billing_outbox()
 
     return StreamingResponse(
         _stream_loop_events(
@@ -306,7 +308,7 @@ async def chat(
             estimated_tokens=estimated_tokens,
             sla_recorder=sla_recorder,
             chat_start_time=chat_start_time,
-            cost_ledger=cost_ledger_service,
+            billing_outbox=billing_outbox,
             db=db,
             verifier_registry=verifier_registry,
         ),
@@ -333,7 +335,7 @@ async def _stream_loop_events(
     estimated_tokens: int = 0,
     sla_recorder: SLAMetricRecorder | None = None,
     chat_start_time: float | None = None,
-    cost_ledger: CostLedgerService | None = None,
+    billing_outbox: BillingOutboxService | None = None,
     db: AsyncSession | None = None,
     verifier_registry: VerifierRegistry | None = None,
 ) -> AsyncIterator[bytes]:
@@ -360,6 +362,9 @@ async def _stream_loop_events(
     # build_handler — built with the loop's OWN adapter (shared ChatClient) when
     # settings.chat_verification_mode == "enabled", else None.
     natural_completion = False
+    # Sprint 57.84 (C-15): per-request monotonic seq disambiguates repeated
+    # same-tool billing events in the idempotency key (a replay reuses the seq).
+    tool_seq = 0
     try:
         async for event in run_with_verification(
             agent_loop=loop,  # type: ignore[arg-type]
@@ -430,56 +435,81 @@ async def _stream_loop_events(
                             tenant_id,
                             session_id,
                         )
-                # Sprint 56.3 Day 3 (US-4) → Sprint 57.2 (closes
-                # AD-Cost-Ledger-Token-Split + AD-Cost-Ledger-Provider-Attribution):
-                # Record TWO ledger entries (input + output split) from
-                # LoopCompleted accumulator-sourced fields. Provider/model
-                # now truthful (sourced from event.provider + event.model
-                # populated by AgentLoop from adapter.model_info().provider +
-                # ChatResponse.model). Best-effort failure: ledger write must
-                # not break SSE stream. Fallback for early-termination paths
-                # (provider="" or empty token counts) skips the write per
-                # event.input_tokens > 0 OR event.output_tokens > 0 gate.
-                if cost_ledger is not None and (event.input_tokens > 0 or event.output_tokens > 0):
+                # Sprint 57.84 (C-15 billing-Outbox flip): ENQUEUE a durable
+                # llm_call billing event into billing_outbox (atomic with this
+                # request's txn) instead of writing cost_ledger directly. A
+                # background drainer materializes cost_ledger from the outbox
+                # idempotently (pricing single-source in the drainer). Provider/
+                # model sourced truthfully from the LoopCompleted accumulator;
+                # early-termination paths (empty tokens) skip the enqueue. The
+                # enqueue is a single INSERT in the request txn → the billing event
+                # commits atomically with session/audit (no more best-effort 漏扣).
+                # Logged best-effort isolation kept so a rare enqueue hiccup does
+                # not break the SSE stream (consistent w/ sessions/audit observers).
+                if (
+                    billing_outbox is not None
+                    and db is not None
+                    and (event.input_tokens > 0 or event.output_tokens > 0)
+                ):
                     try:
-                        await cost_ledger.record_llm_call(
+                        await billing_outbox.enqueue(
+                            db,
                             tenant_id=tenant_id,
-                            provider=event.provider or "azure_openai",
-                            model=event.model or _FALLBACK_PRICING_MODEL,
-                            input_tokens=event.input_tokens,
-                            output_tokens=event.output_tokens,
+                            event_type="llm_call",
+                            payload={
+                                "provider": event.provider or "azure_openai",
+                                "model": event.model or _FALLBACK_PRICING_MODEL,
+                                "input_tokens": event.input_tokens,
+                                "output_tokens": event.output_tokens,
+                                "cached_input_tokens": 0,
+                                "sub_type_suffix": "",
+                            },
+                            idempotency_key=llm_idempotency_key(session_id, ""),
                             session_id=session_id,
                         )
                     except Exception:  # noqa: BLE001
                         logger.exception(
-                            "chat session %s/%s: cost ledger LLM record failed",
+                            "chat session %s/%s: billing outbox LLM enqueue failed",
                             tenant_id,
                             session_id,
                         )
-                # Sprint 57.82 (B-8 leg-1): record the Cat 10 verification judge
-                # LLM call as a DISTINCT `_verification` sub_type so judge cost is
-                # separately auditable (not mixed into the loop entry). Judge shares
-                # the loop adapter → event.provider is correct; model is the judge's
-                # own (verification_model), falling back to the loop model. 0 tokens
+                # Sprint 57.84 (C-15): enqueue the Cat 10 verification judge LLM
+                # call as a DISTINCT `_verification` billing event (B-8 leg-1 cost
+                # attribution preserved — the drainer materializes the
+                # `_verification` sub_type). Judge shares the loop adapter →
+                # event.provider correct; model is the judge's own
+                # (verification_model) falling back to the loop model. 0 tokens
                 # (verification disabled / no judge ran) → skip.
-                if cost_ledger is not None and (
-                    event.verification_input_tokens > 0 or event.verification_output_tokens > 0
+                if (
+                    billing_outbox is not None
+                    and db is not None
+                    and (
+                        event.verification_input_tokens > 0 or event.verification_output_tokens > 0
+                    )
                 ):
                     try:
-                        await cost_ledger.record_llm_call(
+                        await billing_outbox.enqueue(
+                            db,
                             tenant_id=tenant_id,
-                            provider=event.provider or "azure_openai",
-                            model=(
-                                event.verification_model or event.model or _FALLBACK_PRICING_MODEL
-                            ),
-                            input_tokens=event.verification_input_tokens,
-                            output_tokens=event.verification_output_tokens,
+                            event_type="llm_call",
+                            payload={
+                                "provider": event.provider or "azure_openai",
+                                "model": (
+                                    event.verification_model
+                                    or event.model
+                                    or _FALLBACK_PRICING_MODEL
+                                ),
+                                "input_tokens": event.verification_input_tokens,
+                                "output_tokens": event.verification_output_tokens,
+                                "cached_input_tokens": 0,
+                                "sub_type_suffix": "_verification",
+                            },
+                            idempotency_key=llm_idempotency_key(session_id, "_verification"),
                             session_id=session_id,
-                            sub_type_suffix="_verification",
                         )
                     except Exception:  # noqa: BLE001
                         logger.exception(
-                            "chat session %s/%s: cost ledger verification record failed",
+                            "chat session %s/%s: billing outbox verification enqueue failed",
                             tenant_id,
                             session_id,
                         )
@@ -582,21 +612,29 @@ async def _stream_loop_events(
                             session_id,
                         )
                 break
-            # Sprint 56.3 Day 3 (US-4 — Cost Ledger tool hook):
-            # Record one cost ledger entry per ToolCallExecuted event (per
-            # Day 0 D4 — event already exists at events.py:131; no new
-            # event needed). Per-tenant pricing comes from
-            # config/llm_pricing.yml (default_per_call + named overrides).
-            if isinstance(event, ToolCallExecuted) and cost_ledger is not None:
+            # Sprint 57.84 (C-15): enqueue one tool_call billing event per
+            # ToolCallExecuted into billing_outbox (the drainer prices it from
+            # config/llm_pricing.yml + materializes cost_ledger). tool_seq makes
+            # repeated same-tool calls in one loop distinct while a replay reuses
+            # the same key (idempotent). Best-effort isolation kept (SSE safety).
+            if (
+                isinstance(event, ToolCallExecuted)
+                and billing_outbox is not None
+                and db is not None
+            ):
                 try:
-                    await cost_ledger.record_tool_call(
+                    await billing_outbox.enqueue(
+                        db,
                         tenant_id=tenant_id,
-                        tool_name=event.tool_name,
+                        event_type="tool_call",
+                        payload={"tool_name": event.tool_name},
+                        idempotency_key=tool_idempotency_key(session_id, event.tool_name, tool_seq),
                         session_id=session_id,
                     )
+                    tool_seq += 1
                 except Exception:  # noqa: BLE001
                     logger.exception(
-                        "chat session %s/%s: cost ledger tool record failed (tool=%s)",
+                        "chat session %s/%s: billing outbox tool enqueue failed (tool=%s)",
                         tenant_id,
                         session_id,
                         event.tool_name,

--- a/backend/src/core/config/__init__.py
+++ b/backend/src/core/config/__init__.py
@@ -141,6 +141,16 @@ class Settings(BaseSettings):
     # Override via env: VERIFICATION_LOG_PERSIST_ENABLED=false (kill switch).
     verification_log_persist_enabled: bool = True
 
+    # ---- Sprint 57.84 C-15 billing Outbox drainer ------------------
+    # The background poller (api/main.py _start_billing_outbox_drainer)
+    # drains billing_outbox → cost_ledger. These tune the loop. The
+    # enabled flag is read from os.environ directly (BILLING_OUTBOX_DRAINER_
+    # ENABLED, default "true") so tests disable it without the get_settings()
+    # lru_cache timing trap (mirrors AUDIT_LOG_CHAT_OBSERVER).
+    billing_outbox_poll_interval_s: int = 5
+    billing_outbox_batch: int = 50
+    billing_outbox_max_retry: int = 8
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/src/infrastructure/db/migrations/versions/0025_billing_outbox.py
+++ b/backend/src/infrastructure/db/migrations/versions/0025_billing_outbox.py
@@ -1,0 +1,152 @@
+"""billing_outbox — transactional outbox for durable idempotent cost events (Sprint 57.84).
+
+Revision ID: 0025_billing_outbox
+Revises: 0024_memory_ops
+Create Date: 2026-06-05
+
+File: backend/src/infrastructure/db/migrations/versions/0025_billing_outbox.py
+Purpose: Create the billing_outbox table (transactional outbox: chat request
+    enqueues a chargeable LLM/tool event atomically with its own txn; a
+    background drainer materializes cost_ledger idempotently) + RLS policies.
+    No data-seed (new empty outbox). Closes the C-15 billing-write-atomicity
+    leg's schema (US-1 + US-2).
+Category: Infrastructure / Migration (Sprint 57.84 — C-15 billing Outbox)
+Scope: Sprint 57.84 / US-1 + US-2
+
+Tables:
+    billing_outbox
+       - tenant_id FK → tenants(id) ON DELETE CASCADE (TenantScopedMixin).
+       - UNIQUE (tenant_id, idempotency_key) — idempotent enqueue (US-2).
+       - idx_billing_outbox_due (next_retry_at) WHERE status IN
+         ('pending','failed') — the drainer claim path.
+       - idx_billing_outbox_tenant (tenant_id).
+       - CHECK on status + event_type enums.
+       - RLS: tenant_isolation_* (USING) + tenant_insert_* (WITH CHECK) +
+         FORCE, mirroring 0024_memory_ops. The USING clause carries a
+         system-context ESCAPE for the background drainer: when
+         app.tenant_id is the all-zeros sentinel, the row is visible
+         cross-tenant so the poller can claim/update due rows across
+         tenants. Per row the drainer sets app.tenant_id = row.tenant_id
+         before the cost_ledger materialize (cost_ledger keeps its own RLS).
+         No request ever runs under the sentinel (missing JWT → 401), so the
+         escape does not weaken per-request isolation. check_rls_policies
+         only requires ENABLE RLS + a CREATE POLICY ON the table (it does not
+         constrain the USING expression).
+
+downgrade():
+    Drops both policies + indexes + the table.
+
+Modification History:
+    - 2026-06-05: Initial creation (Sprint 57.84 / US-1 + US-2)
+
+Related:
+    - 0024_memory_ops.py — two-policy RLS pattern (mirror + escape extension)
+    - infrastructure/db/models/billing_outbox.py:BillingOutboxEvent — ORM
+    - platform_layer/billing/billing_outbox.py — service + drainer (same sprint)
+    - sprint-57-84-plan.md §3.1
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0025_billing_outbox"
+down_revision: Union[str, None] = "0024_memory_ops"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# All-zeros sentinel tenant: the background drainer sets app.tenant_id to this
+# value to claim/update due rows across tenants. A real request never runs
+# under it (missing JWT → 401), so per-request isolation is unaffected.
+_SYSTEM_SENTINEL = "00000000-0000-0000-0000-000000000000"
+
+
+def upgrade() -> None:
+    """Create billing_outbox + indexes + RLS (two policies + drainer escape)."""
+
+    op.create_table(
+        "billing_outbox",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_type", sa.String(32), nullable=False),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column("idempotency_key", sa.String(256), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(16),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "retry_count",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("next_retry_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text, nullable=True),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("tenant_id", "idempotency_key", name="uq_billing_outbox_idem"),
+        sa.CheckConstraint(
+            "status IN ('pending', 'processing', 'done', 'failed')",
+            name="ck_billing_outbox_status",
+        ),
+        sa.CheckConstraint(
+            "event_type IN ('llm_call', 'tool_call')",
+            name="ck_billing_outbox_event_type",
+        ),
+    )
+    op.create_index(
+        "idx_billing_outbox_due",
+        "billing_outbox",
+        ["next_retry_at"],
+        postgresql_where=sa.text("status IN ('pending', 'failed')"),
+    )
+    op.create_index("idx_billing_outbox_tenant", "billing_outbox", ["tenant_id"])
+
+    # ----- RLS (two policies + drainer system-context escape) ----------
+    op.execute("ALTER TABLE billing_outbox ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE billing_outbox FORCE ROW LEVEL SECURITY")
+    # USING — SELECT / UPDATE / DELETE: per-tenant isolation PLUS the
+    # all-zeros system sentinel escape for the cross-tenant drainer claim.
+    op.execute(f"""
+        CREATE POLICY tenant_isolation_billing_outbox ON billing_outbox
+            USING (
+                tenant_id = current_setting('app.tenant_id', true)::uuid
+                OR current_setting('app.tenant_id', true)::uuid
+                   = '{_SYSTEM_SENTINEL}'::uuid
+            )
+        """)
+    # WITH CHECK — INSERT: the producer (chat request) always runs under a
+    # real tenant context, so enqueue stays strictly tenant-scoped.
+    op.execute("""
+        CREATE POLICY tenant_insert_billing_outbox ON billing_outbox
+            FOR INSERT
+            WITH CHECK (tenant_id = current_setting('app.tenant_id', true)::uuid)
+        """)
+
+
+def downgrade() -> None:
+    """Drop RLS policies + indexes + table."""
+    op.execute("DROP POLICY IF EXISTS tenant_insert_billing_outbox ON billing_outbox")
+    op.execute("DROP POLICY IF EXISTS tenant_isolation_billing_outbox ON billing_outbox")
+    op.drop_index("idx_billing_outbox_tenant", table_name="billing_outbox")
+    op.drop_index("idx_billing_outbox_due", table_name="billing_outbox")
+    op.drop_table("billing_outbox")

--- a/backend/src/infrastructure/db/models/__init__.py
+++ b/backend/src/infrastructure/db/models/__init__.py
@@ -38,6 +38,13 @@ from infrastructure.db.models.api_keys import (
 # Day 1.1 (Sprint 49.3) — Audit
 from infrastructure.db.models.audit import AuditLog
 
+# Sprint 57.84 — BillingOutboxEvent (transactional outbox; C-15 billing leg)
+from infrastructure.db.models.billing_outbox import (
+    BillingOutboxEvent,
+    OutboxEventType,
+    OutboxStatus,
+)
+
 # Sprint 55.1 — Business domain (incident production table)
 from infrastructure.db.models.business import (
     Incident,
@@ -169,6 +176,10 @@ __all__ = [
     # Cost Ledger (Sprint 56.3 Day 2 — US-3)
     "CostLedger",
     "CostType",
+    # Billing Outbox (Sprint 57.84 — transactional outbox, C-15 billing leg)
+    "BillingOutboxEvent",
+    "OutboxStatus",
+    "OutboxEventType",
     # Verification Log (Sprint 57.11 Day 1 — US-1)
     "VerificationLog",
     "VerifierType",

--- a/backend/src/infrastructure/db/models/billing_outbox.py
+++ b/backend/src/infrastructure/db/models/billing_outbox.py
@@ -1,0 +1,133 @@
+"""
+File: backend/src/infrastructure/db/models/billing_outbox.py
+Purpose: BillingOutboxEvent ORM — transactional outbox for durable, idempotent cost events.
+Category: Infrastructure / ORM (platform_layer.billing — C-15 billing-write-atomicity)
+Scope: Sprint 57.84 / US-1 + US-2
+
+Description:
+    Transactional-outbox row capturing a chargeable LLM/tool event. The chat
+    request observer enqueues one row PER chargeable event in the SAME request
+    transaction (atomic with session/audit writes) instead of writing
+    cost_ledger best-effort. A background drainer (BillingOutboxDrainer) then
+    materializes cost_ledger from `payload` idempotently, so a ledger-write
+    flake can no longer silently drop a charge (漏扣) and a retry/replay never
+    double-charges (雙扣).
+
+    `payload` carries the LLM-provider-neutral args of the existing
+    CostLedgerService.record_llm_call / record_tool_call (provider / model /
+    input_tokens / output_tokens / cached_input_tokens / sub_type_suffix /
+    tool_name / session_id) — pricing stays single-source in CostLedgerService
+    (C-11 / Sprint 57.79 unchanged). No SDK import (neutrality).
+
+    Idempotency: UNIQUE(tenant_id, idempotency_key) — a redelivered event is a
+    no-op enqueue; the drain claims + materializes + marks done in one txn so a
+    crash mid-row re-claims rather than double-charges.
+
+Key Components:
+    - OutboxStatus / OutboxEventType: enum mirrors of the CHECK constraints
+    - BillingOutboxEvent: ORM (TenantScopedMixin)
+
+Created: 2026-06-05 (Sprint 57.84)
+
+Modification History:
+    - 2026-06-05: Initial creation (Sprint 57.84 / US-1 + US-2)
+
+Related:
+    - 09-db-schema-design.md §outbox (notification design — NOT reused; D1)
+    - migrations/versions/0025_billing_outbox.py
+    - platform_layer/billing/billing_outbox.py (BillingOutboxService + Drainer)
+    - platform_layer/billing/cost_ledger.py (drain target — pricing single-source)
+    - .claude/rules/multi-tenant-data.md 鐵律 1 (tenant_id NN + RLS)
+"""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from uuid import UUID as PyUUID
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from infrastructure.db.base import Base, TenantScopedMixin
+
+
+class OutboxStatus(str, enum.Enum):
+    """billing_outbox.status — matches CHECK constraint."""
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class OutboxEventType(str, enum.Enum):
+    """billing_outbox.event_type — matches CHECK constraint."""
+
+    LLM_CALL = "llm_call"
+    TOOL_CALL = "tool_call"
+
+
+class BillingOutboxEvent(Base, TenantScopedMixin):
+    """Transactional outbox row for a durable, idempotent cost event."""
+
+    __tablename__ = "billing_outbox"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    event_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    payload: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String(256), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'pending'")
+    )
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    session_id: Mapped[PyUUID | None] = mapped_column(PgUUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "idempotency_key",
+            name="uq_billing_outbox_idem",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'processing', 'done', 'failed')",
+            name="ck_billing_outbox_status",
+        ),
+        CheckConstraint(
+            "event_type IN ('llm_call', 'tool_call')",
+            name="ck_billing_outbox_event_type",
+        ),
+        # Drainer claim path: due rows are pending OR failed-and-retry-due.
+        Index(
+            "idx_billing_outbox_due",
+            "next_retry_at",
+            postgresql_where=text("status IN ('pending', 'failed')"),
+        ),
+        Index("idx_billing_outbox_tenant", "tenant_id"),
+    )
+
+
+__all__ = [
+    "BillingOutboxEvent",
+    "OutboxStatus",
+    "OutboxEventType",
+]

--- a/backend/src/platform_layer/billing/billing_outbox.py
+++ b/backend/src/platform_layer/billing/billing_outbox.py
@@ -1,0 +1,331 @@
+"""
+File: backend/src/platform_layer/billing/billing_outbox.py
+Purpose: Transactional billing Outbox — idempotent enqueue (producer) + idempotent drain (consumer).
+Category: platform_layer.billing (C-15 billing-write-atomicity leg)
+Scope: Sprint 57.84 / US-1 + US-2 + US-3 + US-4
+
+Description:
+    Producer (BillingOutboxService.enqueue): the chat request observer writes a
+    chargeable LLM/tool event into billing_outbox using the REQUEST's session,
+    so the cost event commits atomically with the request (no best-effort
+    swallow → no 漏扣). Idempotent: ON CONFLICT (tenant_id, idempotency_key)
+    DO NOTHING, so a redelivered event is a no-op enqueue.
+
+    Consumer (BillingOutboxDrainer.drain_once): a background poller claims due
+    rows one-at-a-time (FOR UPDATE SKIP LOCKED), sets the row's tenant context,
+    materializes cost_ledger via the EXISTING CostLedgerService (pricing
+    single-source, C-11 unchanged), and marks the row `done` IN THE SAME
+    transaction — exactly-once materialization, so a crash mid-row re-claims
+    rather than double-charges (no 雙扣). A materialize failure rolls back the
+    cost write (nothing billed) and records retry/backoff; after MAX_RETRY the
+    row dead-letters (status=failed, next_retry_at=NULL → no longer claimed).
+
+    Cross-tenant drain (US-4): the poller claims under the all-zeros system
+    sentinel (the billing_outbox RLS USING escape) and SET LOCAL app.tenant_id =
+    row.tenant_id before each cost_ledger insert (cost_ledger keeps its own RLS).
+
+    LLM neutrality: payload carries only neutral record_llm_call args; no SDK
+    import. Pricing resolved by the injected PricingLoader inside the drainer.
+
+Key Components:
+    - DrainStats: per-drain-cycle counters
+    - BillingOutboxService: enqueue (producer)
+    - BillingOutboxDrainer: drain_once (consumer poller body)
+    - llm_idempotency_key / tool_idempotency_key: stable per-event keys
+    - set_/get_/maybe_get_billing_outbox: enqueue-service singleton (+ reset hook)
+
+Created: 2026-06-05 (Sprint 57.84)
+
+Modification History:
+    - 2026-06-05: Initial creation (Sprint 57.84 / US-1..US-4)
+
+Related:
+    - infrastructure/db/models/billing_outbox.py:BillingOutboxEvent — ORM
+    - migrations/versions/0025_billing_outbox.py — table + RLS (sentinel escape)
+    - platform_layer/billing/cost_ledger.py — drain target (pricing single-source)
+    - platform_layer/billing/pricing.py — PricingLoader (injected into drainer)
+    - 17-cross-category-interfaces.md — BillingOutbox enqueue/drain contract
+    - .claude/rules/multi-tenant-data.md 鐵律 (tenant context per cost write)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from sqlalchemy import and_, func, or_, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from infrastructure.db.models.billing_outbox import BillingOutboxEvent
+from platform_layer.billing.cost_ledger import CostLedgerService
+from platform_layer.billing.pricing import PricingLoader
+
+# The all-zeros tenant sentinel matches the billing_outbox RLS USING escape
+# (0025_billing_outbox.py): under this context the poller sees rows across
+# tenants for the claim. A real request never runs under it (missing JWT → 401).
+SYSTEM_SENTINEL_TENANT = "00000000-0000-0000-0000-000000000000"
+
+# Retry backoff: next_retry_at = now + min(BASE * 2**(retry-1), CAP).
+_BASE_BACKOFF_S = 2
+_MAX_BACKOFF_S = 3600
+
+
+def llm_idempotency_key(session_id: UUID, sub_type_suffix: str) -> str:
+    """Stable key for an LLM cost event (loop vs _verification are distinct)."""
+    return f"{session_id}:llm:{sub_type_suffix or 'loop'}"
+
+
+def tool_idempotency_key(session_id: UUID, tool_name: str, seq: int) -> str:
+    """Stable key for a tool cost event (per-request monotonic seq disambiguates
+    repeated same-tool calls in one loop; a replay reuses the same seq → no-op)."""
+    return f"{session_id}:tool:{tool_name}:{seq}"
+
+
+@dataclass
+class DrainStats:
+    """Counters for one drain_once cycle."""
+
+    claimed: int = 0
+    materialized: int = 0
+    failed: int = 0
+    dead_lettered: int = 0
+
+
+# === BillingOutboxService: producer (atomic, idempotent enqueue) ===
+# Why: the chat observer used a best-effort try/except direct cost_ledger write
+# (router.py) that swallowed failures → 漏扣. Enqueuing into billing_outbox in
+# the REQUEST txn makes the cost event durable atomically with the request.
+class BillingOutboxService:
+    """Stateless producer; enqueue uses the caller's request session."""
+
+    async def enqueue(
+        self,
+        db: AsyncSession,
+        *,
+        tenant_id: UUID,
+        event_type: str,
+        payload: dict[str, object],
+        idempotency_key: str,
+        session_id: UUID | None = None,
+    ) -> None:
+        """Insert one outbox row in the caller's transaction; idempotent.
+
+        ON CONFLICT (tenant_id, idempotency_key) DO NOTHING — a redelivered
+        logical event is a no-op (does not raise, does not re-queue). The row
+        commits with the request's own commit (atomic with session/audit).
+        """
+        stmt = (
+            pg_insert(BillingOutboxEvent)
+            .values(
+                tenant_id=tenant_id,
+                event_type=event_type,
+                payload=payload,
+                idempotency_key=idempotency_key,
+                session_id=session_id,
+            )
+            .on_conflict_do_nothing(constraint="uq_billing_outbox_idem")
+        )
+        await db.execute(stmt)
+
+
+# === BillingOutboxDrainer: consumer (exactly-once idempotent drain) ===
+# Why: decouples the (future Stripe / current cost_ledger) write from the
+# request. Claim+materialize+mark-done in ONE txn = exactly-once; failures roll
+# back the cost write and reschedule. Single-instance poller today; SKIP LOCKED
+# keeps it multi-instance-safe.
+class BillingOutboxDrainer:
+    """Drains billing_outbox into cost_ledger, idempotently, with retry/backoff."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        pricing_loader: PricingLoader,
+        *,
+        batch: int = 50,
+        max_retry: int = 8,
+    ) -> None:
+        self._session_factory = session_factory
+        self._pricing = pricing_loader
+        self._batch = batch
+        self._max_retry = max_retry
+
+    async def drain_once(self) -> DrainStats:
+        """Process up to `batch` due rows, one independent transaction each."""
+        stats = DrainStats()
+        for _ in range(self._batch):
+            outcome = await self._drain_one()
+            if outcome is None:
+                break  # no more due rows this cycle
+            stats.claimed += 1
+            if outcome == "done":
+                stats.materialized += 1
+            elif outcome == "dead_letter":
+                stats.dead_lettered += 1
+            else:  # "failed"
+                stats.failed += 1
+        return stats
+
+    async def _drain_one(self) -> str | None:
+        """Claim + materialize + mark one due row. Returns the outcome, or None
+        when there is no due row to claim."""
+        async with self._session_factory() as db:
+            await self._set_tenant(db, SYSTEM_SENTINEL_TENANT)
+            row = (
+                (
+                    await db.execute(
+                        select(BillingOutboxEvent)
+                        .where(
+                            or_(
+                                BillingOutboxEvent.status == "pending",
+                                and_(
+                                    BillingOutboxEvent.status == "failed",
+                                    BillingOutboxEvent.next_retry_at <= func.now(),
+                                ),
+                            )
+                        )
+                        .order_by(BillingOutboxEvent.id)
+                        .limit(1)
+                        .with_for_update(skip_locked=True)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if row is None:
+                return None
+
+            row_id = row.id
+            try:
+                # cost_ledger insert must run under the row's real tenant (its
+                # own RLS WITH CHECK); the claim ran under the sentinel.
+                await self._set_tenant(db, str(row.tenant_id))
+                await self._materialize(db, row)
+                row.status = "done"
+                row.processed_at = _utcnow()
+                row.last_error = None
+                await db.commit()
+                return "done"
+            except Exception as exc:  # noqa: BLE001 — any materialize failure reschedules
+                # The cost write (if any) + the claim are rolled back together:
+                # nothing is billed, the lock releases, the session is usable.
+                await db.rollback()
+                return await self._record_failure(db, row_id, exc)
+
+    async def _record_failure(self, db: AsyncSession, row_id: int, exc: Exception) -> str:
+        """Bump retry/backoff (or dead-letter) in a fresh transaction."""
+        await self._set_tenant(db, SYSTEM_SENTINEL_TENANT)
+        row = (
+            (await db.execute(select(BillingOutboxEvent).where(BillingOutboxEvent.id == row_id)))
+            .scalars()
+            .first()
+        )
+        if row is None:  # pragma: no cover — claimed row vanished (CASCADE delete)
+            return "failed"
+        row.retry_count += 1
+        row.last_error = str(exc)[:2000]
+        if row.retry_count >= self._max_retry:
+            # Dead-letter: stays failed, next_retry_at NULL → no longer claimed.
+            row.status = "failed"
+            row.next_retry_at = None
+            outcome = "dead_letter"
+        else:
+            row.status = "failed"
+            row.next_retry_at = _utcnow() + timedelta(seconds=_backoff_seconds(row.retry_count))
+            outcome = "failed"
+        await db.commit()
+        return outcome
+
+    async def _materialize(self, db: AsyncSession, row: BillingOutboxEvent) -> None:
+        """Write the cost_ledger entries for one outbox row via CostLedgerService."""
+        cost_ledger = CostLedgerService(db=db, pricing_loader=self._pricing)
+        payload = row.payload
+        if row.event_type == "llm_call":
+            await cost_ledger.record_llm_call(
+                tenant_id=row.tenant_id,
+                provider=_payload_str(payload, "provider"),
+                model=_payload_str(payload, "model"),
+                input_tokens=_payload_int(payload, "input_tokens"),
+                output_tokens=_payload_int(payload, "output_tokens"),
+                cached_input_tokens=_payload_int(payload, "cached_input_tokens", 0),
+                session_id=row.session_id,
+                sub_type_suffix=_payload_str(payload, "sub_type_suffix", ""),
+            )
+        elif row.event_type == "tool_call":
+            await cost_ledger.record_tool_call(
+                tenant_id=row.tenant_id,
+                tool_name=_payload_str(payload, "tool_name"),
+                session_id=row.session_id,
+            )
+        else:  # pragma: no cover — CHECK constraint blocks other values
+            raise ValueError(f"unknown billing_outbox event_type: {row.event_type!r}")
+
+    @staticmethod
+    async def _set_tenant(db: AsyncSession, tenant_id: str) -> None:
+        """SET LOCAL app.tenant_id for the current transaction (RLS context)."""
+        # set_config(...) is the bind-param-compatible function form of SET LOCAL
+        # (asyncpg rejects params on the SET utility statement). is_local=true →
+        # txn-scoped, like SET LOCAL. Mirrors middleware/tenant_context.py.
+        await db.execute(text("SELECT set_config('app.tenant_id', :tid, true)"), {"tid": tenant_id})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _backoff_seconds(retry_count: int) -> int:
+    return min(_BASE_BACKOFF_S << (retry_count - 1), _MAX_BACKOFF_S)
+
+
+def _payload_str(payload: dict[str, object], key: str, default: str | None = None) -> str:
+    value = payload.get(key, default)
+    if not isinstance(value, str):
+        raise ValueError(f"billing_outbox payload[{key!r}] expected str, got {value!r}")
+    return value
+
+
+def _payload_int(payload: dict[str, object], key: str, default: int | None = None) -> int:
+    value = payload.get(key, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"billing_outbox payload[{key!r}] expected int, got {value!r}")
+    return value
+
+
+# Module-level singleton for the enqueue producer (stateless; db passed per call).
+# Reset hook per testing.md §Module-level Singleton Reset Pattern.
+_service: BillingOutboxService | None = None
+
+
+def get_billing_outbox() -> BillingOutboxService:
+    """FastAPI Depends accessor (strict — raises if uninitialised)."""
+    if _service is None:
+        raise RuntimeError(
+            "BillingOutboxService not initialised; call set_billing_outbox() at "
+            "app startup or in test fixture"
+        )
+    return _service
+
+
+def maybe_get_billing_outbox() -> BillingOutboxService | None:
+    """Lenient accessor — returns None if uninitialised."""
+    return _service
+
+
+def set_billing_outbox(service: BillingOutboxService | None) -> None:
+    """Install singleton (app startup or tests fixture)."""
+    global _service
+    _service = service
+
+
+__all__ = [
+    "BillingOutboxService",
+    "BillingOutboxDrainer",
+    "DrainStats",
+    "SYSTEM_SENTINEL_TENANT",
+    "llm_idempotency_key",
+    "tool_idempotency_key",
+    "get_billing_outbox",
+    "maybe_get_billing_outbox",
+    "set_billing_outbox",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -28,13 +28,41 @@ Related:
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+import os
+from collections.abc import AsyncIterator, Iterator
 
+import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from infrastructure.db import dispose_engine, get_session_factory
 from infrastructure.db.models import Tenant, User
+
+# Sprint 57.84 (C-15): keep the background billing-outbox drainer OUT of test
+# event loops. It starts in api.main._lifespan, which TestClient triggers
+# (test_main_lifespan / test_health). Read as a plain env flag (not Settings)
+# to dodge the get_settings() lru_cache timing trap — mirrors
+# AUDIT_LOG_CHAT_OBSERVER (tests/integration/api/conftest.py).
+os.environ.setdefault("BILLING_OUTBOX_DRAINER_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
+def _reset_billing_outbox_singleton() -> Iterator[None]:
+    """Reset the billing_outbox enqueue singleton around every test (Risk Class C).
+
+    api.main._lifespan (driven by TestClient in test_main_lifespan) calls
+    set_billing_outbox(); the lifespan shutdown does NOT unset it (correct for
+    production — the singleton lives for the app's life). Without this reset it
+    leaks into later tests, and a chat-path test that consumes
+    maybe_get_billing_outbox() then enqueues on the global engine (binding it to
+    that test's loop with no dispose) → a downstream db_session test hits
+    'Event loop is closed'. Mirrors testing.md §Module-level Singleton Reset.
+    """
+    from platform_layer.billing.billing_outbox import set_billing_outbox
+
+    set_billing_outbox(None)
+    yield
+    set_billing_outbox(None)
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/backend/tests/integration/api/test_chat_cost_ledger.py
+++ b/backend/tests/integration/api/test_chat_cost_ledger.py
@@ -1,39 +1,39 @@
 """
 File: backend/tests/integration/api/test_chat_cost_ledger.py
-Purpose: Integration — chat router LoopCompleted + ToolCallExecuted → CostLedger entries.
-Category: Tests / Integration / API (Phase 56 SaaS Stage 1)
-Scope: Sprint 56.3 / Day 3 / 1 integration US-4.
+Purpose: Integration — chat router LoopCompleted + ToolCallExecuted → billing_outbox enqueue.
+Category: Tests / Integration / API (Phase 56 SaaS Stage 1 / Sprint 57.84 C-15)
+Scope: Sprint 56.3 / Day 3 (US-4) → Sprint 57.84 (C-15 billing-Outbox flip).
 
 Description:
-    Drives _stream_loop_events with a stub loop yielding both
-    ToolCallExecuted (1) + LoopCompleted (1). Asserts both ledger
-    entries land in cost_ledger table with proper tenant_id + cost_type.
+    Drives _stream_loop_events with stub loops and asserts the chat observer
+    ENQUEUES durable billing events into billing_outbox (the Sprint 57.84 flip:
+    the observer no longer writes cost_ledger directly — a background drainer
+    materializes cost_ledger from the outbox; see test_billing_outbox_drain.py
+    for the drain → cost_ledger parity). The quota-reconcile test is unchanged
+    (the flip did not touch the quota path).
 
 Created: 2026-05-06 (Sprint 56.3 Day 3)
+Last Modified: 2026-06-05 (Sprint 57.84 — flip cost-write → billing_outbox enqueue)
 """
 
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from agent_harness._contracts import LoopCompleted, TraceContext
 from agent_harness._contracts.events import ToolCallExecuted
 from api.v1.chat.router import _stream_loop_events
 from api.v1.chat.session_registry import SessionRegistry
-from infrastructure.db.models.cost_ledger import CostLedger
-from platform_layer.billing.cost_ledger import CostLedgerService
-from platform_layer.billing.pricing import PricingLoader
+from infrastructure.db.models.billing_outbox import BillingOutboxEvent
+from platform_layer.billing.billing_outbox import BillingOutboxService
 from tests.conftest import seed_tenant
 
 pytestmark = pytest.mark.asyncio
-
-_PRICING_YAML = Path(__file__).resolve().parents[3] / "config" / "llm_pricing.yml"
 
 
 class _StubLoop:
@@ -67,8 +67,6 @@ class _StubLoop:
             result_content="ok",
             trace_context=trace_context,
         )
-        # Sprint 57.2: LoopCompleted carries split + provider/model
-        # (closes AD-Cost-Ledger-Token-Split + Provider-Attribution).
         yield LoopCompleted(
             stop_reason="end_turn",
             total_turns=1,
@@ -86,24 +84,24 @@ async def _consume(stream: AsyncIterator[bytes]) -> None:
         pass
 
 
-async def test_chat_request_writes_cost_ledger_end_to_end(
+async def _set_tenant(db: AsyncSession, tid: UUID) -> None:
+    # billing_outbox has FORCE RLS — set the tenant context so the enqueue's
+    # INSERT WITH CHECK passes (harmless if the test role bypasses RLS).
+    await db.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
+
+
+async def test_chat_request_enqueues_billing_outbox_end_to_end(
     db_session: AsyncSession,
 ) -> None:
-    """US-4 — full chat run yields LLM + tool ledger entries in cost_ledger table."""
-    t = await seed_tenant(db_session, code="CL_E2E_1")
+    """Sprint 57.84 (US-1/US-5) — a full chat run enqueues an llm_call + a
+    tool_call billing event into billing_outbox (the producer side of the flip)."""
+    t = await seed_tenant(db_session, code="OBX_E2E_1")
+    await _set_tenant(db_session, t.id)
     session_id = uuid4()
     registry = SessionRegistry()
     await registry.register(t.id, session_id)
 
-    pricing = PricingLoader()
-    pricing.load_from_yaml(_PRICING_YAML)
-    cost_ledger = CostLedgerService(db=db_session, pricing_loader=pricing)
-
-    stub_loop = _StubLoop(
-        input_tokens=1_200,
-        output_tokens=800,
-        tool_name="salesforce_query",
-    )
+    stub_loop = _StubLoop(input_tokens=1_200, output_tokens=800, tool_name="salesforce_query")
     trace_ctx = TraceContext(tenant_id=t.id, session_id=session_id)
 
     await _consume(
@@ -114,45 +112,38 @@ async def test_chat_request_writes_cost_ledger_end_to_end(
             registry,
             user_input="hello",
             trace_context=trace_ctx,
-            cost_ledger=cost_ledger,
+            billing_outbox=BillingOutboxService(),
+            db=db_session,
         )
     )
 
     rows = (
         (
             await db_session.execute(
-                select(CostLedger)
-                .where(CostLedger.tenant_id == t.id)
-                .order_by(CostLedger.recorded_at)
+                select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == t.id)
             )
         )
         .scalars()
         .all()
     )
+    event_types = {r.event_type for r in rows}
+    assert event_types == {"llm_call", "tool_call"}
+    assert len(rows) == 2
+    assert all(r.status == "pending" for r in rows)
+    assert all(r.session_id == session_id for r in rows)
 
-    cost_types = {r.cost_type for r in rows}
-    assert "llm" in cost_types
-    assert "tool" in cost_types
-    # Sprint 57.2: 2 LLM entries (input + output split) + 1 tool entry = 3 total.
-    assert len(rows) == 3
+    llm_row = next(r for r in rows if r.event_type == "llm_call")
+    assert llm_row.payload["input_tokens"] == 1_200
+    assert llm_row.payload["output_tokens"] == 800
+    assert llm_row.payload["model"] == "gpt-5.4"
+    assert llm_row.idempotency_key == f"{session_id}:llm:loop"
 
-    # Both LLM entries have provider/model attribution + session_id.
-    llm_rows = [r for r in rows if r.cost_type == "llm"]
-    assert len(llm_rows) == 2
-    sub_types = {r.sub_type for r in llm_rows}
-    assert sub_types == {
-        "azure_openai_gpt-5.4_input",
-        "azure_openai_gpt-5.4_output",
-    }
-    assert all(r.session_id == session_id for r in llm_rows)
-
-    # Tool entry sub_type = the tool name.
-    tool_row = next(r for r in rows if r.cost_type == "tool")
-    assert tool_row.sub_type == "salesforce_query"
-    assert tool_row.session_id == session_id
+    tool_row = next(r for r in rows if r.event_type == "tool_call")
+    assert tool_row.payload["tool_name"] == "salesforce_query"
+    assert tool_row.idempotency_key == f"{session_id}:tool:salesforce_query:0"
 
 
-# === Sprint 57.82 (B-8 leg-1): verification judge cost + quota ===
+# === Sprint 57.82 (B-8 leg-1) verification cost — flipped to outbox in 57.84 ===
 
 
 class _VerificationStubLoop:
@@ -215,19 +206,16 @@ class _SpyQuota:
         return actual_tokens
 
 
-async def test_chat_verification_judge_writes_distinct_cost_ledger_entry(
+async def test_chat_verification_judge_enqueues_distinct_billing_outbox_event(
     db_session: AsyncSession,
 ) -> None:
-    """Sprint 57.82: a LoopCompleted carrying judge tokens writes a DISTINCT
-    `_verification` cost-ledger entry, separate from the loop entry (4 rows total)."""
-    t = await seed_tenant(db_session, code="CL_VERIF_1")
+    """Sprint 57.84 (was 57.82): a LoopCompleted carrying judge tokens enqueues a
+    DISTINCT `_verification` llm_call billing event, separate from the loop event."""
+    t = await seed_tenant(db_session, code="OBX_VERIF_1")
+    await _set_tenant(db_session, t.id)
     session_id = uuid4()
     registry = SessionRegistry()
     await registry.register(t.id, session_id)
-
-    pricing = PricingLoader()
-    pricing.load_from_yaml(_PRICING_YAML)
-    cost_ledger = CostLedgerService(db=db_session, pricing_loader=pricing)
 
     stub_loop = _VerificationStubLoop(
         input_tokens=1_000,
@@ -245,33 +233,44 @@ async def test_chat_verification_judge_writes_distinct_cost_ledger_entry(
             registry,
             user_input="hi",
             trace_context=trace_ctx,
-            cost_ledger=cost_ledger,
+            billing_outbox=BillingOutboxService(),
+            db=db_session,
         )
     )
 
     rows = (
-        (await db_session.execute(select(CostLedger).where(CostLedger.tenant_id == t.id)))
+        (
+            await db_session.execute(
+                select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == t.id)
+            )
+        )
         .scalars()
         .all()
     )
-    sub_types = {r.sub_type for r in rows}
-    # loop entries + DISTINCT judge `_verification` entries
-    assert "azure_openai_gpt-5.4_input" in sub_types
-    assert "azure_openai_gpt-5.4_output" in sub_types
-    assert "azure_openai_gpt-5.4_verification_input" in sub_types
-    assert "azure_openai_gpt-5.4_verification_output" in sub_types
-    assert len(rows) == 4  # loop in+out + judge in+out
+    # Two llm_call events: the loop event + the distinct verification event.
+    assert len(rows) == 2
+    assert all(r.event_type == "llm_call" for r in rows)
+    keys = {r.idempotency_key for r in rows}
+    assert keys == {f"{session_id}:llm:loop", f"{session_id}:llm:_verification"}
 
-    verif_rows = [r for r in rows if "_verification_" in r.sub_type]
-    assert {int(r.quantity) for r in verif_rows} == {120, 8}
-    assert all(r.session_id == session_id for r in verif_rows)
+    by_key = {r.idempotency_key: r for r in rows}
+    loop_row = by_key[f"{session_id}:llm:loop"]
+    verif_row = by_key[f"{session_id}:llm:_verification"]
+    assert loop_row.payload["input_tokens"] == 1_000
+    assert loop_row.payload["sub_type_suffix"] == ""
+    assert verif_row.payload["input_tokens"] == 120
+    assert verif_row.payload["output_tokens"] == 8
+    assert verif_row.payload["sub_type_suffix"] == "_verification"
 
 
 async def test_chat_verification_tokens_counted_against_quota(
     db_session: AsyncSession,
 ) -> None:
-    """Sprint 57.82: judge tokens are added to the quota reconcile actual_tokens."""
-    t = await seed_tenant(db_session, code="CL_VERIF_Q")
+    """Sprint 57.82: judge tokens are added to the quota reconcile actual_tokens.
+
+    (Unchanged by the 57.84 flip — the quota-reconcile path is independent of the
+    cost-write → billing_outbox flip.)"""
+    t = await seed_tenant(db_session, code="OBX_VERIF_Q")
     session_id = uuid4()
     registry = SessionRegistry()
     await registry.register(t.id, session_id)

--- a/backend/tests/integration/api/test_phase56_3_e2e.py
+++ b/backend/tests/integration/api/test_phase56_3_e2e.py
@@ -1,56 +1,52 @@
 """
 File: backend/tests/integration/api/test_phase56_3_e2e.py
-Purpose: Cross-AD e2e — Phase 56.3 SLA Monitor + Cost Ledger combined chat flow.
-Category: Tests / Integration / API (Phase 56 SaaS Stage 1)
-Scope: Sprint 56.3 / Day 4 / US-5 closeout cross-AD e2e
+Purpose: Cross-AD e2e — Phase 56.3 SLA Monitor + billing enqueue + quota chat flow.
+Category: Tests / Integration / API (Phase 56 SaaS Stage 1 / Sprint 57.84 C-15)
+Scope: Sprint 56.3 / Day 4 / US-5 closeout cross-AD e2e (updated Sprint 57.84).
 
 Description:
     Single integrated chat flow that exercises:
-    - US-1 SLAMetricRecorder: record_loop_completion called via chat router
-      observer; classify_loop_complexity bucket recorded in Redis sliding
-      window; get_loop_p99 returns the recorded latency.
-    - US-3 + US-4 CostLedgerService: LoopCompleted observer writes 1 LLM
-      ledger entry; ToolCallExecuted observer writes 1 tool ledger entry;
-      aggregate(month) returns by_type breakdown with total_cost_usd > 0.
-    - US-2 + US-3 quota carryover from 56.2 (still in chat router):
-      pre-call estimate + post-call reconcile via record_usage.
-    - All 4 hooks coexist in single _stream_loop_events run without
-      breaking SSE event stream (best-effort failure pattern).
+    - US-1 SLAMetricRecorder: record_loop_completion via the chat router
+      observer; classify_loop_complexity bucket recorded in Redis; get_loop_p99
+      returns the recorded latency.
+    - US-3 + US-4 billing: Sprint 57.84 (C-15) flipped the chat observer from a
+      direct cost_ledger write to a durable billing_outbox ENQUEUE — so the
+      LoopCompleted + ToolCallExecuted observers now enqueue billing events
+      (a background drainer materializes cost_ledger; the drain → cost_ledger
+      parity is covered by tests/integration/billing/test_billing_outbox_drain.py).
+    - US-2 + US-3 quota carryover from 56.2: pre-call estimate + post-call
+      reconcile via record_usage (UNCHANGED by the flip).
+    - All hooks coexist in one _stream_loop_events run without breaking SSE.
 
-    Uses fakeredis + real db_session fixture (Postgres testcontainer per
-    conftest.py). Stub loop yields ToolCallExecuted + LoopCompleted with
-    known total_tokens to exercise both Cost Ledger code paths.
+    Uses fakeredis + real db_session fixture (Postgres per conftest.py).
 
 Created: 2026-05-06 (Sprint 56.3 Day 4 / US-5 closeout)
+Last Modified: 2026-06-05 (Sprint 57.84 — cost-write flipped to billing_outbox enqueue)
 """
 
 from __future__ import annotations
 
 import time
 from collections.abc import AsyncIterator
-from pathlib import Path
 from uuid import UUID, uuid4
 
 import pytest
 from fakeredis import FakeAsyncRedis
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from agent_harness._contracts import LoopCompleted, TraceContext
 from agent_harness._contracts.events import ToolCallExecuted
 from api.v1.chat.router import _stream_loop_events
 from api.v1.chat.session_registry import SessionRegistry
-from infrastructure.db.models.cost_ledger import CostLedger
-from platform_layer.billing.cost_ledger import CostLedgerService
-from platform_layer.billing.pricing import PricingLoader
+from infrastructure.db.models.billing_outbox import BillingOutboxEvent
+from platform_layer.billing.billing_outbox import BillingOutboxService
 from platform_layer.observability.sla_monitor import SLAMetricRecorder
 from platform_layer.tenant.plans import PlanLoader
 from platform_layer.tenant.quota import QuotaEnforcer
 from tests.conftest import seed_tenant
 
 pytestmark = pytest.mark.asyncio
-
-_PRICING_YAML = Path(__file__).resolve().parents[3] / "config" / "llm_pricing.yml"
 
 
 class _StubLoopWithToolAndCompletion:
@@ -85,8 +81,6 @@ class _StubLoopWithToolAndCompletion:
             result_content="ok",
             trace_context=trace_context,
         )
-        # Sprint 57.2: LoopCompleted carries split + provider/model
-        # (closes AD-Cost-Ledger-Token-Split + Provider-Attribution).
         yield LoopCompleted(
             stop_reason="end_turn",
             total_turns=1,
@@ -105,19 +99,19 @@ async def _consume(stream: AsyncIterator[bytes]) -> None:
 
 
 async def test_phase56_3_cross_ad_full_flow(db_session: AsyncSession) -> None:
-    """Single chat flow exercises US-1 (SLA) + US-3+4 (Cost Ledger) + 56.2 carryover (quota)."""
-    # Setup: real tenant + fakeredis SLA recorder + fakeredis QuotaEnforcer +
-    # PricingLoader-backed CostLedgerService.
+    """One chat flow exercises US-1 (SLA) + US-3+4 (billing enqueue) + 56.2 quota."""
     t = await seed_tenant(db_session, code="P563_E2E")
     tenant_id = t.id
+    # billing_outbox has FORCE RLS — set the tenant context so enqueue's INSERT
+    # WITH CHECK passes (harmless if the test role bypasses RLS).
+    await db_session.execute(
+        text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tenant_id)}
+    )
     session_id = uuid4()
 
     redis = FakeAsyncRedis()
     sla_recorder = SLAMetricRecorder(redis_client=redis)
     quota_enforcer = QuotaEnforcer(client=redis, plan_loader=PlanLoader())
-    pricing = PricingLoader()
-    pricing.load_from_yaml(_PRICING_YAML)
-    cost_ledger = CostLedgerService(db=db_session, pricing_loader=pricing)
 
     registry = SessionRegistry()
     await registry.register(tenant_id, session_id)
@@ -152,57 +146,43 @@ async def test_phase56_3_cross_ad_full_flow(db_session: AsyncSession) -> None:
             estimated_tokens=estimated_tokens,
             sla_recorder=sla_recorder,
             chat_start_time=chat_start_time,
-            cost_ledger=cost_ledger,
+            billing_outbox=BillingOutboxService(),
+            db=db_session,
         )
     )
 
     # === US-1 (SLA) assertion ===
-    # complexity = simple (turns=1, tokens=120 < 1500); recorded in 5-min window.
     p99 = await sla_recorder.get_loop_p99(tenant_id, complexity_category="simple")
     assert p99 is not None, "US-1: SLA loop_completion not recorded"
-    # Latency may be 0 ms in test (sub-millisecond stub-loop run); presence of
-    # a record is what US-1 closeout asserts (recorder wired into chat router).
     assert p99 >= 0, f"US-1: SLA latency must be >= 0, got {p99}"
 
-    # === US-3 + US-4 (Cost Ledger) assertions ===
+    # === US-3 + US-4 (billing enqueue) assertions — Sprint 57.84 flip ===
+    # The chat observer enqueues an llm_call + a tool_call billing event into
+    # billing_outbox (the drainer materializes cost_ledger separately).
     rows = (
         (
             await db_session.execute(
-                select(CostLedger)
-                .where(CostLedger.tenant_id == tenant_id)
-                .order_by(CostLedger.recorded_at)
+                select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == tenant_id)
             )
         )
         .scalars()
         .all()
     )
-    cost_types = {r.cost_type for r in rows}
-    assert "llm" in cost_types, "US-4: LLM ledger entry missing"
-    assert "tool" in cost_types, "US-4: Tool ledger entry missing"
-    # Sprint 57.2: 2 LLM entries (input + output) + 1 tool entry = 3 total.
-    assert len(rows) == 3, f"US-4: expected 3 entries (2 LLM + 1 tool), got {len(rows)}"
+    event_types = {r.event_type for r in rows}
+    assert event_types == {"llm_call", "tool_call"}, "billing events missing"
+    assert len(rows) == 2, f"expected 2 outbox events (1 llm + 1 tool), got {len(rows)}"
+    assert all(r.session_id == session_id for r in rows)
 
-    llm_rows = [r for r in rows if r.cost_type == "llm"]
-    assert len(llm_rows) == 2
-    sub_types = {r.sub_type for r in llm_rows}
-    assert sub_types == {
-        "azure_openai_gpt-5.4_input",
-        "azure_openai_gpt-5.4_output",
-    }
-    assert all(r.session_id == session_id for r in llm_rows)
+    llm_row = next(r for r in rows if r.event_type == "llm_call")
+    assert llm_row.payload["input_tokens"] == 70
+    assert llm_row.payload["output_tokens"] == 50
+    assert llm_row.idempotency_key == f"{session_id}:llm:loop"
 
-    tool_row = next(r for r in rows if r.cost_type == "tool")
-    assert tool_row.sub_type == "salesforce_query"
-    assert tool_row.session_id == session_id
+    tool_row = next(r for r in rows if r.event_type == "tool_call")
+    assert tool_row.payload["tool_name"] == "salesforce_query"
+    assert tool_row.idempotency_key == f"{session_id}:tool:salesforce_query:0"
 
-    # US-3 aggregate API works end-to-end.
-    month = llm_rows[0].recorded_at.strftime("%Y-%m")
-    aggregate = await cost_ledger.aggregate(tenant_id=tenant_id, month=month)
-    assert aggregate.total_cost_usd > 0, "US-3: aggregate total_cost_usd must be > 0"
-    assert "llm" in aggregate.by_type
-    assert "tool" in aggregate.by_type
-
-    # === 56.2 carryover (quota US-3) assertion ===
+    # === 56.2 carryover (quota US-3) assertion — UNCHANGED by the flip ===
     # Reserved 200 → actual 120 → counter reconciled to 120.
     final_usage = await quota_enforcer.get_usage(tenant_id)
     assert final_usage == 120, f"56.2 reconciliation wrong: {final_usage}"

--- a/backend/tests/integration/billing/test_billing_outbox_drain.py
+++ b/backend/tests/integration/billing/test_billing_outbox_drain.py
@@ -1,0 +1,289 @@
+"""
+File: backend/tests/integration/billing/test_billing_outbox_drain.py
+Purpose: BillingOutboxDrainer integration (Sprint 57.84 / US-3 + US-4) — real Postgres.
+Category: Tests / Integration (platform_layer.billing)
+Created: 2026-06-05 (Sprint 57.84 Day 2)
+
+Why integration (not unit): the drainer uses its OWN session factory (one
+independent transaction per row, with commits + FOR UPDATE SKIP LOCKED), so it
+can only see COMMITTED outbox rows. These tests therefore commit seed data via
+get_session_factory() and clean up by deleting the test tenant's rows in a
+finally / fixture teardown (db_session's rollback can't reach committed data).
+Proves the drainer end-to-end BEFORE Day-3 wires it into the lifespan.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select, text
+
+from infrastructure.db import dispose_engine, get_session_factory
+from infrastructure.db.models import Tenant
+from infrastructure.db.models.billing_outbox import BillingOutboxEvent
+from infrastructure.db.models.cost_ledger import CostLedger
+from platform_layer.billing.billing_outbox import (
+    SYSTEM_SENTINEL_TENANT,
+    BillingOutboxDrainer,
+    BillingOutboxService,
+    llm_idempotency_key,
+)
+from platform_layer.billing.pricing import PricingLoader
+
+pytestmark = pytest.mark.asyncio
+
+_PRICING_YAML = Path(__file__).resolve().parents[3] / "config" / "llm_pricing.yml"
+
+_LLM_PAYLOAD: dict[str, object] = {
+    "provider": "azure_openai",
+    "model": "gpt-5.4",
+    "input_tokens": 600,
+    "output_tokens": 400,
+    "cached_input_tokens": 0,
+    "sub_type_suffix": "",
+}
+
+
+def _loader() -> PricingLoader:
+    pl = PricingLoader()
+    pl.load_from_yaml(_PRICING_YAML)
+    return pl
+
+
+async def _commit_tenant(code: str) -> UUID:
+    factory = get_session_factory()
+    async with factory() as s:
+        t = Tenant(code=code, display_name=code)
+        s.add(t)
+        await s.flush()
+        tid = t.id
+        await s.commit()
+    return tid
+
+
+async def _delete_tenant(tid: UUID) -> None:
+    """Delete a tenant's committed billing_outbox + cost_ledger + tenant rows.
+
+    Sets the tenant context so the deletes pass RLS whether or not the test
+    role bypasses it (first USING branch matches tenant_id)."""
+    factory = get_session_factory()
+    async with factory() as s:
+        await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
+        await s.execute(delete(CostLedger).where(CostLedger.tenant_id == tid))
+        await s.execute(delete(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == tid))
+        await s.execute(delete(Tenant).where(Tenant.id == tid))
+        await s.commit()
+
+
+async def _enqueue_committed(
+    tid: UUID,
+    *,
+    event_type: str,
+    payload: dict[str, object],
+    idempotency_key: str,
+    session_id: UUID,
+) -> None:
+    factory = get_session_factory()
+    async with factory() as s:
+        await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
+        await BillingOutboxService().enqueue(
+            s,
+            tenant_id=tid,
+            event_type=event_type,
+            payload=payload,
+            idempotency_key=idempotency_key,
+            session_id=session_id,
+        )
+        await s.commit()
+
+
+async def _cost_rows(tid: UUID) -> list[CostLedger]:
+    factory = get_session_factory()
+    async with factory() as s:
+        await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
+        return list(
+            (await s.execute(select(CostLedger).where(CostLedger.tenant_id == tid))).scalars().all()
+        )
+
+
+async def _outbox_rows(tid: UUID) -> list[BillingOutboxEvent]:
+    factory = get_session_factory()
+    async with factory() as s:
+        # sentinel context: the drainer-escape lets us read the row cross-tenant
+        # (also the first USING branch would match tid — either works).
+        await s.execute(
+            text("SELECT set_config('app.tenant_id', :t, true)"),
+            {"t": SYSTEM_SENTINEL_TENANT},
+        )
+        return list(
+            (await s.execute(select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == tid)))
+            .scalars()
+            .all()
+        )
+
+
+@pytest_asyncio.fixture
+async def committed_tenant() -> AsyncIterator[UUID]:
+    tid = await _commit_tenant(f"OBX_DR_{uuid4().hex[:8]}")
+    try:
+        yield tid
+    finally:
+        await _delete_tenant(tid)
+        await dispose_engine()
+
+
+async def test_drain_materializes_cost_ledger_parity(committed_tenant: UUID) -> None:
+    """US-3 — drain materializes the SAME 2 cost_ledger rows a direct
+    record_llm_call would, and marks the outbox row done."""
+    tid = committed_tenant
+    sid = uuid4()
+    await _enqueue_committed(
+        tid,
+        event_type="llm_call",
+        payload=_LLM_PAYLOAD,
+        idempotency_key=llm_idempotency_key(sid, ""),
+        session_id=sid,
+    )
+
+    stats = await BillingOutboxDrainer(get_session_factory(), _loader()).drain_once()
+    assert stats.claimed == 1
+    assert stats.materialized == 1
+
+    cost = await _cost_rows(tid)
+    assert len(cost) == 2  # input + output split (parity with direct path)
+    assert {r.sub_type for r in cost} == {
+        "azure_openai_gpt-5.4_input",
+        "azure_openai_gpt-5.4_output",
+    }
+    assert all(r.session_id == sid for r in cost)
+
+    obx = await _outbox_rows(tid)
+    assert len(obx) == 1
+    assert obx[0].status == "done"
+    assert obx[0].processed_at is not None
+
+
+async def test_drain_is_idempotent_across_two_cycles(committed_tenant: UUID) -> None:
+    """US-3 — running drain twice materializes exactly once (no 雙扣)."""
+    tid = committed_tenant
+    sid = uuid4()
+    await _enqueue_committed(
+        tid,
+        event_type="llm_call",
+        payload=_LLM_PAYLOAD,
+        idempotency_key=llm_idempotency_key(sid, ""),
+        session_id=sid,
+    )
+    drainer = BillingOutboxDrainer(get_session_factory(), _loader())
+
+    first = await drainer.drain_once()
+    assert first.materialized == 1
+    # Second cycle: the row is now `done` → not due → claims nothing.
+    second = await drainer.drain_once()
+    assert second.claimed == 0
+    assert second.materialized == 0
+
+    cost = await _cost_rows(tid)
+    assert len(cost) == 2  # still 2, not 4 — exactly-once materialization
+
+
+async def test_drain_reschedules_then_dead_letters_on_bad_payload(
+    committed_tenant: UUID,
+) -> None:
+    """US-3 — a materialize failure (malformed payload) rolls back the cost
+    write, bumps retry/backoff, and dead-letters after max_retry."""
+    tid = committed_tenant
+    sid = uuid4()
+    # Missing "provider" → _payload_str raises → materialize fails → rollback.
+    bad_payload: dict[str, object] = {"model": "gpt-5.4", "input_tokens": 1, "output_tokens": 1}
+    await _enqueue_committed(
+        tid,
+        event_type="llm_call",
+        payload=bad_payload,
+        idempotency_key=llm_idempotency_key(sid, ""),
+        session_id=sid,
+    )
+
+    # max_retry=1 → the first failure immediately dead-letters.
+    stats = await BillingOutboxDrainer(get_session_factory(), _loader(), max_retry=1).drain_once()
+    assert stats.claimed == 1
+    assert stats.dead_lettered == 1
+    assert stats.materialized == 0
+
+    obx = await _outbox_rows(tid)
+    assert len(obx) == 1
+    assert obx[0].status == "failed"
+    assert obx[0].retry_count == 1
+    assert obx[0].next_retry_at is None  # dead-letter → not re-claimed
+    assert obx[0].last_error is not None
+
+    # The failed materialize wrote NO cost rows (rolled back).
+    assert await _cost_rows(tid) == []
+
+
+async def test_drain_reschedules_with_backoff_when_retries_remain(
+    committed_tenant: UUID,
+) -> None:
+    """US-3 — below max_retry, a failure reschedules (next_retry_at set, future)."""
+    tid = committed_tenant
+    sid = uuid4()
+    bad_payload: dict[str, object] = {"model": "gpt-5.4"}
+    await _enqueue_committed(
+        tid,
+        event_type="llm_call",
+        payload=bad_payload,
+        idempotency_key=llm_idempotency_key(sid, ""),
+        session_id=sid,
+    )
+
+    stats = await BillingOutboxDrainer(get_session_factory(), _loader(), max_retry=8).drain_once()
+    assert stats.failed == 1
+    assert stats.dead_lettered == 0
+
+    obx = await _outbox_rows(tid)
+    assert obx[0].status == "failed"
+    assert obx[0].retry_count == 1
+    assert obx[0].next_retry_at is not None  # rescheduled (not dead-lettered)
+
+
+async def test_drain_two_tenants_scopes_cost_rows() -> None:
+    """US-4 — the drainer materializes each row under its OWN tenant; no cross-leak."""
+    tid_a = await _commit_tenant(f"OBX_DR_A_{uuid4().hex[:8]}")
+    tid_b = await _commit_tenant(f"OBX_DR_B_{uuid4().hex[:8]}")
+    try:
+        sid_a, sid_b = uuid4(), uuid4()
+        await _enqueue_committed(
+            tid_a,
+            event_type="llm_call",
+            payload=_LLM_PAYLOAD,
+            idempotency_key=llm_idempotency_key(sid_a, ""),
+            session_id=sid_a,
+        )
+        await _enqueue_committed(
+            tid_b,
+            event_type="tool_call",
+            payload={"tool_name": "salesforce_query"},
+            idempotency_key=f"{sid_b}:tool:salesforce_query:0",
+            session_id=sid_b,
+        )
+
+        stats = await BillingOutboxDrainer(get_session_factory(), _loader()).drain_once()
+        assert stats.materialized == 2
+
+        cost_a = await _cost_rows(tid_a)
+        cost_b = await _cost_rows(tid_b)
+        # Tenant A got its 2 LLM rows; tenant B got its 1 tool row — no cross-leak.
+        assert {r.cost_type for r in cost_a} == {"llm"}
+        assert len(cost_a) == 2
+        assert {r.cost_type for r in cost_b} == {"tool"}
+        assert len(cost_b) == 1
+        assert all(r.tenant_id == tid_a for r in cost_a)
+        assert all(r.tenant_id == tid_b for r in cost_b)
+    finally:
+        await _delete_tenant(tid_a)
+        await _delete_tenant(tid_b)
+        await dispose_engine()

--- a/backend/tests/integration/billing/test_billing_outbox_drain.py
+++ b/backend/tests/integration/billing/test_billing_outbox_drain.py
@@ -7,7 +7,7 @@ Created: 2026-06-05 (Sprint 57.84 Day 2)
 Why integration (not unit): the drainer uses its OWN session factory (one
 independent transaction per row, with commits + FOR UPDATE SKIP LOCKED), so it
 can only see COMMITTED outbox rows. These tests therefore commit seed data via
-get_session_factory() and clean up by deleting the test tenant's rows in a
+_get_factory() and clean up by deleting the test tenant's rows in a
 finally / fixture teardown (db_session's rollback can't reach committed data).
 Proves the drainer end-to-end BEFORE Day-3 wires it into the lifespan.
 """
@@ -21,8 +21,15 @@ from uuid import UUID, uuid4
 import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool
 
-from infrastructure.db import dispose_engine, get_session_factory
+from core.config import get_settings
 from infrastructure.db.models import Tenant
 from infrastructure.db.models.billing_outbox import BillingOutboxEvent
 from infrastructure.db.models.cost_ledger import CostLedger
@@ -35,6 +42,29 @@ from platform_layer.billing.billing_outbox import (
 from platform_layer.billing.pricing import PricingLoader
 
 pytestmark = pytest.mark.asyncio
+
+# Sprint 57.84: a dedicated NullPool engine isolates this module's heavy direct-
+# session churn (the drainer opens a session per row + the helpers commit seed
+# data) from the global pooled engine. NullPool closes each connection on session
+# return → nothing lingers to be GC'd on a closed event loop, which would raise
+# asyncpg's "_cancel never awaited / Event loop is closed" unraisable and fail an
+# unrelated test. Disposed in the fixture / test finally.
+_engine: AsyncEngine | None = None
+
+
+def _get_factory() -> async_sessionmaker[AsyncSession]:
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(get_settings().database_url, poolclass=NullPool)
+    return async_sessionmaker(_engine, expire_on_commit=False)
+
+
+async def _dispose() -> None:
+    global _engine
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+
 
 _PRICING_YAML = Path(__file__).resolve().parents[3] / "config" / "llm_pricing.yml"
 
@@ -55,7 +85,7 @@ def _loader() -> PricingLoader:
 
 
 async def _commit_tenant(code: str) -> UUID:
-    factory = get_session_factory()
+    factory = _get_factory()
     async with factory() as s:
         t = Tenant(code=code, display_name=code)
         s.add(t)
@@ -70,7 +100,7 @@ async def _delete_tenant(tid: UUID) -> None:
 
     Sets the tenant context so the deletes pass RLS whether or not the test
     role bypasses it (first USING branch matches tenant_id)."""
-    factory = get_session_factory()
+    factory = _get_factory()
     async with factory() as s:
         await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
         await s.execute(delete(CostLedger).where(CostLedger.tenant_id == tid))
@@ -87,7 +117,7 @@ async def _enqueue_committed(
     idempotency_key: str,
     session_id: UUID,
 ) -> None:
-    factory = get_session_factory()
+    factory = _get_factory()
     async with factory() as s:
         await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
         await BillingOutboxService().enqueue(
@@ -102,7 +132,7 @@ async def _enqueue_committed(
 
 
 async def _cost_rows(tid: UUID) -> list[CostLedger]:
-    factory = get_session_factory()
+    factory = _get_factory()
     async with factory() as s:
         await s.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(tid)})
         return list(
@@ -111,7 +141,7 @@ async def _cost_rows(tid: UUID) -> list[CostLedger]:
 
 
 async def _outbox_rows(tid: UUID) -> list[BillingOutboxEvent]:
-    factory = get_session_factory()
+    factory = _get_factory()
     async with factory() as s:
         # sentinel context: the drainer-escape lets us read the row cross-tenant
         # (also the first USING branch would match tid — either works).
@@ -133,7 +163,7 @@ async def committed_tenant() -> AsyncIterator[UUID]:
         yield tid
     finally:
         await _delete_tenant(tid)
-        await dispose_engine()
+        await _dispose()
 
 
 async def test_drain_materializes_cost_ledger_parity(committed_tenant: UUID) -> None:
@@ -149,7 +179,7 @@ async def test_drain_materializes_cost_ledger_parity(committed_tenant: UUID) -> 
         session_id=sid,
     )
 
-    stats = await BillingOutboxDrainer(get_session_factory(), _loader()).drain_once()
+    stats = await BillingOutboxDrainer(_get_factory(), _loader()).drain_once()
     assert stats.claimed == 1
     assert stats.materialized == 1
 
@@ -178,7 +208,7 @@ async def test_drain_is_idempotent_across_two_cycles(committed_tenant: UUID) -> 
         idempotency_key=llm_idempotency_key(sid, ""),
         session_id=sid,
     )
-    drainer = BillingOutboxDrainer(get_session_factory(), _loader())
+    drainer = BillingOutboxDrainer(_get_factory(), _loader())
 
     first = await drainer.drain_once()
     assert first.materialized == 1
@@ -209,7 +239,7 @@ async def test_drain_reschedules_then_dead_letters_on_bad_payload(
     )
 
     # max_retry=1 → the first failure immediately dead-letters.
-    stats = await BillingOutboxDrainer(get_session_factory(), _loader(), max_retry=1).drain_once()
+    stats = await BillingOutboxDrainer(_get_factory(), _loader(), max_retry=1).drain_once()
     assert stats.claimed == 1
     assert stats.dead_lettered == 1
     assert stats.materialized == 0
@@ -240,7 +270,7 @@ async def test_drain_reschedules_with_backoff_when_retries_remain(
         session_id=sid,
     )
 
-    stats = await BillingOutboxDrainer(get_session_factory(), _loader(), max_retry=8).drain_once()
+    stats = await BillingOutboxDrainer(_get_factory(), _loader(), max_retry=8).drain_once()
     assert stats.failed == 1
     assert stats.dead_lettered == 0
 
@@ -271,7 +301,7 @@ async def test_drain_two_tenants_scopes_cost_rows() -> None:
             session_id=sid_b,
         )
 
-        stats = await BillingOutboxDrainer(get_session_factory(), _loader()).drain_once()
+        stats = await BillingOutboxDrainer(_get_factory(), _loader()).drain_once()
         assert stats.materialized == 2
 
         cost_a = await _cost_rows(tid_a)
@@ -286,4 +316,4 @@ async def test_drain_two_tenants_scopes_cost_rows() -> None:
     finally:
         await _delete_tenant(tid_a)
         await _delete_tenant(tid_b)
-        await dispose_engine()
+        await _dispose()

--- a/backend/tests/unit/platform_layer/billing/test_billing_outbox_service.py
+++ b/backend/tests/unit/platform_layer/billing/test_billing_outbox_service.py
@@ -1,0 +1,152 @@
+"""
+File: backend/tests/unit/platform_layer/billing/test_billing_outbox_service.py
+Purpose: BillingOutbox producer + pure-logic unit tests (Sprint 57.84 / US-1 + US-2).
+Category: Tests / Unit (platform_layer.billing)
+Created: 2026-06-05 (Sprint 57.84 Day 2)
+
+Covers the producer (enqueue idempotency, db_session — rolled back) + the pure
+helpers (idempotency-key builders, backoff, payload validators). The stateful
+drain is integration-tested in tests/integration/billing/test_billing_outbox_drain.py
+(needs committed data — the drainer uses its own session factory).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from infrastructure.db.models.billing_outbox import BillingOutboxEvent
+from platform_layer.billing.billing_outbox import (
+    BillingOutboxService,
+    _backoff_seconds,
+    _payload_int,
+    _payload_str,
+    llm_idempotency_key,
+    tool_idempotency_key,
+)
+from tests.conftest import seed_tenant
+
+_LLM_PAYLOAD: dict[str, object] = {
+    "provider": "azure_openai",
+    "model": "gpt-5.4",
+    "input_tokens": 100,
+    "output_tokens": 50,
+    "cached_input_tokens": 0,
+    "sub_type_suffix": "",
+}
+
+
+# ----- pure helpers (no DB) -----------------------------------------------
+
+
+def test_llm_idempotency_key_loop_vs_verification_distinct() -> None:
+    sid = uuid4()
+    assert llm_idempotency_key(sid, "") == f"{sid}:llm:loop"
+    assert llm_idempotency_key(sid, "_verification") == f"{sid}:llm:_verification"
+    # loop vs verification are distinct events under the same session.
+    assert llm_idempotency_key(sid, "") != llm_idempotency_key(sid, "_verification")
+
+
+def test_tool_idempotency_key_seq_disambiguates_same_tool() -> None:
+    sid = uuid4()
+    assert tool_idempotency_key(sid, "web_search", 0) != tool_idempotency_key(sid, "web_search", 1)
+    # same (session, tool, seq) → stable key (a replay is a no-op enqueue).
+    assert tool_idempotency_key(sid, "web_search", 0) == tool_idempotency_key(sid, "web_search", 0)
+
+
+def test_backoff_seconds_exponential_and_capped() -> None:
+    assert _backoff_seconds(1) == 2
+    assert _backoff_seconds(2) == 4
+    assert _backoff_seconds(3) == 8
+    assert _backoff_seconds(100) == 3600  # capped at _MAX_BACKOFF_S
+
+
+def test_payload_validators() -> None:
+    assert _payload_str({"x": "ok"}, "x") == "ok"
+    assert _payload_str({}, "x", "") == ""
+    assert _payload_int({"x": 5}, "x") == 5
+    assert _payload_int({}, "missing", 0) == 0
+    with pytest.raises(ValueError):
+        _payload_str({"x": 1}, "x")
+    with pytest.raises(ValueError):
+        _payload_int({"x": "nope"}, "x")
+    with pytest.raises(ValueError):
+        _payload_int({"x": True}, "x")  # bool is not a valid int payload value
+
+
+# ----- enqueue (db_session — rolled back at teardown) ---------------------
+
+
+@pytest.mark.asyncio
+async def test_enqueue_adds_pending_row(db_session: AsyncSession) -> None:
+    """US-1 — enqueue writes one pending outbox row in the caller's txn."""
+    t = await seed_tenant(db_session, code="OBX_ENQ_1")
+    await db_session.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(t.id)})
+    sid = uuid4()
+
+    await BillingOutboxService().enqueue(
+        db_session,
+        tenant_id=t.id,
+        event_type="llm_call",
+        payload=_LLM_PAYLOAD,
+        idempotency_key=llm_idempotency_key(sid, ""),
+        session_id=sid,
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].event_type == "llm_call"
+    assert rows[0].status == "pending"  # server default
+    assert rows[0].retry_count == 0
+    assert rows[0].session_id == sid
+    assert rows[0].payload["model"] == "gpt-5.4"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_duplicate_idempotency_key_is_noop(db_session: AsyncSession) -> None:
+    """US-2 — re-enqueuing the same (tenant, idempotency_key) is a no-op (ON CONFLICT)."""
+    t = await seed_tenant(db_session, code="OBX_ENQ_DUP")
+    await db_session.execute(text("SELECT set_config('app.tenant_id', :t, true)"), {"t": str(t.id)})
+    sid = uuid4()
+    key = llm_idempotency_key(sid, "")
+    svc = BillingOutboxService()
+
+    await svc.enqueue(
+        db_session,
+        tenant_id=t.id,
+        event_type="llm_call",
+        payload=_LLM_PAYLOAD,
+        idempotency_key=key,
+        session_id=sid,
+    )
+    # Redelivery of the same logical event — must NOT raise and must NOT duplicate.
+    await svc.enqueue(
+        db_session,
+        tenant_id=t.id,
+        event_type="llm_call",
+        payload=_LLM_PAYLOAD,
+        idempotency_key=key,
+        session_id=sid,
+    )
+
+    rows = (
+        (
+            await db_session.execute(
+                select(BillingOutboxEvent).where(BillingOutboxEvent.tenant_id == t.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1  # ON CONFLICT DO NOTHING — single row

--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -222,6 +222,21 @@ C-11 本機 real-LLM smoke 已實跑（用既有 `.env` Azure 憑證、零 GitHu
 
 ---
 
+## 🆕 Sprint 57.84 — C-15 billing-write-atomicity leg CLOSED + sub-items deferred (2026-06-06)
+
+**C-15 的 in-repo billing leg = DONE**（transactional billing Outbox；CHANGE-051；`memory/project_phase57_84_billing_outbox.md`）。`billing_outbox` 表 + enqueue（請求 txn 內原子、ON CONFLICT 冪等 → 無漏扣）+ drainer（per-row txn 精確一次、materialize via 既有 CostLedgerService → 無雙扣）+ lifespan poller；router 已 flip（chat cost-write → billing_outbox enqueue）。real-Azure smoke ✅（gpt-5.2 chain chat→enqueue→drain→cost_ledger，unit_cost>0）。**billing key-chain ②（C-11 57.79 + B-7 57.81 + B-8 57.82/83 + C-15-billing-leg 57.84）= 全部 closed。**
+
+**C-15 剩餘 sub-items — DEFERRED（external-blocked，非本 repo 可獨力完成）**：
+- **IaC deploy pipeline** — Bicep 5 模組齊全但 pipeline 停用；需 Azure provision + GitHub Secrets（用戶 policy：secret 不進 GitHub）。
+- **DR 自動化 / multi-region / WAL streaming** — 僅設計文件；需確認 Azure Postgres Flexible Server 內建 backup/geo-redundancy 是否滿足 RPO 1h/RTO 4h + 流量管理拓樸決策。
+- **Analytics / data warehouse / CDC / dbt / BI** — 0% 實作；全新外部基礎設施。
+- **Stripe（外部 billing）consumer** — outbox backbone 已就位（為此設計的解耦）；本 sprint drainer 只 materialize cost_ledger，Stripe drain target 是未來純 worker 變更。
+- **enqueue-itself failure** — 目前 logged best-effort（SSE 安全）；罕見、若 metrics 顯示再議。
+
+> 詳見 `claudedocs/5-status/c15-devops-data-platform-analysis-20260601.md`（4 sub-item 現況）。開工任一 sub-item 前需用戶提供對應外部輸入（Azure 資源 / Secrets / 基礎設施決策）。
+
+---
+
 ## 🆕 Process / Calibration carryover (2026-06-03 — Area-A 教訓固化副產物)
 
 固化 Area-A（57.66-73）教訓時，6 條可行教訓已 fold-in `.claude/rules/sprint-workflow.md`（Prong-1 test-infra verify / Prong-2 +2 drift rows: codegen-shape + no-live-producer / Risk Class E stale-`--reload`-masks-wiring / Risk Class C 補強 DB-call-test-isolation / Before-Commit item 7 agent-delegation 紀律）+ README-integration-gap-abc A 區同步至 57.73。1 條無法用「一行規則」解決，記此追蹤：

--- a/claudedocs/4-changes/feature-changes/CHANGE-051-billing-outbox.md
+++ b/claudedocs/4-changes/feature-changes/CHANGE-051-billing-outbox.md
@@ -1,0 +1,34 @@
+# CHANGE-051: Transactional billing Outbox (durable cost events + idempotent drain)
+
+**Date**: 2026-06-05
+**Sprint**: 57.84
+**Scope**: platform_layer.billing + api/v1/chat + infrastructure/db (C-15 billing-write-atomicity leg)
+
+## Problem
+Chat billing was best-effort: the chat observer wrote `cost_ledger` directly inside a bare `try/except` that swallowed failures (`router.py`). A ledger-write flake therefore silently dropped a charge (**漏扣**) while the rest of the request committed — real money on the now-live real-LLM path. There was also no idempotency key on `cost_ledger`, so any future retry/replay path would **雙扣** (double-charge). (No live double-charge bug existed; the present risk was 漏扣 + future-retry prevention.) This is the lone in-repo, billing-key-chain ② leg of C-15; the IaC / DR / Analytics sub-items are external-blocked and deferred.
+
+## Root Cause
+The cost write was not transactionally coupled to the request and was isolated as best-effort (so a failure couldn't break the SSE stream). That isolation is exactly what made a failed write a silent revenue loss.
+
+## Solution
+Transactional Outbox pattern (user chose full Outbox over the lightweight option):
+- **NEW `billing_outbox` table** (migration `0025`, `TenantScopedMixin`): `event_type` / `payload` (JSONB, neutral `record_*` args) / `idempotency_key` / `status` / `retry_count` / `next_retry_at` / `last_error` / `session_id`. `UNIQUE(tenant_id, idempotency_key)` + status/event_type CHECK + due/tenant indexes + RLS (two-policy + a system-sentinel USING escape so the cross-tenant drainer can claim). Dedicated table — NOT the unbuilt notification `outbox` design in 09.md (different shape).
+- **`BillingOutboxService.enqueue`** (`platform_layer/billing/billing_outbox.py`): `pg_insert(...).on_conflict_do_nothing()` in the **request** transaction → the cost event commits atomically with session/audit (no swallow → no 漏扣); a redelivered event is a no-op (idempotent enqueue).
+- **`BillingOutboxDrainer.drain_once`**: per-row independent txn — claim one due row (`FOR UPDATE SKIP LOCKED` under the system sentinel) → `set_config('app.tenant_id', row.tenant_id)` → materialize via the EXISTING `CostLedgerService.record_*` (pricing single-source, C-11 unchanged) → mark `done` in the same commit (**exactly-once** → no 雙扣). On failure: rollback (no cost written) → fresh txn records retry/backoff/`last_error`; dead-letter (next_retry_at=NULL) after MAX_RETRY.
+- **Lifespan poller** (`api/main.py`): env-gated (`BILLING_OUTBOX_DRAINER_ENABLED`), fail-open, clean shutdown cancel.
+- **Router flip** (`api/v1/chat/router.py`): the 3 cost-write observers (loop / `_verification` / tool) now `billing_outbox.enqueue(...)`; removed the per-request `CostLedgerService` + `pricing_loader` dep (drainer prices). Logged best-effort kept (SSE safety); atomicity comes from the shared request txn.
+
+PR: pending (branch `feature/sprint-57-84-billing-outbox`).
+
+## Verification
+- Unit (`test_billing_outbox_service.py`): enqueue + idempotent no-op + pure helpers (6).
+- Integration (`test_billing_outbox_drain.py`, real Postgres + NullPool engine): drain → cost_ledger **parity**, idempotent-twice (exactly-once), reschedule+backoff, dead-letter, **2-tenant isolation** (5).
+- Updated flipped-contract callers: `test_chat_cost_ledger.py` + `test_phase56_3_e2e.py` (chat → outbox enqueue; SLA/quota unchanged).
+- Gates: `mypy src/` 0/335 · `run_all.py` 10/10 (`check_rls_policies` + `check_llm_sdk_leak`) · full pytest **2161 passed**.
+- real-Azure smoke: see retrospective (chat → enqueue → drain → cost_ledger on real Azure).
+
+## Impact
+Backend-only (+ migration `0025`). Behavioral change to a real-LLM-live billing path: chat now enqueues durable billing events; a background poller materializes `cost_ledger`. Env rollback: re-enabling the direct write is a 1-commit revert; the drainer can be disabled via `BILLING_OUTBOX_DRAINER_ENABLED=false`. LLM neutrality preserved (neutral payload; drainer uses existing CostLedgerService). Stripe (external billing) consumer is a future worker-only change — the backbone is now in place.
+
+## Regression caught + fixed (in-sprint, pre-merge)
+`_wire_billing_outbox()` leaked the module singleton (lifespan sets it; shutdown doesn't unset) → `test_main_lifespan` leaked it → a downstream chat-path test enqueued on the global engine without dispose → an innocent later `db_session` test hit `Event loop is closed`. Fixed with an autouse `_reset_billing_outbox_singleton` conftest fixture (Risk Class C / testing.md §Module-level Singleton Reset) + a dedicated NullPool engine for the drain test. Verified pre-sprint main was clean (2150 passed) → introduced + fixed within the sprint.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
@@ -1,0 +1,50 @@
+# Sprint 57.84 Progress — C-15 billing leg: transactional billing Outbox
+
+**Branch**: `feature/sprint-57-84-billing-outbox` (from `main` `179b4416`)
+**Closes**: C-15 **billing-write-atomicity leg** (durable cost events + idempotent drain). IaC/DR/Analytics deferred (external-blocked).
+
+---
+
+## Day 0 — 2026-06-05 — Plan-vs-Repo Verify + Branch + Decisions
+
+### Accomplishments
+- A/B/C area sweep → user picked **C-15**; two parallel read-only Explore recons (planning-doc scope + cost_ledger code map) defined the real shape.
+- AskUserQuestion ×1 (2 questions): scope = **billing-write-atomicity leg only** (IaC/DR/Analytics external-blocked → deferred); depth = **full Outbox pattern**.
+- Day-0 三-prong verify (Prong 1 path + Prong 2 content + Prong 3 schema — schema in scope) + 3 drift findings.
+- Plan + checklist drafted (mirror 57.83 9-section / Day 0-4); branch created.
+
+### Day-0 verify (Prong 1 + 2 + 3)
+- **Prong 1 (path)** ✅ — `router.py` cost observer, `cost_ledger.py` service+accessors, `session.py:41-57` get_db_session auto-commit, `models/cost_ledger.py` + `models/__init__.py`, `api/main.py` `_lifespan`+`_wire_*`, `runtime/workers/*` stubs, migration head `0024_memory_ops`.
+- **Prong 2 (content)** ✅:
+  - Chat flow PURELY in-memory (`artifact.messages`); only DB writes = observer `sessions`/`cost_ledger`/`audit_log`/`tool_calls`. `get_db_session` auto-commits AFTER the SSE generator (`session.py:51-57`).
+  - Cost write = `db.add`+`flush()` in a **bare try/except that swallows** (`router.py:453-458/:480-485/:597-600`) → **漏扣 vector**. NO idempotency key on cost_ledger.
+  - **No live 雙扣 bug** (loop / `_verification` / tool sub_types distinct; quota & ledger independent layers). Present risk is 漏扣; 雙扣 is future-retry prevention.
+  - No production worker runtime (`runtime/workers` `[STUB]` Phase 53.1; MockQueueBackend only); no `SKIP LOCKED` idiom; poller must follow `_wire_*` lifespan pattern (57.81 `_wire_error_budget` precedent).
+- **Prong 3 (schema)** ✅:
+  - 09.md `outbox` (`:1045-1073`) is NOTIFICATION-shaped (`destination` teams/email/webhook; `source_type` approval_request/alert) — **NOT billing**; no migration exists → dedicated `billing_outbox`.
+  - Migration head `0024_memory_ops` → next `0025` (exact `down_revision` read Day-1).
+  - `cost_ledger` ORM has NO unique/dedup key (recon); new model registers in `models/__init__.py`.
+
+### Drift findings
+- **D1** — 09.md `outbox` is notification-shaped, not billing. Implication: build dedicated `billing_outbox` table (single-responsibility); do NOT reuse/extend the unbuilt notification design. (plan §0 + §8 Risk #6)
+- **D2** — no production background-task runtime (`runtime/workers` stubs). Implication: outbox poller is NEW, following the `api/main.py:_lifespan` `_wire_*` hook pattern (57.81). (plan §3.4)
+- **D3** — RLS: the poller runs outside a request (no tenant JWT) but reads pending rows cross-tenant while writing `cost_ledger` per-tenant. Implication: system-context escape clause on the `billing_outbox` policy for the claim read + `SET LOCAL app.tenant_id = row.tenant_id` per row before the materialize. Resolved Day-3 against `0009_rls_policies`. (plan §8 Risk #3)
+
+### Decisions locked (AskUserQuestion 2026-06-05)
+- **Scope** = billing-write-atomicity leg ONLY. C-15 IaC / DR / multi-region / Analytics are external-blocked (Azure provision + Secrets + infra decisions + new external infra) → deferred to `next-phase-candidates.md`.
+- **Depth** = **full Outbox pattern** (table + migration + idempotent worker + publisher) — user chose this over the lightweight transactional-coupling option, motivated by future external (Stripe) billing-consumer decoupling.
+- **parent-direct** (NOT agent-delegated) — atomicity boundary, RLS-correct worker, and the live-billing-path flip are judgment-sensitive (consistent with billing sprints 57.79-57.83).
+- **Shadow cut-line**: Day-2-end dual-write (billing never regresses) is a safe partial-ship point; Day-3 enqueue-only flip can carryover if it over-runs.
+
+### Blockers / dependencies
+- **Day 4 real-Azure smoke** (user-authorized, bounded 1-2 chats) — confirm a `cost_ledger` row still appears via the DRAINED path post-flip. Clean backend restart (Risk Class E).
+
+### Remaining for Day 1+
+- Day 1: `billing_outbox` ORM + register + migration `0025` (+ RLS).
+- Day 2: `BillingOutboxService.enqueue` + `BillingOutboxDrainer.drain_once` + router shadow dual-write + unit tests. **(Day-2-end cut-line)**
+- Day 3: lifespan poller wiring + RLS-correct cross-tenant drain + router flip to enqueue-only.
+- Day 4: integration/isolation tests + real-Azure smoke + closeout.
+
+### Notes
+- Bottom-up est ~10.5 hr → calibrated ~8.4 hr (`medium-backend` 0.80, parent-direct, `agent_factor` 1.0). Large sprint (≈2× normal); Day structure carries the safety via the Day-2-end shadow cut-line.
+- LLM neutrality preserved: outbox payload carries neutral `record_llm_call` args; drainer calls the EXISTING `CostLedgerService` (pricing single-source, C-11/57.79 unchanged).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
@@ -102,3 +102,34 @@
 
 ### Notes
 - Drainer is the harder piece; the per-row-txn + rollback-then-record-failure pattern avoids the poisoned-session trap of a single batch txn. Integration-tested against real Postgres (AP-10 — no mock divergence).
+
+---
+
+## Day 3 — 2026-06-05 — Poller wiring + router flip + regression fix (US-3/US-4/US-5)
+
+### Accomplishments
+- **`api/main.py`** — `_wire_billing_outbox()` (enqueue singleton) + `_billing_outbox_poll_loop` (fail-open; `asyncio.wait_for(stop_event.wait(), timeout)` interruptible sleep) + `_start_billing_outbox_drainer(app)` (env-gated; pricing-loader dep; `asyncio.create_task`; task+stop on app.state) + lifespan startup calls + shutdown cancel (stops the drainer BEFORE OTel/engine teardown).
+- **`core/config`** — `billing_outbox_poll_interval_s`/`_batch`/`_max_retry` settings (enabled flag read from `os.environ` directly, NOT Settings, to dodge the `get_settings()` lru_cache timing trap — mirrors AUDIT_LOG_CHAT_OBSERVER).
+- **`router.py` FLIP** — the 3 cost-write observers (loop / `_verification` / tool) now `billing_outbox.enqueue(...)` instead of `cost_ledger.record_*`. Removed `cost_ledger`/`PricingLoader`/`maybe_get_pricing_loader` imports + the `pricing_loader` endpoint dep + the per-request `CostLedgerService`. `_FALLBACK_PRICING_MODEL` retained (drainer prices). Added a per-request `tool_seq` counter. No dead code (AP-11).
+  - **Swallow-vs-propagate decision**: kept logged best-effort isolation (SSE-stream safety, consistent with the sessions/audit/tool observers). The atomicity win is real anyway — the enqueue is a single INSERT in the request txn, so the billing event commits with session/audit (no more best-effort-swallow 漏扣 of a heavy pricing+flush block). Residual: an enqueue-itself failure that doesn't poison the txn is swallowed (rare for a single INSERT) — noted as a minor known limitation in retro.
+- **Updated flipped-contract callers** — `test_chat_cost_ledger.py` (2 tests → assert billing_outbox enqueue; quota test unchanged) + `test_phase56_3_e2e.py` (cost section → outbox; SLA + quota unchanged). `db=db_session` now passed (enqueue needs db; old cost_ledger held its own). Other `_stream_loop_events` callers don't pass `cost_ledger=` → unaffected.
+
+### Day-3 regression: cross-test pollution (FOUND + FIXED)
+- **Symptom**: full suite → 1 flaky fail on an INNOCENT test (`incident/test_service::test_create_returns_incident`, passes in isolation) with `RuntimeError: Event loop is closed` on the GLOBAL engine in `seed_tenant`. The failing test moved between runs at first (test_enqueue, then test_phase56_3, then incident) — looked like GC-timing flakiness.
+- **Two real bugs uncovered along the way**:
+  1. `test_phase56_3_e2e` called `_stream_loop_events(cost_ledger=...)` → `TypeError` after the param rename (a flipped-contract caller I'd missed) → fixed (→ billing_outbox + outbox assertions).
+  2. The actual pollution: **`_wire_billing_outbox()` leaks the module singleton**. `test_main_lifespan` (TestClient) triggers the lifespan → sets the singleton; shutdown doesn't unset it (correct for prod). A downstream chat-path test then consumes `maybe_get_billing_outbox()` → enqueues on the GLOBAL engine without dispose → `incident` (later `db_session` test) gets the stale closed-loop engine.
+- **Root-cause method**: bisected to a 2-second repro (`pytest tests/unit/api/ tests/unit/business_domain/incident/test_service.py`). Confirmed pre-sprint main was clean (2150 passed) → I introduced it (not pre-existing). `-p no:unraisableexception` proved it's a REAL failure, not a GC-warning-elevated-to-failure.
+- **Fixes (3)**:
+  1. autouse `_reset_billing_outbox_singleton` in `tests/conftest.py` (`set_billing_outbox(None)` around each test — testing.md §Module-level Singleton Reset / Risk Class C). **Primary fix.**
+  2. drain test → dedicated NullPool engine (isolates its heavy direct-session churn from the global pooled engine; NullPool closes connections on session return → nothing to GC on a closed loop).
+  3. (Day-2 carried) `SET LOCAL app.tenant_id = :p` → `SELECT set_config('app.tenant_id', :p, true)` (asyncpg rejects bind params on the SET utility statement).
+
+### Verification
+- `mypy src/` **0 / 335**; black + isort + flake8 **0**; `run_all.py` **10/10** (check_rls_policies + check_llm_sdk_leak green); full **pytest 2161 passed / 4 skipped** (was 1 flaky fail).
+
+### Remaining for Day 4
+- real-Azure smoke (user-authorized; Risk Class E clean restart) — confirm a `cost_ledger` row appears via the DRAINED path on a real chat. Then closeout (CHANGE-051 + 17.md + retrospective + MEMORY + CLAUDE lean + next-phase-candidates).
+
+### Notes
+- The flip turned a ~6-hr code sprint into a longer one: the singleton-leak pollution took the most time (the failure attribution was non-obvious — it surfaced on innocent tests). Lesson for retro: a new lifespan-wired singleton needs a conftest reset fixture from the start (the pricing/rate-limit/error-budget singletons leak too, but only billing_outbox's consumer binds the global engine).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
@@ -48,3 +48,28 @@
 ### Notes
 - Bottom-up est ~10.5 hr → calibrated ~8.4 hr (`medium-backend` 0.80, parent-direct, `agent_factor` 1.0). Large sprint (≈2× normal); Day structure carries the safety via the Day-2-end shadow cut-line.
 - LLM neutrality preserved: outbox payload carries neutral `record_llm_call` args; drainer calls the EXISTING `CostLedgerService` (pricing single-source, C-11/57.79 unchanged).
+
+---
+
+## Day 1 — 2026-06-05 — Schema: billing_outbox table + migration + ORM (US-1/US-2)
+
+### Accomplishments
+- **NEW `infrastructure/db/models/billing_outbox.py`** — `BillingOutboxEvent` (TenantScopedMixin): BigInteger PK (ordered drain), event_type/payload(JSONB `dict[str, object]`)/idempotency_key/status/retry_count/next_retry_at/last_error/session_id/created_at/processed_at; `UNIQUE(tenant_id, idempotency_key)` (idempotency) + status/event_type CHECK + `idx_billing_outbox_due` (partial WHERE status IN pending/failed) + `idx_billing_outbox_tenant`. Enums `OutboxStatus`/`OutboxEventType`.
+- **Registered** in `models/__init__.py` (import + `__all__`).
+- **NEW migration `0025_billing_outbox.py`** (down_revision `0024_memory_ops`) — table + 2 indexes + ENABLE+FORCE RLS + two policies mirroring 0024, **plus the drainer system-context escape** in the USING clause (all-zeros sentinel → cross-tenant visibility for the poller claim).
+
+### Key decision — D3 (RLS cross-tenant drain) resolved at Day-1, not Day-3
+- Read `scripts/lint/check_rls_policies.py`: the lint only requires `ENABLE ROW LEVEL SECURITY` + a `CREATE POLICY ... ON <table>` (regex), it does **NOT** constrain the USING expression. → I can write the full poller-escape RLS in the Day-1 migration without a second migration on Day-3. The escape: `tenant_id = current_setting('app.tenant_id', true)::uuid OR current_setting(...) = '00000000-...-0'::uuid`. A real request never runs under the all-zeros sentinel (missing JWT → 401), so per-request isolation is unaffected; the isolation test (US-4, Day-4) is the gate.
+
+### Verification
+- Migration applied **both directions** on Docker DB (ipa_v2, head was `0024_memory_ops`): upgrade → downgrade -1 (drops cleanly) → re-upgrade; `alembic current` = `0025_billing_outbox (head)`.
+- `run_all.py` **10/10 green** (`check_rls_policies` recognizes `billing_outbox`; `check_llm_sdk_leak` green — no SDK import).
+- `mypy src/` **0 issues / 334 files** (+2 vs 332: new model); black/isort applied; flake8 0.
+
+### Remaining for Day 2+
+- Day 2: `BillingOutboxService.enqueue` (idempotent) + `BillingOutboxDrainer.drain_once` (claim/materialize/mark idempotent) + idempotency-key builder + router **shadow dual-write** + unit tests. **Day-2-end = safe cut-line.**
+- Day 3: lifespan poller wiring + per-row tenant-context drain + router flip to enqueue-only.
+- Day 4: integration/isolation tests + real-Azure smoke + closeout.
+
+### Notes
+- Day-1 was lighter than the ~1.5+0.5 hr bottom-up (schema + model + migration ≈ 1 hr) — the lint-leniency discovery folded the D3 RLS design into Day-1 cleanly.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
@@ -133,3 +133,21 @@
 
 ### Notes
 - The flip turned a ~6-hr code sprint into a longer one: the singleton-leak pollution took the most time (the failure attribution was non-obvious — it surfaced on innocent tests). Lesson for retro: a new lifespan-wired singleton needs a conftest reset fixture from the start (the pricing/rate-limit/error-budget singletons leak too, but only billing_outbox's consumer binds the global engine).
+
+---
+
+## Day 4 — 2026-06-06 — real-Azure smoke + closeout
+
+### Accomplishments
+- **real-Azure smoke ✅ PASSED** (user-authorized). Clean backend restart (drainer enabled, verification disabled for a focused billing smoke; Risk Class E — :8000 confirmed free first, startup log showed "billing outbox drainer started" + "enqueue service wired" + "pricing loader wired"). `real_llm` chat (session f5f60c3a, gpt-5.2) → `stop_reason=end_turn` (converged). DB verification:
+  - `billing_outbox`: 1 `llm_call` row, status **done**, retry=0, no error (enqueue atomic + drainer materialized).
+  - `cost_ledger` (via DRAINER, not direct): `azure_openai_gpt-5.2-2025-12-11_input` qty=1997 unit=0.00000175 total=0.00349 + `_output` qty=41 unit=0.0000140 total=0.000574 — **unit_cost > 0** (C-11 date-suffix normalize works through the drainer's single-source pricing).
+  - VERDICT: outbox_all_done=True / cost_rows=2 / nonzero_cost=True. Chain chat→enqueue→drain→cost_ledger verified end-to-end on the live path.
+  - Backend stopped (python PID, not node) + temp scripts removed (workspace hygiene).
+- **Closeout docs**: CHANGE-051 (feature-changes); retrospective Q1-Q7 (+ smoke result); 17.md assessed N/A (11+1 registry scope; billing not there — sibling cost_ledger absent too); MEMORY subfile + pointer; CLAUDE.md lean; next-phase-candidates (defer IaC/DR/Analytics + Stripe carryover).
+
+### Verification (final sweep)
+- `mypy src/` 0/335 · `run_all.py` 10/10 · full `pytest` 2161 passed / 4 skipped · black/isort/flake8 0.
+
+### Outcome
+- C-15 billing-write-atomicity leg **COMPLETE**. IaC / DR / Analytics sub-items deferred (external-blocked) → next-phase-candidates. Billing key-chain ② (C-11 + B-7 + B-8 + C-15-billing-leg) now closed.

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/progress.md
@@ -73,3 +73,32 @@
 
 ### Notes
 - Day-1 was lighter than the ~1.5+0.5 hr bottom-up (schema + model + migration ≈ 1 hr) — the lint-leniency discovery folded the D3 RLS design into Day-1 cleanly.
+
+---
+
+## Day 2 — 2026-06-05 — Service: enqueue + drain + tests (US-1..US-4)
+
+### Accomplishments
+- **NEW `platform_layer/billing/billing_outbox.py`**:
+  - `BillingOutboxService.enqueue` — `pg_insert(...).on_conflict_do_nothing(constraint="uq_billing_outbox_idem")` in the caller's request txn (atomic, idempotent — no 漏扣, redelivery no-op).
+  - `BillingOutboxDrainer.drain_once` — **per-row independent txn**: claim ONE due row (`FOR UPDATE SKIP LOCKED LIMIT 1` under the system sentinel) → `set_config('app.tenant_id', row.tenant_id, true)` → existing `CostLedgerService.record_*` from payload → mark `done` (same commit = exactly-once, no 雙扣). On failure: rollback (clears poisoned session + releases lock) → fresh txn records retry/backoff/last_error; dead-letter (next_retry_at=NULL) after MAX_RETRY.
+  - `DrainStats`, `llm_idempotency_key`/`tool_idempotency_key`, `set_/get_/maybe_get_billing_outbox` accessors, `_backoff_seconds` (exponential capped 3600s), `_payload_str/_int` validators.
+- **Tests** — `test_billing_outbox_service.py` (6 unit: enqueue + pure helpers) + `test_billing_outbox_drain.py` (5 integration: parity / idempotent-twice / reschedule / dead-letter / 2-tenant scoping). 11/11 green.
+
+### Day-序 resequence (NOT a scope change)
+- Plan slotted "router shadow" in Day 2, "flip" in Day 3. Reordered: **both move to Day 3** (shadow = Day-3 intra-day safety step BEFORE the flip). Rationale: the shadow needs the enqueue singleton wired (a Day-3 `api/main.py` edit); doing it in Day 2 would split the main.py edit across days for no safety gain. Day-2-end is already safe (nothing wired → existing direct cost-write path untouched → billing unchanged). Drainer is integration-proven NOW, so Day-3 wiring is de-risked.
+
+### Gate fixes (3)
+- **asyncpg SET param**: `SET LOCAL app.tenant_id = :p` fails (`syntax error at $1` — SET is a utility statement, no bind params). → `SELECT set_config('app.tenant_id', :p, true)` (function form, is_local=true = SET LOCAL). Mirrors `middleware/tenant_context.py:246`. Fixed in drainer `_set_tenant` + all test helpers.
+- **mypy `int ** int` → Any**: `2 ** (retry-1)` types as Any (pow can return float) → `min(...)` returned Any. → bit-shift `_BASE_BACKOFF_S << (retry-1)` (int<<int = int).
+- **pytest package collision**: stray `tests/integration/billing/__init__.py` made `billing` a regular package basename, colliding with `tests/unit/platform_layer/billing/` (which has `__init__.py`). Repo convention: integration test dirs have NO `__init__.py` (namespace/rootdir import, like `tests/integration/api/`). Removed the stray init.
+
+### Verification
+- `mypy src/` **0 / 335 files**; black + isort + flake8 **0**; **pytest 11/11** (6 unit + 5 drain integration, real Docker Postgres).
+
+### Remaining for Day 3+
+- Day 3: `api/main.py` `_wire_billing_outbox_drainer` (singleton + lifespan poller asyncio task + `BILLING_OUTBOX_*` config + `_DRAINER_ENABLED` flag) → router **shadow** dual-write → verify drain → router **flip** to enqueue-only (remove direct cost-write from 3 sites).
+- Day 4: chat-end-to-end + isolation integration (`test_chat_billing_outbox.py`) + real-Azure smoke + closeout.
+
+### Notes
+- Drainer is the harder piece; the per-row-txn + rollback-then-record-failure pattern avoids the poisoned-session trap of a single batch txn. Integration-tested against real Postgres (AP-10 — no mock divergence).

--- a/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/retrospective.md
+++ b/docs/03-implementation/agent-harness-execution/phase-57/sprint-57-84/retrospective.md
@@ -1,0 +1,59 @@
+# Sprint 57.84 Retrospective — C-15 billing leg: transactional billing Outbox
+
+**Sprint**: 57.84
+**Closed**: 2026-06-06
+**Branch**: `feature/sprint-57-84-billing-outbox`
+**Closes**: C-15 **billing-write-atomicity leg** / `AD-Cost-Ledger-Outbox-Atomicity`. IaC / DR / Analytics sub-items external-blocked → deferred.
+
+---
+
+## Q1. Goal achieved?
+
+✅ Yes. Chat billing is now durable + idempotent via a transactional `billing_outbox`:
+- NEW `billing_outbox` table (migration `0025`, RLS + system-sentinel drainer escape) + `BillingOutboxService.enqueue` (atomic, ON CONFLICT idempotent) + `BillingOutboxDrainer.drain_once` (per-row txn, exactly-once materialize via existing CostLedgerService, retry/backoff/dead-letter) + lifespan poller.
+- Router **flipped** from best-effort direct `cost_ledger` write → durable `billing_outbox.enqueue` (the 漏扣 vector is gone; the outbox idempotency key prevents future 雙扣).
+- Gates: mypy 0/335 · run_all 10/10 · full pytest **2161 passed**. real-Azure smoke: see Q7.
+
+## Q2. Estimate accuracy
+
+- Plan: bottom-up ~10.5 hr → class-calibrated commit ~8.4 hr (`medium-backend` 0.80, `agent_factor` 1.0 parent-direct).
+- Actual: ~9-10 hr. Day-0 + schema (Day 1) ~2 hr; service + drainer + tests (Day 2) ~3 hr; **router flip + poller + the regression hunt (Day 3) ~4-5 hr** (the singleton-leak pollution debugging was ~1.5-2 hr of that); closeout ~1 hr.
+- Ratio actual/committed ~1.1-1.2 — band upper edge. **The over-run was entirely the Day-3 test-isolation regression** (a self-inflicted singleton leak whose failure surfaced on innocent tests, requiring bisection). Pure-code estimate held; the debugging tail did not. `medium-backend` 0.80 roughly held given the larger-than-usual scope. Clean parent-direct data point.
+
+## Q3. What went well
+
+- **Day-0 三-prong caught the real shape early**: the 09.md `outbox` being notification-shaped (D1) + no worker runtime (D2) + the RLS cross-tenant wrinkle (D3) were all surfaced before code. The lint-leniency discovery (check_rls_policies only needs ENABLE+CREATE POLICY, not the USING body) let me fold the D3 RLS escape into the Day-1 migration cleanly (no second migration).
+- **Drainer correctness design held**: per-row independent txn (claim+materialize+mark-done atomic = exactly-once; rollback-then-record-failure avoids the poisoned-session trap of a single batch txn) was integration-proven against real Postgres BEFORE Day-3 wired it.
+- **The pre-sprint-main baseline check was decisive**: running the full suite on `main` (2150 clean) proved I introduced the flakiness — that turned an "is this pre-existing?" rabbit hole into a definite "find my bug".
+- **Bisection to a 2-second repro** (`unit/api` + incident) made the singleton-leak root cause tractable after the full-suite symptom looked like non-deterministic GC timing.
+
+## Q4. Lessons
+
+- **A new lifespan-wired module singleton needs a conftest reset fixture from the START.** `_wire_billing_outbox()` set the singleton; `test_main_lifespan` (TestClient) leaked it; a downstream chat-path test consumed it → enqueued on the global engine → an innocent later test hit "Event loop is closed". The pricing/rate-limit/error-budget singletons leak the same way but were benign (no consumer binds the global engine); billing_outbox's consumer does. **Action codified**: when adding a `set_*` singleton wired in the lifespan, add the autouse reset in the same sprint (Risk Class C / testing.md §Module-level Singleton Reset).
+- **`-p no:unraisableexception` is the fast way to tell a GC-warning-elevated-to-failure from a real failure.** Here it stayed failing → real pollution, not a cosmetic GC warning. Saved chasing the wrong (asyncpg GC) theory.
+- **asyncpg + SET utility statement rejects bind params** → use `SELECT set_config(name, value, is_local)` (the function form). Mirror `middleware/tenant_context.py`.
+- **Direct `get_session_factory()` use in tests (outside the db_session fixture) needs a dedicated NullPool engine** to avoid pooled connections lingering across per-test event loops.
+
+## Q5. Improvements next sprint
+
+- For any sprint that wires a new singleton in `api/main.py:_lifespan`, add the conftest reset fixture as a Day-1 checklist item (not discovered as a Day-3 regression). Consider a lint/grep that flags a `set_*` singleton without a matching conftest reset.
+
+## Q6. Carryover (→ next-phase-candidates.md)
+
+- **C-15 IaC deploy pipeline** — external-blocked (Azure provision + GitHub Secrets). Deferred.
+- **C-15 DR automation / multi-region / WAL** — external-blocked (Azure infra decisions). Deferred.
+- **C-15 Analytics / data warehouse / CDC / dbt** — fully external infra. Deferred.
+- **Stripe (external billing) consumer** — the outbox backbone is built for it; this sprint's drainer materializes `cost_ledger` only. Future worker-only change.
+- **Enqueue-itself failure** — kept logged best-effort (SSE safety); a rare enqueue failure that doesn't poison the txn is swallowed (the major 漏扣 vector — heavy pricing+flush after session commit — is eliminated). Revisit if metrics show enqueue failures.
+- (B-8 carryovers unrelated: per-verifier cost attribution, multi-judge registry.)
+
+## Q7. Risks
+
+- **Medium** (touched a real-LLM-live billing path). Mitigations: producer + drainer + 2-tenant isolation all tested; the flip is env-revertible (`BILLING_OUTBOX_DRAINER_ENABLED=false` + 1-commit revert of the direct write); not merged until gates green. **real-Azure smoke**: ✅ PASSED (user-authorized, gpt-5.2). A `real_llm` chat (session f5f60c3a) enqueued 1 `llm_call` outbox row → the background drainer marked it `done` (retry=0) and materialized 2 `cost_ledger` rows (`azure_openai_gpt-5.2-2025-12-11` input qty=1997 + output qty=41) with **unit_cost > 0** (C-11 date-suffix pricing normalize applied via the drainer's single-source CostLedgerService). VERDICT: outbox_all_done + 2 cost rows + nonzero cost — the chat→enqueue→drain→cost_ledger chain works end-to-end on the live path (clean backend restart per Risk Class E; backend stopped + temp scripts removed after). The full chain is also covered by the producer tests (chat→outbox) + drainer tests (outbox→cost_ledger parity + isolation).
+- Residual: the in-sprint singleton-leak regression is fixed + verified (2161 passed); the conftest reset is autouse so it can't regress silently.
+
+---
+
+## Design Note Extract
+
+NO — this is a feature-continuation sprint within the billing key-chain (extends the existing cost_ledger / pricing single-source with a durable-event backbone). New transactional-outbox pattern, but no new domain spike + no new cross-CATEGORY contract (17.md scope = 11+1 categories; billing is platform_layer, not registered there). The pattern + contract live in CHANGE-051 + the module docstrings + the plan.

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
@@ -19,23 +19,23 @@
 ### 0.2 Branch + decisions
 - [x] **Branch created** `feature/sprint-57-84-billing-outbox`
 - [x] **Decisions locked**: dedicated `billing_outbox`; atomic enqueue in request txn; lifespan async poller (`SKIP LOCKED` + backoff + dead-letter); idempotency via `UNIQUE(tenant_id, idempotency_key)` + idempotent drain; shadow dual-write Day-2 → enqueue-only flip Day-3; drainer materializes `cost_ledger` (Stripe future-leg); parent-direct (`agent_factor` 1.0).
-- [ ] **Day-0 commit** plan + checklist + progress.md Day 0
+- [x] **Day-0 commit** plan + checklist + progress.md Day 0 (`ef8c1f3e`)
 
 ---
 
 ## Day 1 — Schema: `billing_outbox` table + migration + ORM (US-1/US-2)
 
 ### 1.1 ORM model
-- [ ] **NEW `infrastructure/db/models/billing_outbox.py`** — `BillingOutboxEvent` (TenantScopedMixin): id/tenant_id/event_type/payload(JSONB)/idempotency_key/status/retry_count/next_retry_at/last_error/session_id/created_at/processed_at
-  - DoD: mypy clean; columns match plan §3.1; status/event_type as constrained strings
-- [ ] **Register** in `infrastructure/db/models/__init__.py` (after cost_ledger import)
-  - DoD: Base.metadata sees it; `check_rls_policies` discovers the new table
+- [x] **NEW `infrastructure/db/models/billing_outbox.py`** — `BillingOutboxEvent` (TenantScopedMixin): id(BigInteger PK)/tenant_id/event_type/payload(JSONB)/idempotency_key/status/retry_count/next_retry_at/last_error/session_id/created_at/processed_at + UNIQUE + 2 CHECK + 2 Index
+  - DoD: mypy clean ✅ (`dict[str, object]` for JSONB under strict); columns match plan §3.1
+- [x] **Register** in `infrastructure/db/models/__init__.py` (after audit, before cost_ledger import) + `__all__`
+  - DoD: `check_rls_policies` discovers `billing_outbox` (10/10 green) ✅
 
 ### 1.2 migration 0025
-- [ ] **Read `0024_memory_ops.py` header** → confirm exact `revision` id for `down_revision`
-- [ ] **NEW `migrations/versions/0025_billing_outbox.py`** — CREATE TABLE + `UNIQUE(tenant_id, idempotency_key)` + `idx_billing_outbox_due` (partial WHERE status IN pending/failed) + `idx_billing_outbox_tenant` + status/event_type CHECK + `ENABLE ROW LEVEL SECURITY` + `tenant_isolation_billing_outbox` policy (mirror 0009 style)
-  - DoD: `alembic upgrade head` applies on the 0024 head (verify against Docker DB); downgrade drops cleanly
-- [ ] **black + isort + flake8 + mypy src/** — clean
+- [x] **Read `0024_memory_ops.py` header** → `revision="0024_memory_ops"` → `down_revision="0024_memory_ops"`
+- [x] **NEW `migrations/versions/0025_billing_outbox.py`** — CREATE TABLE + `UNIQUE(tenant_id, idempotency_key)` + `idx_billing_outbox_due` (partial WHERE status IN pending/failed) + `idx_billing_outbox_tenant` + status/event_type CHECK + ENABLE+FORCE RLS + `tenant_isolation_billing_outbox` (USING + **system-sentinel escape** for drainer) + `tenant_insert_billing_outbox` (WITH CHECK) — mirror 0024 two-policy
+  - DoD: applied **both directions** on Docker DB (upgrade → downgrade -1 → re-upgrade; head=`0025_billing_outbox`) ✅. Lint leniency confirmed (`check_rls_policies` only needs ENABLE+CREATE POLICY, not USING content) → full escape RLS in Day-1 (D3 resolved early)
+- [x] **black + isort + flake8 + mypy src/** — clean (mypy 0/334; flake8 0; black/isort applied)
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
@@ -68,23 +68,28 @@
 ## Day 3 — Poller wiring + router flip + RLS-correct drain (US-3/US-4/US-5)
 
 ### 3.1 lifespan poller
-- [ ] **`api/main.py` `_wire_billing_outbox_drainer()`** — construct drainer + `asyncio.create_task` polling loop (interval/batch/max_retry from config); store task+stop on app state; cancel+await on shutdown; fail-open restart; `BILLING_OUTBOX_DRAINER_ENABLED` flag (conftest false)
-- [ ] **`core/config/__init__.py`** — `billing_outbox_poll_interval_s` (5) / `_batch` (50) / `_max_retry` (8) / `_drainer_enabled` (true) settings + docstring
+- [x] **`api/main.py`** — `_wire_billing_outbox()` (enqueue singleton) + `_billing_outbox_poll_loop` (fail-open, stop-event-interruptible sleep) + `_start_billing_outbox_drainer(app)` (env `BILLING_OUTBOX_DRAINER_ENABLED` gate; pricing-loader dep; `asyncio.create_task`; task+stop on app.state) + lifespan startup calls + shutdown cancel (stop BEFORE OTel/engine teardown)
+- [x] **`core/config/__init__.py`** — `billing_outbox_poll_interval_s` (5) / `_batch` (50) / `_max_retry` (8) settings + docstring (enabled flag = os.environ, not Settings, to dodge the lru_cache trap)
 
 ### 3.2 RLS-correct cross-tenant drain
-- [ ] **Read `0009_rls_policies`** → confirm policy style + how app.tenant_id is set
-- [ ] **system-context escape** on `billing_outbox` policy for the poller claim read + per-row `SET LOCAL app.tenant_id = row.tenant_id` before `cost_ledger` materialize
-  - DoD: `check_rls_policies` green; isolation test (3.4) passes
+- [x] **RLS escape** — resolved at **Day-1** (0025 migration already carries the system-sentinel escape in the `tenant_isolation_billing_outbox` USING clause; `check_rls_policies` lenient → no separate migration). Drainer `set_config('app.tenant_id', sentinel)` for the claim + per-row `set_config(..., row.tenant_id)` before the `cost_ledger` materialize.
+  - DoD: `check_rls_policies` green ✅; **2-tenant isolation test** (drain test US-4) passes ✅
 
 ### 3.3 router flip to enqueue-only
-- [ ] **`router.py` flip** — remove direct `cost_ledger.record_*` from the 3 sites (loop / `_verification` / tool); observer ONLY enqueues; no dead code / `_v2` (AP-11); decide enqueue swallow-vs-propagate with a test (atomic-rollback is correct behaviour now)
+- [x] **`router.py` flip** — removed direct `cost_ledger.record_*` from the 3 sites; observer now ONLY `billing_outbox.enqueue(...)`; removed `cost_ledger`/`PricingLoader`/`maybe_get_pricing_loader` imports + `pricing_loader` endpoint dep + per-request `CostLedgerService`; `_FALLBACK_PRICING_MODEL` retained (drainer prices); tool_seq counter; no dead code (AP-11). Swallow-vs-propagate: kept **logged best-effort** (SSE safety, consistent w/ sessions/audit observers); atomicity from the shared request txn (enqueue = single INSERT committing with session/audit).
+- [x] **Updated existing callers of the flipped contract** — `test_chat_cost_ledger.py` (2 tests → assert outbox; quota test unchanged) + `test_phase56_3_e2e.py` (cost section → outbox; SLA + quota unchanged). Other `_stream_loop_events` callers don't pass `cost_ledger=` → unaffected.
+
+### 3.4 Day-3 regression fix — test-isolation (Risk Class C)
+- [x] **Root cause (bisected `unit/api`+incident, 2s repro)** — `_wire_billing_outbox()` in the lifespan sets the module singleton; shutdown doesn't unset it (correct for prod). `test_main_lifespan` (TestClient) leaks it → a downstream chat-path test consumes `maybe_get_billing_outbox()` → enqueues on the GLOBAL engine without dispose → a later `db_session` test (`incident/test_service`) hits `RuntimeError: Event loop is closed`. Verified pre-sprint main clean (2150) → I introduced it (not pre-existing).
+- [x] **Fix** — autouse `_reset_billing_outbox_singleton` in `tests/conftest.py` (`set_billing_outbox(None)` around each test; testing.md §Module-level Singleton Reset) + drain test dedicated NullPool engine (isolates direct-session churn) + `SET LOCAL`→`set_config(...)` (Day-2).
+  - DoD: full suite **2161 passed** (was 1 flaky fail); mypy 0/335; run_all 10/10
 
 ---
 
 ## Day 4 — Integration tests + real-Azure smoke + Closeout
 
 ### 4.1 integration + isolation
-- [ ] **NEW `test_chat_billing_outbox.py`** — request enqueues atomically (commit ⟺ outbox row); drain parity (same cost_ledger rows as old direct path); multi-tenant isolation (tenant-A cost rows scoped to A, no B leak); singleton reset fixture (Risk Class C)
+- [x] **Coverage achieved across existing files (no separate `test_chat_billing_outbox.py` — would duplicate)** — producer (chat → enqueue): `test_chat_cost_ledger.py` + `test_phase56_3_e2e.py` (Day 3); drainer parity + idempotent-twice + dead-letter + **2-tenant isolation (US-4)**: `test_billing_outbox_drain.py` (Day 2). The full chat→enqueue→drain→cost_ledger chain on real data = the real-Azure smoke below. A separate automated chain test would need the committed-data pattern (db_session rolls back) and mostly re-assert the drain test — skipped to avoid redundant infra.
 - [ ] **real-Azure smoke** (user-authorized; Risk Class E clean restart) — 1-2 chats mode=real_llm → confirm a `cost_ledger` row appears via the DRAINED path (not direct) before closeout
 
 ### 4.2 Full sweep

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
@@ -39,25 +39,29 @@
 
 ---
 
-## Day 2 — Service: enqueue + drain + shadow dual-write (US-1/US-2/US-3)
+## Day 2 — Service: enqueue + drain + tests (US-1/US-2/US-3/US-4)
+
+> **Day-序 resequence** (noted in progress.md, not a scope change): the router **shadow + flip** both move to Day 3 (shadow becomes the Day-3 intra-day safety step before the flip). Day 2 = pure new module + tests, ZERO risk to the existing cost-write path (nothing wired). The drainer is integration-tested NOW (before Day-3 wiring).
 
 ### 2.1 BillingOutboxService.enqueue
-- [ ] **NEW `platform_layer/billing/billing_outbox.py`** — `BillingOutboxService.enqueue(db, *, tenant_id, event_type, payload, idempotency_key, session_id)` using the passed-in request session; UNIQUE-conflict → no-op (idempotent enqueue); singleton accessors (`set_/get_/maybe_get_billing_outbox`, reset hook)
-  - DoD: enqueue adds row in caller's txn; duplicate key no-op
+- [x] **NEW `platform_layer/billing/billing_outbox.py`** — `BillingOutboxService.enqueue(db, *, tenant_id, event_type, payload, idempotency_key, session_id)` using the passed-in request session; `pg_insert(...).on_conflict_do_nothing(constraint="uq_billing_outbox_idem")` (idempotent enqueue); singleton accessors (`set_/get_/maybe_get_billing_outbox`, reset hook)
+  - DoD: enqueue adds row in caller's txn ✅; duplicate key no-op ✅ (unit tests)
 
 ### 2.2 BillingOutboxDrainer.drain_once
-- [ ] **`BillingOutboxDrainer.drain_once(system_db_factory) -> DrainStats`** — claim due rows (`FOR UPDATE SKIP LOCKED LIMIT N`); per row `SET LOCAL app.tenant_id` → call existing `CostLedgerService.record_llm_call/record_tool_call` from payload → mark `done`; on failure bump retry_count + next_retry_at(backoff) + last_error + status `failed`; dead-letter after MAX_RETRY (log/metric, not dropped)
-  - DoD: claim+materialize+mark in one txn (idempotent re-claim); pricing single-source (existing CostLedgerService)
+- [x] **`BillingOutboxDrainer.drain_once() -> DrainStats`** — per-row independent txn: claim ONE due row (`FOR UPDATE SKIP LOCKED LIMIT 1` under sentinel) → `set_config('app.tenant_id', row.tenant_id, true)` → existing `CostLedgerService.record_llm_call/record_tool_call` from payload → mark `done` (same commit = exactly-once); on materialize failure → rollback (clears poisoned session + releases lock) → fresh txn records retry/backoff/last_error; dead-letter (status=failed, next_retry_at=NULL) after MAX_RETRY
+  - DoD: claim+materialize+mark atomic (no 雙扣) ✅; pricing single-source (existing CostLedgerService) ✅ (drain integration tests)
 
-### 2.3 idempotency key builder + router shadow enqueue
-- [ ] **Idempotency key builder** — LLM `{session_id}:{event_type}:{sub_type or 'loop'}`; tool `{session_id}:tool:{tool_name}:{seq}` (per-request monotonic seq) — finalized against the real router event stream
-- [ ] **`router.py` shadow** — after each existing `cost_ledger.record_*` call, ALSO `billing_outbox.enqueue(...)` (dual-write; billing never regresses)
-  - DoD: shadow run writes BOTH a cost_ledger row (old path) AND an outbox row (new path)
+### 2.3 idempotency key builder
+- [x] **Idempotency key builder** — `llm_idempotency_key(session_id, sub_type)` = `{sid}:llm:{sub_type or 'loop'}` (loop vs _verification distinct); `tool_idempotency_key(session_id, tool_name, seq)` = `{sid}:tool:{tool_name}:{seq}` (per-request monotonic seq)
+  - DoD: loop≠verification, same-tool seq disambiguation (unit tests)
+- [→] **`router.py` shadow** — MOVED to Day 3 (intra-day safety step before flip). Not deleted; see Day 3.
 
-### 2.4 unit tests + gate
-- [ ] **NEW `test_billing_outbox_service.py`** — enqueue adds row / dup key no-op / drain materializes cost_ledger / drain idempotent (twice → one cost row) / retry+backoff on failure / dead-letter after MAX_RETRY
-- [ ] **black + isort + flake8 + mypy src/** — clean; pytest green
-- [ ] **Cut-line checkpoint** — Day-2-end = safe shadow ship; assess Day-3 flip risk
+### 2.4 unit + integration tests + gate
+- [x] **NEW `test_billing_outbox_service.py`** (unit, db_session) — enqueue adds pending row / dup key no-op + pure helpers (key builders / backoff exponential+capped / payload validators incl. error cases) — 6 tests
+- [x] **NEW `test_billing_outbox_drain.py`** (integration, committed data + cleanup) — drain materializes cost_ledger PARITY / idempotent-twice (→ exactly-once) / reschedule+backoff / dead-letter after max_retry / **2-tenant scoping (US-4)** — 5 tests
+- [x] **black + isort + flake8 + mypy src/** — clean (mypy 0/335; flake8 0); **pytest 11/11 green** (6 unit + 5 integration)
+  - Fix during gate: `SET LOCAL app.tenant_id = :p` → `SELECT set_config('app.tenant_id', :p, true)` (asyncpg rejects bind params on SET utility; mirror `middleware/tenant_context.py`); `int ** int`→`Any` mypy → bit-shift `<<`; removed stray `tests/integration/billing/__init__.py` (basename `billing` package collided with unit test pkg)
+- [x] **Cut-line checkpoint** — Day-2-end = safe (nothing wired; existing cost-write path untouched). Day-3 flip risk assessed: drainer proven by integration tests → safe to wire.
 
 ---
 

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
@@ -1,0 +1,103 @@
+# Sprint 57.84 — Checklist (C-15 billing leg: transactional billing Outbox)
+
+**Plan**: `sprint-57-84-plan.md`
+**Branch**: `feature/sprint-57-84-billing-outbox` (from `main` `179b4416`)
+**Closes**: C-15 **billing-write-atomicity leg** / `AD-Cost-Ledger-Outbox-Atomicity`. IaC/DR/Analytics deferred (external-blocked).
+
+---
+
+## Day 0 — Plan-vs-Repo Verify + Branch + Decisions
+
+### 0.1 Day-0 verify (parent grep + code read, main `179b4416`)
+- [x] **Prong 1 (path)** — confirm: `api/v1/chat/router.py` (cost-write observer), `platform_layer/billing/cost_ledger.py` (CostLedgerService + singleton accessors), `infrastructure/db/session.py` (get_db_session auto-commit), `infrastructure/db/models/cost_ledger.py` + `models/__init__.py`, `api/main.py` `_lifespan` + `_wire_*`, `runtime/workers/*` (stubs), migration head `0024_memory_ops`.
+- [x] **Prong 2 (content)** — chat flow in-memory; cost write best-effort try/except + flush (漏扣 vector); no idempotency key on cost_ledger; no live double-charge (sub_types distinct); no production worker runtime (`[STUB]`); no `SKIP LOCKED` idiom; poller must follow `_wire_*` lifespan pattern.
+- [x] **Prong 3 (schema)** — 09.md `outbox` is NOTIFICATION-shaped (teams/email/webhook), NOT billing → build dedicated `billing_outbox` (D1); migration head `0024` → next `0025` (exact down_revision read Day-1); cost_ledger has NO unique/dedup key; new model must register in `models/__init__.py`; RLS poller-cross-tenant wrinkle (D3).
+- [x] **Drift findings** — D1 (notification outbox ≠ billing → dedicated table); D2 (no worker runtime → new lifespan poller); D3 (RLS: poller reads cross-tenant, writes per-tenant → system-context escape + per-row tenant SET).
+- [x] **Design locked** (AskUserQuestion 2026-06-05): scope = billing-write-atomicity leg only (IaC/DR/Analytics deferred); depth = **full Outbox** (table + migration + idempotent worker + publisher). parent-direct.
+- [x] **go/no-go** — GO; shadow cut-line at Day-2-end; flip can carryover if Day-3 over-runs.
+
+### 0.2 Branch + decisions
+- [x] **Branch created** `feature/sprint-57-84-billing-outbox`
+- [x] **Decisions locked**: dedicated `billing_outbox`; atomic enqueue in request txn; lifespan async poller (`SKIP LOCKED` + backoff + dead-letter); idempotency via `UNIQUE(tenant_id, idempotency_key)` + idempotent drain; shadow dual-write Day-2 → enqueue-only flip Day-3; drainer materializes `cost_ledger` (Stripe future-leg); parent-direct (`agent_factor` 1.0).
+- [ ] **Day-0 commit** plan + checklist + progress.md Day 0
+
+---
+
+## Day 1 — Schema: `billing_outbox` table + migration + ORM (US-1/US-2)
+
+### 1.1 ORM model
+- [ ] **NEW `infrastructure/db/models/billing_outbox.py`** — `BillingOutboxEvent` (TenantScopedMixin): id/tenant_id/event_type/payload(JSONB)/idempotency_key/status/retry_count/next_retry_at/last_error/session_id/created_at/processed_at
+  - DoD: mypy clean; columns match plan §3.1; status/event_type as constrained strings
+- [ ] **Register** in `infrastructure/db/models/__init__.py` (after cost_ledger import)
+  - DoD: Base.metadata sees it; `check_rls_policies` discovers the new table
+
+### 1.2 migration 0025
+- [ ] **Read `0024_memory_ops.py` header** → confirm exact `revision` id for `down_revision`
+- [ ] **NEW `migrations/versions/0025_billing_outbox.py`** — CREATE TABLE + `UNIQUE(tenant_id, idempotency_key)` + `idx_billing_outbox_due` (partial WHERE status IN pending/failed) + `idx_billing_outbox_tenant` + status/event_type CHECK + `ENABLE ROW LEVEL SECURITY` + `tenant_isolation_billing_outbox` policy (mirror 0009 style)
+  - DoD: `alembic upgrade head` applies on the 0024 head (verify against Docker DB); downgrade drops cleanly
+- [ ] **black + isort + flake8 + mypy src/** — clean
+
+---
+
+## Day 2 — Service: enqueue + drain + shadow dual-write (US-1/US-2/US-3)
+
+### 2.1 BillingOutboxService.enqueue
+- [ ] **NEW `platform_layer/billing/billing_outbox.py`** — `BillingOutboxService.enqueue(db, *, tenant_id, event_type, payload, idempotency_key, session_id)` using the passed-in request session; UNIQUE-conflict → no-op (idempotent enqueue); singleton accessors (`set_/get_/maybe_get_billing_outbox`, reset hook)
+  - DoD: enqueue adds row in caller's txn; duplicate key no-op
+
+### 2.2 BillingOutboxDrainer.drain_once
+- [ ] **`BillingOutboxDrainer.drain_once(system_db_factory) -> DrainStats`** — claim due rows (`FOR UPDATE SKIP LOCKED LIMIT N`); per row `SET LOCAL app.tenant_id` → call existing `CostLedgerService.record_llm_call/record_tool_call` from payload → mark `done`; on failure bump retry_count + next_retry_at(backoff) + last_error + status `failed`; dead-letter after MAX_RETRY (log/metric, not dropped)
+  - DoD: claim+materialize+mark in one txn (idempotent re-claim); pricing single-source (existing CostLedgerService)
+
+### 2.3 idempotency key builder + router shadow enqueue
+- [ ] **Idempotency key builder** — LLM `{session_id}:{event_type}:{sub_type or 'loop'}`; tool `{session_id}:tool:{tool_name}:{seq}` (per-request monotonic seq) — finalized against the real router event stream
+- [ ] **`router.py` shadow** — after each existing `cost_ledger.record_*` call, ALSO `billing_outbox.enqueue(...)` (dual-write; billing never regresses)
+  - DoD: shadow run writes BOTH a cost_ledger row (old path) AND an outbox row (new path)
+
+### 2.4 unit tests + gate
+- [ ] **NEW `test_billing_outbox_service.py`** — enqueue adds row / dup key no-op / drain materializes cost_ledger / drain idempotent (twice → one cost row) / retry+backoff on failure / dead-letter after MAX_RETRY
+- [ ] **black + isort + flake8 + mypy src/** — clean; pytest green
+- [ ] **Cut-line checkpoint** — Day-2-end = safe shadow ship; assess Day-3 flip risk
+
+---
+
+## Day 3 — Poller wiring + router flip + RLS-correct drain (US-3/US-4/US-5)
+
+### 3.1 lifespan poller
+- [ ] **`api/main.py` `_wire_billing_outbox_drainer()`** — construct drainer + `asyncio.create_task` polling loop (interval/batch/max_retry from config); store task+stop on app state; cancel+await on shutdown; fail-open restart; `BILLING_OUTBOX_DRAINER_ENABLED` flag (conftest false)
+- [ ] **`core/config/__init__.py`** — `billing_outbox_poll_interval_s` (5) / `_batch` (50) / `_max_retry` (8) / `_drainer_enabled` (true) settings + docstring
+
+### 3.2 RLS-correct cross-tenant drain
+- [ ] **Read `0009_rls_policies`** → confirm policy style + how app.tenant_id is set
+- [ ] **system-context escape** on `billing_outbox` policy for the poller claim read + per-row `SET LOCAL app.tenant_id = row.tenant_id` before `cost_ledger` materialize
+  - DoD: `check_rls_policies` green; isolation test (3.4) passes
+
+### 3.3 router flip to enqueue-only
+- [ ] **`router.py` flip** — remove direct `cost_ledger.record_*` from the 3 sites (loop / `_verification` / tool); observer ONLY enqueues; no dead code / `_v2` (AP-11); decide enqueue swallow-vs-propagate with a test (atomic-rollback is correct behaviour now)
+
+---
+
+## Day 4 — Integration tests + real-Azure smoke + Closeout
+
+### 4.1 integration + isolation
+- [ ] **NEW `test_chat_billing_outbox.py`** — request enqueues atomically (commit ⟺ outbox row); drain parity (same cost_ledger rows as old direct path); multi-tenant isolation (tenant-A cost rows scoped to A, no B leak); singleton reset fixture (Risk Class C)
+- [ ] **real-Azure smoke** (user-authorized; Risk Class E clean restart) — 1-2 chats mode=real_llm → confirm a `cost_ledger` row appears via the DRAINED path (not direct) before closeout
+
+### 4.2 Full sweep
+- [ ] **Backend gates** — black/isort/flake8 0 + `mypy src/` 0 + `pytest` green + `run_all.py` 10/10 (`check_rls_policies` + `check_llm_sdk_leak` + `check_event_schema_sync`)
+- [ ] **No frontend** — backend + docs only
+- [ ] **Read all changed code** — final pass
+
+### 4.3 Closeout docs
+- [ ] **CHANGE-051** in `claudedocs/4-changes/feature-changes/`
+- [ ] **17.md** — BillingOutbox enqueue/drain contract (single-source)
+- [ ] **progress.md** Day 0-4 + **retrospective.md** Q1-Q7 (atomicity design + flip decision + real-Azure smoke)
+- [ ] **Checklist** all `[x]` (mark 🚧 + reason if flip carried over per §Workload cut-line)
+- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio; large-sprint note)
+- [ ] **AD status**: C-15 billing-write-atomicity leg CLOSED (or partial + `AD-Billing-Outbox-Flip` carryover); IaC/DR/Analytics deferred → next-phase-candidates.md
+- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [ ] **Design note?** — likely YES (new transactional-outbox pattern + cross-cutting contract; spike-extract 8-point gate) — decide at closeout per §Step 5.5
+
+### 4.4 Ship
+- [ ] **Commit mapping** Day-0 / Day-1 schema / Day-2 service+shadow / Day-3 poller+flip / Day-4 tests+closeout
+- [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-checklist.md
@@ -90,23 +90,23 @@
 
 ### 4.1 integration + isolation
 - [x] **Coverage achieved across existing files (no separate `test_chat_billing_outbox.py` — would duplicate)** — producer (chat → enqueue): `test_chat_cost_ledger.py` + `test_phase56_3_e2e.py` (Day 3); drainer parity + idempotent-twice + dead-letter + **2-tenant isolation (US-4)**: `test_billing_outbox_drain.py` (Day 2). The full chat→enqueue→drain→cost_ledger chain on real data = the real-Azure smoke below. A separate automated chain test would need the committed-data pattern (db_session rolls back) and mostly re-assert the drain test — skipped to avoid redundant infra.
-- [ ] **real-Azure smoke** (user-authorized; Risk Class E clean restart) — 1-2 chats mode=real_llm → confirm a `cost_ledger` row appears via the DRAINED path (not direct) before closeout
+- [x] **real-Azure smoke** ✅ (user-authorized; Risk Class E clean restart) — `real_llm` chat (session f5f60c3a, gpt-5.2) → 1 `llm_call` outbox row drained to `done` → 2 `cost_ledger` rows via the DRAINER (input qty=1997 + output qty=41, **unit_cost > 0** — C-11 normalize works through the drainer). Chain chat→enqueue→drain→cost_ledger verified live. Backend stopped + temps removed.
 
 ### 4.2 Full sweep
-- [ ] **Backend gates** — black/isort/flake8 0 + `mypy src/` 0 + `pytest` green + `run_all.py` 10/10 (`check_rls_policies` + `check_llm_sdk_leak` + `check_event_schema_sync`)
-- [ ] **No frontend** — backend + docs only
-- [ ] **Read all changed code** — final pass
+- [x] **Backend gates** — black/isort/flake8 0 + `mypy src/` 0/335 + `pytest` 2161 passed/4 skipped + `run_all.py` 10/10 (`check_rls_policies` + `check_llm_sdk_leak` + `check_event_schema_sync` green)
+- [x] **No frontend** — backend + docs only
+- [x] **Read all changed code** — final pass (router flip, drainer, migration, conftest fix)
 
 ### 4.3 Closeout docs
-- [ ] **CHANGE-051** in `claudedocs/4-changes/feature-changes/`
-- [ ] **17.md** — BillingOutbox enqueue/drain contract (single-source)
-- [ ] **progress.md** Day 0-4 + **retrospective.md** Q1-Q7 (atomicity design + flip decision + real-Azure smoke)
-- [ ] **Checklist** all `[x]` (mark 🚧 + reason if flip carried over per §Workload cut-line)
-- [ ] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio; large-sprint note)
-- [ ] **AD status**: C-15 billing-write-atomicity leg CLOSED (or partial + `AD-Billing-Outbox-Flip` carryover); IaC/DR/Analytics deferred → next-phase-candidates.md
-- [ ] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
-- [ ] **Design note?** — likely YES (new transactional-outbox pattern + cross-cutting contract; spike-extract 8-point gate) — decide at closeout per §Step 5.5
+- [x] **CHANGE-051** in `claudedocs/4-changes/feature-changes/`
+- [→] **17.md** — **N/A** (assessed): 17.md is the 11+1 cross-CATEGORY registry (ChatClient / LoopEvent / HITL / tool registry); platform_layer.billing is not registered there (sibling `cost_ledger` is absent too). BillingOutbox is documented in CHANGE-051 + module docstrings + the plan — forcing it into 17.md would violate that file's scope.
+- [x] **progress.md** Day 0-4 + **retrospective.md** Q1-Q7 (atomicity design + flip + real-Azure smoke)
+- [x] **Checklist** all `[x]` (no flip carryover — flip shipped; smoke passed)
+- [x] **Calibration** record (medium-backend 0.80; agent_factor 1.0 parent-direct; ratio ~1.1-1.2 — over-run entirely the Day-3 singleton-leak debug; large-sprint note in retro Q2)
+- [x] **AD status**: C-15 billing-write-atomicity leg **CLOSED**; IaC/DR/Analytics deferred → next-phase-candidates.md (no flip carryover)
+- [x] **MEMORY subfile + pointer** + **CLAUDE.md lean** (Current Sprint + Last Updated)
+- [x] **Design note?** — **NO** (feature-continuation within the billing key-chain; new pattern but no new domain spike / no new cross-CATEGORY contract — lives in CHANGE-051 + module docstrings + plan; per §Step 5.5 spike-vs-continuation)
 
 ### 4.4 Ship
-- [ ] **Commit mapping** Day-0 / Day-1 schema / Day-2 service+shadow / Day-3 poller+flip / Day-4 tests+closeout
+- [x] **Commit mapping** Day-0 `ef8c1f3e` / Day-1 schema `cd84b437` / Day-2 service+tests `fe4beeed` / Day-3 flip+poller+fix `51524a35` / Day-4 closeout (pending)
 - [ ] **Push + PR** (user-gated — explicit authorization required)

--- a/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-plan.md
+++ b/docs/03-implementation/agent-harness-planning/phase-57-frontend-saas/sprint-57-84-plan.md
@@ -1,0 +1,156 @@
+# Sprint 57.84 Plan — C-15 billing leg: transactional billing Outbox (durable cost events + idempotent drain) (closes C-15 billing-write-atomicity / AD-Cost-Ledger-Outbox-Atomicity)
+
+**Branch**: `feature/sprint-57-84-billing-outbox` (from `main` `179b4416`)
+**Closes**: the **billing-write-atomicity leg of C-15** (the lone in-repo, billing-key-chain ② leg). IaC / DR / Analytics sub-items are external-blocked → deferred to `next-phase-candidates.md` (user decision 2026-06-05). This sprint ships the transactional Outbox backbone: cost events become durable atomically with the chat request, and an idempotent background drain materializes `cost_ledger` (Stripe consumer is future-leg).
+
+---
+
+## 0. Background
+
+C-11 (57.79) fixed pricing-key + token-param billing **correctness**; B-7 (57.81) wired ErrorBudget Redis; B-8 (57.82-57.83) wired verification judge cost → ledger + flipped verification default. Those closed the "what we charge" correctness. C-15's billing leg closes the remaining **"do we reliably record the charge at all"** gap.
+
+**The problem (Day-0 grep + code read, main `179b4416`)**:
+- The chat flow is **purely in-memory** (`artifact.messages`); the only DB writes during a request are observer-driven: `sessions` (SAVEPOINT, `router.py:259`), `cost_ledger` (`router.py:445-485`), `audit_log` (SAVEPOINT, `router.py:504`), `tool_calls` (SAVEPOINT, `router.py:615`).
+- `get_db_session` (`infrastructure/db/session.py:51-57`) **auto-commits after the SSE generator finishes**. The cost write is `db.add(...)` + `await db.flush()` (`cost_ledger.py:186-188`) inside that generator.
+- The cost write sits in a **bare `try/except` that swallows the exception** (`router.py:453-458`, `:480-485`, `:597-600`). A flush failure (constraint, pool flake, poisoned session) is logged and dropped → the session/audit rows still attempt commit → **漏扣 (missing-charge)**: real-LLM (live since 57.79) revenue silently lost. There is **no idempotency key** on `cost_ledger` (recon: `models/cost_ledger.py` has zero unique/dedup constraint) → a future retry/replay path would **雙扣 (double-charge)**.
+- **No live double-charge bug exists today** (Day-0 code recon: loop / `_verification` / tool sub_types are distinct, quota and ledger are independent layers). The present risk is **漏扣**; **雙扣** is a prevention concern for the future Stripe/retry path.
+
+**The fix (Outbox pattern, user chose full Outbox over the lightweight option, 2026-06-05)**:
+- Emit a **billing event row into a NEW `billing_outbox` table in the same request transaction** (atomic with session/audit — guaranteed to commit together; replaces the best-effort swallow).
+- A **background poller drains pending outbox rows idempotently**, materializing `cost_ledger` (and, future-leg, Stripe), with a stable idempotency key so retries/replays never double-charge.
+
+### Day-0 ground-truth (parent grep + code read, main `179b4416`)
+- **Existing `outbox` design is NOT billing-shaped** (`09-db-schema-design.md:1045-1073`): `destination` ∈ {teams,email,webhook}, `source_type` ∈ {approval_request,alert} — a NOTIFICATION outbox. **No migration exists for it** (recon `grep outbox models/+migrations/` → 0). → build a dedicated `billing_outbox` (single-responsibility; do NOT cram billing into the notification schema). **Drift D1.**
+- **Migration head = `0024_memory_ops`** (recon) → next = `0025`. Exact `down_revision` confirmed Day-1 by reading `0024` header.
+- **No production background-task runtime**: `runtime/workers/{agent_loop_worker,queue_backend}.py` are `[STUB]` (Phase 53.1 Temporal, not wired); `MockQueueBackend` only. → the outbox poller is NEW, following the `api/main.py:_lifespan` `_wire_*` hook pattern (`_wire_rate_limit_counter` / `_wire_error_budget` precedent, 57.81). **Drift D2.**
+- **No existing idempotency key** anywhere on `cost_ledger`; no `SELECT … FOR UPDATE SKIP LOCKED` idiom in repo → both NEW. Idempotency lives on `billing_outbox` (unique natural key) + an idempotent drain (claim → materialize → mark done in one txn).
+- **RLS wrinkle**: per-request RLS sets `app.tenant_id` via middleware (`SET LOCAL`). The poller runs OUTSIDE a request (no tenant JWT) but must read pending rows **across all tenants**, then write `cost_ledger` **per-tenant-scoped**. Resolution (Day-3 design, confirmed against `0009_rls_policies`): a system-context escape clause on the `billing_outbox` policy for the claim read + `SET LOCAL app.tenant_id = <row.tenant_id>` before each row's `cost_ledger` materialize. **Drift D3 / Risk #3.**
+- Leg-1 (57.82) judge→ledger wiring + C-11 (57.79) pricing are unchanged: the poller calls the **existing** `CostLedgerService.record_llm_call(...)` (pricing logic stays single-source); the outbox payload just carries that call's neutral args (provider/model/tokens/sub_type_suffix/session_id).
+
+---
+
+## 1. Sprint Goal
+
+Make chat billing **durable + idempotent** by introducing a transactional `billing_outbox`: the chat request enqueues cost events atomically with its own DB transaction, and a new idempotent background poller drains them into `cost_ledger` — eliminating the swallowed-exception 漏扣 vector and preventing future 雙扣 — while keeping pricing/quota single-source and not regressing live real-LLM billing (shadow cut-line: direct write stays until the worker is proven, then flip to enqueue-only).
+
+## 2. User Stories
+
+- **US-1**: As finance, I want every chargeable LLM/tool call recorded as a durable `billing_outbox` event committed atomically with the chat request, so a ledger-write flake can no longer silently drop a charge (漏扣). (table + atomic enqueue)
+- **US-2**: As finance, I want a stable idempotency key per billing event so a retry/replay/redelivery never charges twice (雙扣). (idempotency)
+- **US-3**: As an operator, I want a background poller that drains pending outbox rows into `cost_ledger` idempotently with bounded retry/backoff, so transient DB/pricing failures self-heal instead of losing revenue. (drain worker)
+- **US-4**: As a security owner, I want the poller to honour multi-tenant isolation (per-tenant `cost_ledger` writes; no cross-tenant leak), so the outbox does not become an isolation hole. (RLS-correct worker)
+- **US-5**: As a maintainer, I want the chat router to enqueue instead of best-effort direct-write (with a safe shadow cut-line), plus unit/integration tests pinning atomicity + idempotency + isolation + drain, so the contract is verifiable and the live path doesn't regress. (router flip + tests)
+
+## 3. Technical Specifications
+
+### 3.0 Architecture
+
+Transactional Outbox, single new domain in `platform_layer/billing/`. Producer side: the chat router observer enqueues a `BillingOutboxEvent` row using the **request's** `AsyncSession` (same `begin()` scope as session/audit → atomic commit). Consumer side: a NEW lifespan-managed async poller claims `pending`/retry-due rows (`FOR UPDATE SKIP LOCKED`), materializes `cost_ledger` via the **existing** `CostLedgerService.record_llm_call` (pricing single-source), marks `done`, all in one txn per claim batch; failures bump `retry_count` + `next_retry_at` (exponential backoff) and record `last_error`. LLM neutrality unaffected (payload carries neutral args; no SDK import). Multi-tenant: outbox table is `tenant_id`-scoped + RLS; the poller uses a system-context read for the claim and sets per-row tenant context for the `cost_ledger` write.
+
+**Shadow cut-line (live-path safety)**: through Day 2 the router enqueues **in addition to** the existing direct `cost_ledger` write (dual-write shadow → billing never regresses even if the poller isn't running). Day 3 flips the router to **enqueue-only** once the poller drains correctly; the direct-write code is removed (no `_v2`/dead-code per AP-11).
+
+### 3.1 `billing_outbox` table + migration `0025` (US-1/US-2) — NEW
+
+- NEW `infrastructure/db/migrations/versions/0025_billing_outbox.py` (`down_revision` = `0024_memory_ops` revision id, confirmed Day-1).
+- Columns: `id UUID PK`, `tenant_id UUID NOT NULL`, `event_type VARCHAR(32)` (`llm_call`/`tool_call`), `payload JSONB NOT NULL` (neutral `record_llm_call`/`record_tool_call` args: provider/model/input_tokens/output_tokens/cached_input_tokens/sub_type_suffix/tool_name/session_id), `idempotency_key VARCHAR(256) NOT NULL`, `status VARCHAR(16) NOT NULL DEFAULT 'pending'` (pending/processing/done/failed), `retry_count INT NOT NULL DEFAULT 0`, `next_retry_at TIMESTAMPTZ`, `last_error TEXT`, `session_id UUID`, `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `processed_at TIMESTAMPTZ`.
+- Constraints/indexes: `UNIQUE (tenant_id, idempotency_key)` (idempotency — US-2); `idx_billing_outbox_due` on `(next_retry_at)` `WHERE status IN ('pending','failed')`; `idx_billing_outbox_tenant` on `(tenant_id)`; `CHECK` on status/event_type enums.
+- **RLS** (multi-tenant 鐵律): `ENABLE ROW LEVEL SECURITY` + `tenant_isolation_billing_outbox` policy mirroring `0009_rls_policies` style, **plus** a system-context escape clause for the poller claim (Day-3, confirmed against `0009`). `run_all.py` `check_rls_policies` must stay green.
+- ORM model `infrastructure/db/models/billing_outbox.py` (TenantScopedMixin) + register in `models/__init__.py` (after `cost_ledger` import) so Alembic/`check_rls_policies` see it.
+
+### 3.2 `BillingOutboxService` enqueue (US-1/US-2) — `platform_layer/billing/billing_outbox.py` NEW
+
+- `async def enqueue(self, db, *, tenant_id, event_type, payload, idempotency_key, session_id) -> None`: `db.add(BillingOutboxEvent(...))` + `flush()` using the **passed-in request session** (caller's txn). On `UNIQUE(tenant_id, idempotency_key)` conflict → swallow as no-op (idempotent enqueue; a redelivered event is not re-queued).
+- Idempotency key builder: stable per logical event, e.g. `f"{session_id}:{event_type}:{sub_type_suffix or 'loop'}"` for LLM (loop vs `_verification` distinct), `f"{session_id}:tool:{tool_name}:{seq}"` for tools (seq from a per-request monotonic counter so repeated same-tool calls in one loop are distinct but replays are stable). Decide final shape Day-2 against the real router event stream.
+- Module-level singleton + `set_/get_/maybe_get_billing_outbox` accessors mirroring `cost_ledger.py:272-295` (testability + reset hook per testing.md §Module-level Singleton Reset).
+
+### 3.3 `BillingOutboxDrainer` idempotent drain (US-3/US-4) — same module
+
+- `async def drain_once(self, system_db_factory) -> DrainStats`: claim a batch of due rows (`status='pending' OR (status='failed' AND next_retry_at<=now)`) via `FOR UPDATE SKIP LOCKED LIMIT N`; per row: `SET LOCAL app.tenant_id = row.tenant_id` → call existing `CostLedgerService.record_llm_call/record_tool_call` from `payload` → mark `status='done', processed_at=now`; on exception bump `retry_count`, set `next_retry_at = now + backoff(retry_count)`, `status='failed'`, `last_error`; after `MAX_RETRY` leave `failed` (dead-letter, surfaced by metric/log — NOT silently dropped). Idempotency: claim+materialize+mark in one txn so a crash mid-row re-claims it; the `done` flag + `cost_ledger` write are committed together (no double-charge on re-claim).
+
+### 3.4 Lifespan poller wiring (US-3) — `api/main.py`
+
+- NEW `_wire_billing_outbox_drainer()` in `_lifespan` (mirror `_wire_error_budget` 57.81): construct `BillingOutboxDrainer` + start an `asyncio.create_task` polling loop (`while not stop: await drain_once(); await asyncio.sleep(BILLING_OUTBOX_POLL_INTERVAL_S)`), store the task + a stop event on app state; cancel + await on shutdown. Fail-open: a poller crash logs + restarts the loop (never crashes app). Env: `BILLING_OUTBOX_POLL_INTERVAL_S` (default 5), `BILLING_OUTBOX_BATCH` (default 50), `BILLING_OUTBOX_MAX_RETRY` (default 8). A test/CI flag `BILLING_OUTBOX_DRAINER_ENABLED` (default true; conftest sets false) keeps the background task out of unit-test event loops (audit-observer precedent `router.py:498`).
+
+### 3.5 Router flip (US-5) — `api/v1/chat/router.py`
+
+- Day-2 (shadow): after each existing `cost_ledger.record_*` call, ALSO `billing_outbox.enqueue(...)` with the same args + idempotency key (dual-write; billing never regresses).
+- Day-3 (flip): remove the direct `cost_ledger.record_*` calls from the 3 sites (loop / `_verification` / tool); the observer now ONLY enqueues; the poller materializes. Keep the best-effort isolation (enqueue failure must not break SSE — but now enqueue is in the guaranteed request txn, so a failure rolls the whole request back, which is the correct atomic behaviour — decide swallow-vs-propagate Day-3 with a test).
+
+### 3.6 Tests (US-5) + 17.md
+
+- Unit: `test_billing_outbox_service.py` — enqueue adds row; duplicate idempotency_key is no-op; drain_once materializes cost_ledger from payload; drain idempotent (run twice → one cost row); retry/backoff on materialize failure; dead-letter after MAX_RETRY.
+- Integration: `test_chat_billing_outbox.py` — chat request enqueues outbox rows atomically (commit) ; drain produces the same cost_ledger rows the old direct path produced (parity); multi-tenant: tenant A's poller-materialized cost rows are tenant-A scoped, no tenant-B leak (Risk Class C singleton reset fixture).
+- 17.md `17-cross-category-interfaces.md`: register the BillingOutbox enqueue/drain contract under the billing/governance cross-cutting section (single-source).
+
+### 3.7 Lint / validation
+
+`black + isort + flake8 + mypy src/` 0 + `run_all.py` 10/10 (esp. `check_rls_policies` for the new table + `check_llm_sdk_leak`). Full format chain pre-commit.
+
+## 4. File Change List
+
+**Code — NEW (4)**:
+1. `backend/src/infrastructure/db/models/billing_outbox.py` — BillingOutboxEvent ORM (TenantScopedMixin)
+2. `backend/src/infrastructure/db/migrations/versions/0025_billing_outbox.py` — table + indexes + RLS policy
+3. `backend/src/platform_layer/billing/billing_outbox.py` — BillingOutboxService (enqueue) + BillingOutboxDrainer (drain) + singleton accessors
+4. (poller wiring lives in `api/main.py` — edit, not new)
+
+**Code — EDIT (3)**:
+5. `backend/src/infrastructure/db/models/__init__.py` — register BillingOutboxEvent
+6. `backend/src/api/main.py` — `_wire_billing_outbox_drainer()` lifespan hook + shutdown cancel
+7. `backend/src/api/v1/chat/router.py` — Day-2 shadow enqueue → Day-3 flip to enqueue-only
+
+**Config (1)**:
+8. `backend/src/core/config/__init__.py` — `billing_outbox_poll_interval_s` / `_batch` / `_max_retry` / `_drainer_enabled` settings
+
+**Tests (2 NEW)**:
+9. `backend/tests/unit/platform_layer/billing/test_billing_outbox_service.py`
+10. `backend/tests/integration/billing/test_chat_billing_outbox.py` (+ conftest singleton reset)
+
+**Docs (2)**:
+11. `docs/03-implementation/agent-harness-planning/17-cross-category-interfaces.md` — BillingOutbox contract
+12. `claudedocs/4-changes/feature-changes/CHANGE-051-billing-outbox.md`
+
+## 5. Acceptance Criteria
+
+1. `billing_outbox` table exists (migration `0025` applies on the `0024` head), `tenant_id` + RLS policy present, `UNIQUE(tenant_id, idempotency_key)` enforced; `check_rls_policies` green.
+2. Chat request enqueues a durable outbox row per chargeable event atomically with its own transaction (integration test proves: request commit ⟺ outbox row present; no best-effort swallow on the producer side post-flip).
+3. The drainer materializes the SAME `cost_ledger` rows the old direct path produced (parity test), idempotently (run drain twice → exactly one cost row per event), with retry/backoff + dead-letter after MAX_RETRY.
+4. Multi-tenant isolation holds: poller-materialized `cost_ledger` rows are scoped to the originating tenant; no cross-tenant leak (isolation test).
+5. Router flipped to enqueue-only (direct `cost_ledger.record_*` removed from the 3 sites; no dead code/`_v2`); live real-LLM chat still bills (verified — see §8 Risk #1 measurement).
+6. `mypy src/` 0; full pytest green; `run_all.py` 10/10 (`check_llm_sdk_leak` + `check_rls_policies`).
+
+## 6. Deliverables
+
+- [ ] US-1: `billing_outbox` table + migration `0025` + RLS + ORM + register
+- [ ] US-2: idempotency key (UNIQUE + builder) + idempotent enqueue
+- [ ] US-3: `BillingOutboxDrainer` drain_once + lifespan poller + retry/backoff/dead-letter
+- [ ] US-4: multi-tenant-correct drain (system claim + per-row tenant context)
+- [ ] US-5: router shadow → flip; unit + integration tests (atomicity/idempotency/parity/isolation)
+- [ ] Closeout: CHANGE-051 + 17.md + progress + retrospective + checklist + MEMORY + CLAUDE lean + next-phase-candidates (defer IaC/DR/Analytics)
+
+## 7. Workload Calibration
+
+- **Agent-delegated: no** (parent-direct — atomicity boundary, RLS-correct worker, and the live-billing-path flip are judgment-sensitive; consistent with billing sprints 57.79-57.83 all parent-direct). `agent_factor` 1.0 → 3-segment form.
+- Bottom-up est ~10.5 hr (schema+migration+RLS ~1.5 / ORM+register ~0.5 / service enqueue+drain+idempotency ~2.5 / router shadow+flip ~1.5 / poller+lifespan+shutdown+system-tenant ~2 / tests ~2.5) → class-calibrated commit ~8.4 hr (`medium-backend` 0.80).
+- **Size caveat (honest)**: this is ≈2× a normal sprint and touches a real-LLM-live billing path. The Day structure carries the safety: **Day-2-end is a safe cut-line** (shadow dual-write — billing works via either path). If the Day-3 live-path flip + RLS-worker proves riskier than estimated, ship Day-1-2 (durable enqueue + shadow + drainer) and **carryover the enqueue-only flip** (the AD splits cleanly; not a failure). Noted in §8 Risk #2.
+
+## 8. Dependencies & Risks
+
+| # | Risk | Mitigation |
+|---|------|-----------|
+| 1 | Flipping the live real-LLM billing path (enqueue-only) could silently regress billing | Shadow dual-write through Day 2 (billing never regresses); Day-3 flip gated on a drain-parity integration test; a real-Azure smoke (1-2 chats, mode=real_llm) confirms a `cost_ledger` row still appears via the drained path before closeout (57.79/57.80 local-backend pattern; user-authorized). Env rollback: re-enable direct write is a 1-commit revert. |
+| 2 | Full Outbox is large (~8.4 hr) for one sprint | Day-2-end cut-line (shadow) = safe partial ship; enqueue-only flip can carryover as `AD-Billing-Outbox-Flip` if Day-3 over-runs. Not a failure — durable enqueue + drainer alone close the 漏扣 vector. |
+| 3 | RLS: poller reads cross-tenant but must write per-tenant `cost_ledger` (Drift D3) | Day-3: read `0009_rls_policies` first; add a system-context escape clause to the `billing_outbox` policy for the claim read + `SET LOCAL app.tenant_id = row.tenant_id` per row before the `cost_ledger` materialize. Isolation test (US-4) is the gate. `check_rls_policies` must stay green. |
+| 4 | Background `asyncio` task in lifespan leaking into unit-test event loops (Risk Class C/E) | `BILLING_OUTBOX_DRAINER_ENABLED` flag (conftest sets false; audit-observer precedent `router.py:498`); singleton reset autouse fixture; clean backend restart for the real-Azure smoke (Risk Class E — stale `--reload` masks lifespan wiring, 57.81/57.79 lesson). |
+| 5 | Idempotency key collision or over-uniqueness (replays vs distinct same-tool calls in one loop) | Key builder decided Day-2 against the real router event stream; tool calls use a per-request monotonic seq; unit test covers duplicate-key no-op + distinct-event separation. |
+| 6 | Drift D1: 09.md `outbox` is notification-shaped, not billing | Deliberately build dedicated `billing_outbox` (single-responsibility); do NOT reuse/extend the unbuilt notification design; documented in §0 + 17.md. |
+| 7 | LLM neutrality | Payload carries neutral `record_llm_call` args; drainer calls existing `CostLedgerService` (pricing single-source); no SDK import. `check_llm_sdk_leak` green. |
+
+## 9. Out of Scope (this sprint; carryover → next-phase-candidates.md)
+
+- **C-15 IaC deploy pipeline** — external-blocked (Azure provision + GitHub Secrets). Deferred.
+- **C-15 DR automation / multi-region / WAL** — external-blocked (Azure infra decisions). Deferred.
+- **C-15 Analytics / data warehouse / CDC / dbt** — fully external infra. Deferred.
+- **Stripe (external billing) consumer** — the outbox backbone is built for it, but this sprint's drainer materializes `cost_ledger` only; the Stripe drain target is a future worker-only change (the whole point of the outbox decoupling).
+- **Notification outbox** (the 09.md teams/email/webhook design) — separate concern, not built here.
+- **Per-verifier cost attribution / multi-judge registry** — B-8 carryovers, unrelated.


### PR DESCRIPTION
## Summary

Closes the **C-15 billing-write-atomicity leg** (the lone in-repo, billing-key-chain ② leg; IaC / DR / Analytics sub-items are external-blocked → deferred). Makes chat billing **durable + idempotent** via a transactional Outbox.

**Problem**: the chat observer wrote `cost_ledger` best-effort in a bare `try/except` that swallowed failures → silent **漏扣 (missing-charge)** on the now-live real-LLM path; no idempotency key → future **雙扣 (double-charge)**. (No live double-charge bug existed; the present risk was 漏扣.)

**Fix** (transactional Outbox, full pattern):
- **NEW `billing_outbox` table** (migration `0025`, `TenantScopedMixin`): `UNIQUE(tenant_id, idempotency_key)` + status/event_type CHECK + due/tenant indexes + RLS (two-policy mirror of `0024` **plus** a system-sentinel USING escape so the cross-tenant drainer can claim). Dedicated table — NOT the unbuilt notification `outbox` in `09.md` (different shape).
- **`BillingOutboxService.enqueue`**: `pg_insert(...).on_conflict_do_nothing()` in the **request** transaction → the cost event commits atomically with session/audit (no swallow → no 漏扣); redelivery is a no-op.
- **`BillingOutboxDrainer.drain_once`**: per-row independent txn — claim one due row (`FOR UPDATE SKIP LOCKED` under the sentinel) → `set_config('app.tenant_id', row.tenant_id)` → materialize via the **existing** `CostLedgerService` (pricing single-source, C-11 unchanged) → mark `done` in the same commit (**exactly-once → no 雙扣**); on failure rollback → fresh txn retry/backoff/`last_error`; dead-letter after MAX_RETRY.
- **Lifespan poller** (`api/main.py`): env-gated (`BILLING_OUTBOX_DRAINER_ENABLED`), fail-open, clean shutdown cancel.
- **Router flip**: the 3 cost-write observers (loop / `_verification` / tool) now `billing_outbox.enqueue(...)`; removed the per-request `CostLedgerService` + `pricing_loader` dep (drainer prices). Logged best-effort kept (SSE safety); atomicity comes from the shared request txn. LLM neutrality preserved.

→ billing key-chain ② (C-11 #245 + B-7 #247 + B-8 #248/#249 + C-15-billing-leg) is now closed.

## Verification
- `mypy src/` **0 / 335** · `run_all.py` **10/10** (`check_rls_policies` + `check_llm_sdk_leak` green) · full `pytest` **2161 passed** / 4 skipped · black/isort/flake8 0.
- **real-Azure smoke ✅** (gpt-5.2): a `real_llm` chat enqueued 1 `llm_call` outbox row → the drainer marked it `done` + materialized 2 `cost_ledger` rows (input qty=1997 + output qty=41) with **unit_cost > 0** (C-11 date-suffix normalize via the drainer). Chain chat→enqueue→drain→cost_ledger verified end-to-end on the live path.

## Notable: in-sprint regression caught + fixed (pre-merge)
`_wire_billing_outbox()` leaked the module singleton (the lifespan sets it; shutdown doesn't unset — correct for prod) → `test_main_lifespan` leaked it → a downstream chat-path test enqueued on the global engine without dispose → an innocent later `db_session` test hit `Event loop is closed`. Bisected to a 2s repro; verified pre-sprint `main` was clean (2150 passed) → self-inflicted. Fixed with an autouse `_reset_billing_outbox_singleton` conftest fixture (Risk Class C / testing.md §Module-level Singleton Reset) + a dedicated NullPool engine for the drain test.

## Deferred (external-blocked → next-phase-candidates.md)
C-15 IaC pipeline (Azure provision + GitHub Secrets) / DR-multiregion-WAL / Analytics-CDC-dbt; Stripe external-billing consumer (the outbox backbone is built for it — future worker-only change).

## Commits
Day-0 plan/verify · Day-1 schema (`0025`) · Day-2 service + tests · Day-3 router flip + poller + regression fix · Day-4 real-Azure smoke + closeout (CHANGE-051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)