### PR TITLE
fix(chat-v2): honest testing surface — wire New session, default real_llm, real labels, render agent answer

### DIFF
--- a/claudedocs/4-changes/feature-changes/CHANGE-054-chat-v2-honest-testing-surface.md
+++ b/claudedocs/4-changes/feature-changes/CHANGE-054-chat-v2-honest-testing-surface.md
@@ -1,0 +1,60 @@
+# CHANGE-054: chat-v2 honest testing surface (frontend UX correctness)
+
+**Change Date**: 2026-06-06
+**Change Type**: Feature Improvement (frontend UX correctness)
+**Status**: ✅ Completed (browser-verified)
+**Scope**: Frontend / chat_v2 (no backend change)
+**Branch**: `feature/chat-v2-honest-testing-surface`
+
+## Change Summary
+
+After the unmocked e2e + real-LLM smoke (PR #253) the user opened `/chat-v2` and reported it was not a usable testing surface:
+1. Left session history is 6 rows of fixture demo data; the "New session" button did nothing.
+2. Sending a message showed no normal LLM output; could not tell what was demo vs real.
+
+Investigation confirmed both — plus a deeper root cause behind #2: the agent's **final text answer was never rendered**. This change makes `/chat-v2` an honest, non-misleading surface that defaults to the live agent and shows its answer.
+
+## Change Reason
+
+The page conflated "the agent loop works (when driven in real_llm)" with "the page is ready". Several elements were fixture/dead/misleading independent of the loop:
+- `New session` button had no `onClick` (visual-only).
+- Default mode was `echo_demo` (echoes input — never a real answer); a casual tester saw an echo, not the agent.
+- Header model badge was hardcoded `claude-haiku-4-5`; per-turn label hardcoded `incident-responder` — both shown even on a real gpt-5.2 run.
+- The Block union (thinking / tool / verification / subagent_fork) had **no assistant-answer block**, so a plain Q&A answer (no tool call) rendered an empty turn — the literal "can't see the LLM output".
+
+## Detailed Changes (5 fixes)
+
+1. **New session wired** — `SessionList` "New session" button now calls `store.reset()`; `reset()` also zeroes the module-global `_turnCounter` so a fresh session restarts at turn 1.
+2. **Default mode → `real_llm`** + clarity — `chatStore` default mode flipped `echo_demo`→`real_llm`; `InputBar` mode buttons gained tooltips (echo = offline mock / real = live Azure) and an inline note when `echo_demo` is active ("echoes your input — switch to real_llm for a live answer").
+3. **Honest labels** — added `currentModel` to the store (captured from `llm_request.model`); `ChatHeader` model badge now shows the real model (e.g. `gpt-5.2`), falling back to the mode before the first call; header agent default `incident-responder`→`agent`; `AgentTurn` per-turn role `incident-responder`→`agent`.
+4. **Session list DEMO badge** — added a `DEMO` badge on the SESSIONS section (the fixture list is unmistakably demo; existing AP-2 banner preserved). Real persisted list remains deferred (`AD-ChatV2-SessionList-Backend`, item 5 — NOT in this change).
+5. **Render the agent's final answer** (root of #2) — new `AnswerBlock` type + component; `chatStore.llm_response` pushes an answer block from `ev.data.content` when non-empty; `Block` dispatcher + `InspectorTurn` block-sequence handle the new type.
+
+## Modified Files
+
+- `frontend/src/features/chat_v2/store/chatStore.ts` — default mode, `currentModel`, `reset()` counter, `llm_response` answer block
+- `frontend/src/features/chat_v2/types.ts` — `AnswerBlock` type + Block union
+- `frontend/src/features/chat_v2/components/SessionList.tsx` — wire New session + DEMO badge
+- `frontend/src/features/chat_v2/components/ChatHeader.tsx` — real model badge + honest agent label
+- `frontend/src/features/chat_v2/components/InputBar.tsx` — mode tooltips + echo note (+ i18n)
+- `frontend/src/features/chat_v2/components/TurnList.tsx` — mode-aware empty-state copy
+- `frontend/src/features/chat_v2/components/turns/AgentTurn.tsx` — role label `agent`
+- `frontend/src/features/chat_v2/components/blocks/AnswerBlock.tsx` — NEW
+- `frontend/src/features/chat_v2/components/blocks/Block.tsx` — answer case
+- `frontend/src/features/chat_v2/components/inspector/InspectorTurn.tsx` — answer tone + describe
+- `frontend/src/i18n/locales/{en,zh-TW}/common.json` — `chat.session.demoTag` + `chat.composer.*`
+- Tests: `ChatHeader.test.tsx`, `TurnList.test.tsx`, `SessionList.test.tsx` (assertions updated for the deliberate label/copy changes + New-session reset test), `chat-v2-real-backend.spec.ts` (stale comment)
+
+## Verification
+
+- Gates: `tsc -b && vite build` ✓ · `vitest` 762 ✓ · `check:mockup-fidelity` ✓ (styles-mockup.css byte-identical; hardcoded-color baseline 53 unchanged — all additions use `var(--*)`) · `eslint src` no errors.
+- **Browser-verified (real Azure gpt-5.2, `/chat-v2`)**:
+  - Default mode `real_llm` active; echo tooltips + echo note appear on `echo_demo`.
+  - Header badge shows `gpt-5.2` after a run (mode label before); agent label `agent`; SESSIONS shows `DEMO` badge.
+  - "What is 2 plus 2?" → **answer block renders `4`** (was previously invisible); model badge `gpt-5.2`; verification 0.55.
+  - "New session" clears the conversation (2 turns → 0, empty state, `○ idle`).
+- Screenshot: `frontend/.playwright-mcp/chat-v2-honest-surface-after-fixes-20260606.png`.
+
+## Impact
+
+Frontend-only. No backend / API / SSE wire change. The real persisted session list (load history on click) remains the one deferred item (`AD-ChatV2-SessionList-Backend`), tracked separately.

--- a/frontend/src/features/chat_v2/components/ChatHeader.tsx
+++ b/frontend/src/features/chat_v2/components/ChatHeader.tsx
@@ -33,6 +33,7 @@
  * Last Modified: 2026-05-23
  *
  * Modification History:
+ *   - 2026-06-06: chat-v2 honest surface — model badge shows real currentModel (was hardcoded "claude-haiku-4-5"); agent default "incident-responder"→"agent" (CHANGE-054)
  *   - 2026-05-23: Sprint 57.30 Day 2 US-C2 — verbatim re-point to mockup page-chat.jsx L93-121 ChatHeader markup (.panel-toggle, inline-style literals byte-identical)
  *   - 2026-05-17: Initial creation (Sprint 57.21 Day 3 §3.2)
  *
@@ -61,13 +62,21 @@ export function ChatHeader({ listOpen, inspOpen, onToggleList, onToggleInsp }: P
   const activeSessionId = useChatStore((s) => s.activeSessionId);
   const status = useChatStore((s) => s.status);
   const totalTurns = useChatStore((s) => s.totalTurns);
+  const currentModel = useChatStore((s) => s.currentModel);
+  const mode = useChatStore((s) => s.mode);
   const { t } = useTranslation("common");
 
   const active = activeSessionId
     ? FIXTURE_SESSIONS.find((s) => s.id === activeSessionId)
     : undefined;
   const titleText = active?.title ?? "New session";
-  const agentText = active?.agent ?? "incident-responder";
+  // Honest-surface: with no fixture session selected (a real ad-hoc chat), show a
+  // neutral "agent" instead of the fixture persona "incident-responder".
+  const agentText = active?.agent ?? "agent";
+  // Honest-surface: badge reflects the ACTUAL model from the live run
+  // (currentModel from llm_request), falling back to the active mode before the
+  // first call. Replaces the hardcoded "claude-haiku-4-5" that misreported the model.
+  const modelText = currentModel ?? mode;
   // Prefer live totalTurns once a real session is running; otherwise show fixture turns.
   const turnCount = totalTurns > 0 ? totalTurns : (active?.turns ?? 0);
   const isStreaming = status === "running";
@@ -130,7 +139,7 @@ export function ChatHeader({ listOpen, inspOpen, onToggleList, onToggleInsp }: P
         </div>
         <div className="row" style={{ gap: 6, marginTop: 2, flexWrap: "wrap" }}>
           <span className="badge">{agentText}</span>
-          <span className="badge thinking">claude-haiku-4-5</span>
+          <span className="badge thinking">{modelText}</span>
           <span className="provider-neutral">{t("chat.header.providerNeutral")}</span>
           <span className="subtle" style={{ fontSize: 11 }}>
             · {t("chat.session.meta.turns", { count: turnCount })}

--- a/frontend/src/features/chat_v2/components/InputBar.tsx
+++ b/frontend/src/features/chat_v2/components/InputBar.tsx
@@ -30,6 +30,7 @@
  * Last Modified: 2026-05-23
  *
  * Modification History (newest-first):
+ *   - 2026-06-06: chat-v2 honest surface — mode-button tooltips + echo_demo "echoes input" note; +useTranslation (CHANGE-054)
  *   - 2026-05-23: Sprint 57.30 Day 2 US-C2 — verbatim re-point to mockup composer shell (.composer / .composer-inner / .composer-input / .btn primary / .btn danger / .btn ghost)
  *   - 2026-05-17: Sprint 57.20 Day 3 US-D1 — token migration text-muted-foreground→text-fg-muted; bg-muted-foreground→bg-fg-muted (disabled Send) for new shell mockup consistency
  *   - 2026-05-11: Sprint 57.16 — inline styles → Tailwind utility classes; statusPill/modeButton/sendBtn → finite class lookup (AD-Inline-Style-Cleanup-Sweep-Round2)
@@ -45,6 +46,7 @@
  */
 
 import { useState, type CSSProperties, type KeyboardEvent } from "react";
+import { useTranslation } from "react-i18next";
 
 import { useLoopEventStream } from "../hooks/useLoopEventStream";
 import { useChatStore } from "../store/chatStore";
@@ -64,6 +66,7 @@ function getPill(status: string): { label: string; color: string } {
 }
 
 export default function InputBar(): JSX.Element {
+  const { t } = useTranslation("common");
   const [text, setText] = useState("");
   const status = useChatStore((s) => s.status);
   const mode = useChatStore((s) => s.mode);
@@ -135,12 +138,25 @@ export default function InputBar(): JSX.Element {
               style={modeButtonStyle(mode === m)}
               onClick={() => setMode(m)}
               disabled={isRunning}
+              title={
+                m === "echo_demo"
+                  ? t("chat.composer.echoModeTitle")
+                  : t("chat.composer.realModeTitle")
+              }
             >
               {m}
             </button>
           ))}
         </div>
       </div>
+
+      {/* Honest-surface: echo_demo mirrors the input (offline mock) — make that
+          explicit so a tester doesn't mistake the echo for a real LLM answer. */}
+      {mode === "echo_demo" && (
+        <div style={{ fontSize: 11, color: "var(--warning)", marginBottom: 6 }}>
+          {t("chat.composer.echoModeNote")}
+        </div>
+      )}
 
       <div className="composer-inner">
         <textarea

--- a/frontend/src/features/chat_v2/components/SessionList.tsx
+++ b/frontend/src/features/chat_v2/components/SessionList.tsx
@@ -36,6 +36,7 @@
  * Last Modified: 2026-05-23
  *
  * Modification History:
+ *   - 2026-06-06: chat-v2 honest surface — wire "New session" → store.reset() (was a no-op button) + DEMO badge on section header (fixture list honesty) (CHANGE-054)
  *   - 2026-05-23: Sprint 57.30 Day 2 US-C2 — verbatim re-point to mockup page-chat.jsx L123-156 SessionList markup (.chat-list, .session-item, .session-title, .session-meta, .live-dot, .badge)
  *   - 2026-05-17: Initial creation (Sprint 57.21 Day 3 §3.1 + §3.3)
  *
@@ -129,6 +130,11 @@ function SessionItem({ session }: { session: Session }): JSX.Element {
 
 export function SessionList(): JSX.Element {
   const { t } = useTranslation("common");
+  // Honest-surface: "New session" was a visual-only button (no onClick). Wire it
+  // to reset the store so it actually starts a fresh conversation (clears turns /
+  // session id / inspector slices). A real persisted session-list is deferred to
+  // the backend endpoint (AD-ChatV2-SessionList-Backend).
+  const reset = useChatStore((s) => s.reset);
 
   return (
     <div className="chat-list" data-testid="session-list">
@@ -159,7 +165,12 @@ export function SessionList(): JSX.Element {
           gap: 6,
         }}
       >
-        <button type="button" className="btn primary" data-size="sm">
+        <button
+          type="button"
+          className="btn primary"
+          data-size="sm"
+          onClick={() => reset()}
+        >
           <Plus size={12} aria-hidden="true" />
           {t("chat.session.newSession")}
         </button>
@@ -182,16 +193,24 @@ export function SessionList(): JSX.Element {
           alignItems: "center",
         }}
       >
-        <span
-          className="mono"
-          style={{
-            fontSize: 10.5,
-            color: "var(--fg-subtle)",
-            textTransform: "uppercase",
-            letterSpacing: "0.06em",
-          }}
-        >
-          {t("chat.session.title")}
+        <span className="row" style={{ gap: 6, alignItems: "center" }}>
+          <span
+            className="mono"
+            style={{
+              fontSize: 10.5,
+              color: "var(--fg-subtle)",
+              textTransform: "uppercase",
+              letterSpacing: "0.06em",
+            }}
+          >
+            {t("chat.session.title")}
+          </span>
+          {/* Honest-surface: the rows below are fixture demo data (see banner
+              above) — a DEMO badge makes that unmistakable until the backend
+              session-list endpoint ships (AD-ChatV2-SessionList-Backend). */}
+          <span className="badge warning" style={{ fontSize: 9 }}>
+            {t("chat.session.demoTag")}
+          </span>
         </span>
         <span className="mono" style={{ fontSize: 10.5, color: "var(--fg-subtle)" }}>
           {FIXTURE_SESSIONS.length}

--- a/frontend/src/features/chat_v2/components/TurnList.tsx
+++ b/frontend/src/features/chat_v2/components/TurnList.tsx
@@ -20,6 +20,7 @@
  * Created: 2026-05-17 (Sprint 57.21 Day 2 §2.1)
  *
  * Modification History:
+ *   - 2026-06-06: chat-v2 honest surface — empty-state copy explains real_llm (live) vs echo_demo (mock) instead of only teaching echo_demo (CHANGE-054)
  *   - 2026-05-23: Sprint 57.30 Day 3 §D1 — re-point scroll wrapper to mockup L83 verbatim inline-style + empty-state to mockup .subtle/.mono
  *   - 2026-05-17: Initial creation (Sprint 57.21 Day 2 §2.1)
  *
@@ -59,9 +60,11 @@ export function TurnList(): JSX.Element {
         className="subtle"
       >
         <div style={{ padding: "32px 24px", textAlign: "center", fontSize: 13 }}>
-          Type a message below to start. Try{" "}
-          <code className="mono" style={{ fontSize: 11 }}>echo hello</code>{" "}
-          in echo_demo mode.
+          Type a message below to start. The mode toggle switches between{" "}
+          <code className="mono" style={{ fontSize: 11 }}>real_llm</code>{" "}
+          (live agent) and{" "}
+          <code className="mono" style={{ fontSize: 11 }}>echo_demo</code>{" "}
+          (offline mock that just echoes your input).
         </div>
       </div>
     );

--- a/frontend/src/features/chat_v2/components/blocks/AnswerBlock.tsx
+++ b/frontend/src/features/chat_v2/components/blocks/AnswerBlock.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable no-restricted-syntax -- production-only block: the mockup's block set
+   (thinking / tool / verification / subagent_fork) has no assistant-answer block, so the
+   final LLM text answer must still render for the chat to be usable. Inline styles use
+   only layout/typography (no color literal) and inherit the mockup .turn-body color. */
+/**
+ * File: frontend/src/features/chat_v2/components/blocks/AnswerBlock.tsx
+ * Purpose: Renders the agent's final text answer (llm_response.content) inside an AgentTurn.
+ * Category: Frontend / chat_v2 / components / blocks
+ * Scope: 2026-06-06 honest testing surface (CHANGE-054)
+ *
+ * Description:
+ *   The Sprint 57.21 Block union mirrored the mockup (thinking / tool / verification /
+ *   subagent_fork) — which had NO assistant-answer block. As a result a plain Q&A turn
+ *   (the model answers directly, no tool call) rendered an empty turn body, so the agent's
+ *   actual answer was invisible (the root of "can't see the LLM output"). This block
+ *   renders the final content as readable, whitespace-preserving prose. Inherits the
+ *   mockup .turn-body text color (no color literal). Rich markdown render deferred
+ *   (AD-ChatV2-Answer-Markdown-Phase2).
+ *
+ * Created: 2026-06-06 (CHANGE-054)
+ *
+ * Related:
+ *   - ../../types.ts (AnswerBlock)
+ *   - ./Block.tsx (dispatcher — exhaustive switch)
+ *   - ../../store/chatStore.ts (llm_response case emits this from ev.data.content)
+ */
+
+import type { AnswerBlock as AnswerBlockType } from "../../types";
+
+export function AnswerBlock({ block }: { block: AnswerBlockType }): JSX.Element {
+  return (
+    <div
+      data-testid="answer-block"
+      style={{ whiteSpace: "pre-wrap", fontSize: 13.5, lineHeight: 1.55, margin: "4px 0" }}
+    >
+      {block.text}
+    </div>
+  );
+}

--- a/frontend/src/features/chat_v2/components/blocks/Block.tsx
+++ b/frontend/src/features/chat_v2/components/blocks/Block.tsx
@@ -15,6 +15,7 @@
  * Created: 2026-05-17 (Sprint 57.21 Day 2 §2.2)
  *
  * Modification History:
+ *   - 2026-06-06: CHANGE-054 honest surface — +answer case (AnswerBlock) so the agent's final text answer renders (was dropped — no answer block existed)
  *   - 2026-05-23: Sprint 57.30 Day 3 §D2 — no markup change (pure dispatcher); per-block re-point shipped in ThinkingBlock / ToolBlock
  *   - 2026-05-17: Initial creation (Sprint 57.21 Day 2 §2.2)
  *
@@ -25,6 +26,7 @@
  */
 
 import type { Block } from "../../types";
+import { AnswerBlock } from "./AnswerBlock";
 import { SubagentForkBlock } from "./SubagentForkBlock";
 import { ThinkingBlock } from "./ThinkingBlock";
 import { ToolBlock } from "./ToolBlock";
@@ -34,6 +36,9 @@ export function BlockRender({ block }: { block: Block }): JSX.Element | null {
   switch (block.type) {
     case "thinking":
       return <ThinkingBlock block={block} />;
+    // Honest-surface (CHANGE-054): render the agent's final text answer.
+    case "answer":
+      return <AnswerBlock block={block} />;
     case "tool":
       return <ToolBlock block={block} />;
     case "verification":

--- a/frontend/src/features/chat_v2/components/inspector/InspectorTurn.tsx
+++ b/frontend/src/features/chat_v2/components/inspector/InspectorTurn.tsx
@@ -71,6 +71,7 @@ function KV({ k, v, mono = false }: { k: string; v: ReactNode; mono?: boolean })
 
 const BLOCK_TONE: Record<Block["type"], string> = {
   thinking: "var(--thinking)",
+  answer: "var(--primary)",
   tool: "var(--tool)",
   verification: "var(--success)",
   subagent_fork: "var(--info)",
@@ -82,6 +83,12 @@ function describeBlock(block: Block): string {
       const trimmed = block.text.trim();
       if (trimmed.length === 0) return "—";
       return trimmed.length > 36 ? `${trimmed.slice(0, 36)}…` : trimmed;
+    }
+    // Honest-surface (CHANGE-054): the agent's final text answer block.
+    case "answer": {
+      const trimmed = block.text.trim();
+      if (trimmed.length === 0) return "—";
+      return trimmed.length > 48 ? `${trimmed.slice(0, 48)}…` : trimmed;
     }
     case "tool":
       return `${block.name} · ${block.status === "pending" ? "pending" : `${block.durationMs ?? 0}ms`}`;

--- a/frontend/src/features/chat_v2/components/turns/AgentTurn.tsx
+++ b/frontend/src/features/chat_v2/components/turns/AgentTurn.tsx
@@ -21,13 +21,16 @@
  *   inline-style approach as the mockup (page-chat.jsx L188-191) so the
  *   warning live-dot pulsing matches.
  *
- *   Agent name "incident-responder" is currently a fixture label per
- *   mockup; Sprint 57.22+ AD-ChatV2-SessionList-Backend will derive from
- *   active session metadata when /api/v1/sessions list ships.
+ *   Honest-surface (2026-06-06): the role label shows a neutral "agent" rather
+ *   than the misleading fixture persona "incident-responder" (which rendered on
+ *   every real run regardless of the actual model). A real per-session agent name
+ *   will derive from active session metadata when /api/v1/sessions ships
+ *   (AD-ChatV2-SessionList-Backend).
  *
  * Created: 2026-05-17 (Sprint 57.21 Day 2 §2.1)
  *
  * Modification History:
+ *   - 2026-06-06: chat-v2 honest surface — role label "incident-responder"→"agent" (drop misleading fixture persona on real runs) (CHANGE-054)
  *   - 2026-05-23: Sprint 57.30 Day 3 §D1 — verbatim re-point Tailwind → mockup .turn/.turn-head/.badge/.badge.primary/.turn-body + .row inline-style for awaiting-approval
  *   - 2026-05-17: Initial extract from mockup L178-197 + Tailwind convert
  *
@@ -53,7 +56,7 @@ export function AgentTurn({ turn }: { turn: AgentTurnType }): JSX.Element {
       <div className="turn-rail" />
       <div className="turn-marker" />
       <div className="turn-head">
-        <span className="role">incident-responder</span>
+        <span className="role">agent</span>
         <span className="badge primary">turn {turnNum}</span>
         {turn.stopReason && <span className="badge">stop: {turn.stopReason}</span>}
         {turn.durationMs !== null && (

--- a/frontend/src/features/chat_v2/store/chatStore.ts
+++ b/frontend/src/features/chat_v2/store/chatStore.ts
@@ -34,6 +34,7 @@
  * Last Modified: 2026-06-02
  *
  * Modification History:
+ *   - 2026-06-06: chat-v2 honest testing surface — default mode echo_demo→real_llm; +currentModel (from llm_request); reset() zeroes _turnCounter (CHANGE-054)
  *   - 2026-06-03: Sprint 57.75 A-5 — +spans / memoryOps derived slices + span_started/span_ended/memory_accessed cases (Inspector Trace + Memory tabs)
  *   - 2026-06-02: Sprint 57.69 A-3b slice 2 — agent_handoff now pivots session (pivotSession + handoffBanner state)
  *   - 2026-06-02: Sprint 57.68 A-3b — +agent_handoff passthrough case (rawEvents-only, Cat 11)
@@ -113,6 +114,10 @@ type ChatStoreState = {
   stopReason: string | null;
   errorMessage: string | null;
   mode: ChatMode;
+  // Honest-surface: model name from the latest llm_request (null until the first
+  // LLM call). Drives the ChatHeader model badge instead of a hardcoded fixture
+  // ("claude-haiku-4-5"), so the badge reflects the ACTUAL model that ran.
+  currentModel: string | null;
 
   // Sprint 57.69: HANDOFF transition banner (null when no active handoff notice)
   handoffBanner: HandoffBanner | null;
@@ -157,6 +162,7 @@ const _initial = (): Pick<
   | "totalTurns"
   | "stopReason"
   | "errorMessage"
+  | "currentModel"
   | "handoffBanner"
   | "turns"
   | "sessions"
@@ -173,6 +179,7 @@ const _initial = (): Pick<
   totalTurns: 0,
   stopReason: null,
   errorMessage: null,
+  currentModel: null,
   handoffBanner: null,
   turns: [],
   sessions: [],
@@ -260,7 +267,10 @@ const applyPivot = (
 
 export const useChatStore = create<ChatStoreState>((set) => ({
   ..._initial(),
-  mode: "echo_demo",
+  // Honest default: real_llm so a user who just opens the page and sends a
+  // message gets the LIVE agent, not the offline echo mock. echo_demo stays
+  // available via the InputBar toggle for deterministic / offline use.
+  mode: "real_llm",
 
   setMode: (m) => set({ mode: m }),
   setStatus: (s) => set({ status: s }),
@@ -322,6 +332,7 @@ export const useChatStore = create<ChatStoreState>((set) => ({
           return {
             ...s,
             rawEvents,
+            currentModel: ev.data.model,
             turns: updateLastAgentTurn(s.turns, (t) => ({
               ...t,
               tokensIn: ev.data.tokens_in,
@@ -330,8 +341,8 @@ export const useChatStore = create<ChatStoreState>((set) => ({
         }
 
         case "llm_response": {
-          // Append ThinkingBlock (if thinking) + ToolBlock per tool_call.
-          // Visual order matches mockup (thinking before tools in same turn).
+          // Append ThinkingBlock (if thinking) + AnswerBlock (if final content)
+          // + ToolBlock per tool_call. Visual order: thinking → answer → tools.
           return {
             ...s,
             rawEvents,
@@ -339,6 +350,12 @@ export const useChatStore = create<ChatStoreState>((set) => ({
               const newBlocks: Block[] = [...t.blocks];
               if (ev.data.thinking) {
                 newBlocks.push({ type: "thinking", text: ev.data.thinking });
+              }
+              // Honest-surface (CHANGE-054): render the agent's final text answer.
+              // Only when non-empty — a tool-calling turn carries content="" until
+              // the model produces its final reply, so this skips intermediate turns.
+              if (ev.data.content) {
+                newBlocks.push({ type: "answer", text: ev.data.content });
               }
               for (const tc of ev.data.tool_calls) {
                 newBlocks.push({
@@ -733,5 +750,10 @@ export const useChatStore = create<ChatStoreState>((set) => ({
 
   clearSubagents: () => set({ subagents: [] }),
 
-  reset: () => set({ ..._initial() }),
+  reset: () => {
+    // Zero the module-global turn counter so a fresh session's turns restart at
+    // t_1 (otherwise "New session" inherits the prior session's climbing ids).
+    _turnCounter = 0;
+    set({ ..._initial() });
+  },
 }));

--- a/frontend/src/features/chat_v2/types.ts
+++ b/frontend/src/features/chat_v2/types.ts
@@ -72,6 +72,15 @@ export type ThinkingBlock = {
   text: string;
 };
 
+// Honest-surface (CHANGE-054): the agent's final text answer (llm_response.content).
+// The mockup's block set (thinking / tool / verification / subagent_fork) had NO
+// assistant-answer block, so a plain Q&A turn (content, no tool call) rendered
+// nothing — the user saw an empty turn. This block makes the answer visible.
+export type AnswerBlock = {
+  type: "answer";
+  text: string;
+};
+
 export type ToolBlock = {
   type: "tool";
   toolCallId: string;
@@ -96,7 +105,12 @@ export type SubagentForkBlock = {
   agents: SubagentEntry[];
 };
 
-export type Block = ThinkingBlock | ToolBlock | VerificationBlock | SubagentForkBlock;
+export type Block =
+  | ThinkingBlock
+  | AnswerBlock
+  | ToolBlock
+  | VerificationBlock
+  | SubagentForkBlock;
 
 // === Sprint 57.21: Turn discriminated union ===============================
 // Per mockup L17-70 (TURNS data shape) + L159-313 (render dispatch).

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -426,7 +426,8 @@
       "meta": {
         "turns": "{{count}} turns"
       },
-      "demoBanner": "Demo data — backend list endpoint pending Sprint 57.22+ (AD-ChatV2-SessionList-Backend)"
+      "demoBanner": "Demo data — backend list endpoint pending Sprint 57.22+ (AD-ChatV2-SessionList-Backend)",
+      "demoTag": "DEMO"
     },
     "header": {
       "toggleList": "Toggle session list",
@@ -438,6 +439,11 @@
     },
     "inspector": {
       "comingSoon": "Inspector content lands Sprint 57.21 Day 4 (Turn tab) + Sprint 57.22+ (Trace / Memory / Tree tabs)."
+    },
+    "composer": {
+      "echoModeTitle": "Offline mock — echoes your input, not a real answer",
+      "realModeTitle": "Live agent — calls the real LLM provider (Azure OpenAI)",
+      "echoModeNote": "echo_demo echoes your input — switch to real_llm for a live answer"
     }
   },
   "sla": {

--- a/frontend/src/i18n/locales/zh-TW/common.json
+++ b/frontend/src/i18n/locales/zh-TW/common.json
@@ -426,7 +426,8 @@
       "meta": {
         "turns": "{{count}} 輪"
       },
-      "demoBanner": "示範資料 — 後端 list 端點待 Sprint 57.22+ 接通（AD-ChatV2-SessionList-Backend）"
+      "demoBanner": "示範資料 — 後端 list 端點待 Sprint 57.22+ 接通（AD-ChatV2-SessionList-Backend）",
+      "demoTag": "示範"
     },
     "header": {
       "toggleList": "切換工作階段列表",
@@ -438,6 +439,11 @@
     },
     "inspector": {
       "comingSoon": "Inspector 內容於 Sprint 57.21 Day 4（Turn 分頁）與 Sprint 57.22+（Trace / Memory / Tree 分頁）落地。"
+    },
+    "composer": {
+      "echoModeTitle": "離線模擬 — 只回放你的輸入，不是真實回答",
+      "realModeTitle": "真實 agent — 呼叫真正的 LLM 供應商（Azure OpenAI）",
+      "echoModeNote": "echo_demo 只回放你的輸入 — 切換到 real_llm 取得真實回答"
     }
   },
   "sla": {

--- a/frontend/tests/e2e/chat/chat-v2-real-backend.spec.ts
+++ b/frontend/tests/e2e/chat/chat-v2-real-backend.spec.ts
@@ -67,8 +67,8 @@ test.describe("chat-v2 unmocked regression net (opt-in, live backend)", () => {
       page.getByRole("heading", { level: 1, name: "Chat (V2)" }),
     ).toBeVisible();
 
-    // 3) Explicitly select echo_demo mode (also the store default) — exercises the
-    //    real mode toggle and pins the deterministic, Azure-free path.
+    // 3) Explicitly select echo_demo mode (store default is now real_llm, CHANGE-054)
+    //    — exercises the real mode toggle and pins the deterministic, Azure-free path.
     await page.getByRole("button", { name: "echo_demo", exact: true }).click();
 
     // 4) Send a message through the real composer → real POST /api/v1/chat/ → real SSE.

--- a/frontend/tests/unit/chat_v2/components/ChatHeader.test.tsx
+++ b/frontend/tests/unit/chat_v2/components/ChatHeader.test.tsx
@@ -7,6 +7,7 @@
  * Created: 2026-05-17 (Sprint 57.21 Day 3 §3.2)
  *
  * Modification History:
+ *   - 2026-06-06: CHANGE-054 honest surface — fallback assertions "incident-responder"→"agent", "claude-haiku-4-5"→"real_llm" (model badge reflects real run/mode)
  *   - 2026-05-17: Initial creation (Sprint 57.21 Day 3 §3.2)
  */
 
@@ -45,8 +46,11 @@ describe("ChatHeader (Sprint 57.21 Day 3 §3.2)", () => {
   test("renders fallback title when no active session", () => {
     setUp();
     expect(screen.getByText("New session")).toBeInTheDocument();
-    expect(screen.getByText("incident-responder")).toBeInTheDocument();
-    expect(screen.getByText("claude-haiku-4-5")).toBeInTheDocument();
+    // Honest-surface (CHANGE-054): no active fixture session → neutral "agent"
+    // label; model badge reflects the active mode ("real_llm" default, since no
+    // llm_request has set currentModel yet) instead of the hardcoded "claude-haiku-4-5".
+    expect(screen.getByText("agent")).toBeInTheDocument();
+    expect(screen.getByText("real_llm")).toBeInTheDocument();
   });
 
   test("renders fixture session title when activeSessionId is set", () => {

--- a/frontend/tests/unit/chat_v2/components/SessionList.test.tsx
+++ b/frontend/tests/unit/chat_v2/components/SessionList.test.tsx
@@ -89,4 +89,15 @@ describe("SessionList (Sprint 57.21 Day 3 §3.1)", () => {
     const counts = screen.getAllByText(String(FIXTURE_SESSIONS.length));
     expect(counts.length).toBeGreaterThanOrEqual(1);
   });
+
+  test("'New session' resets the store (clears active session) — honest-surface wiring", async () => {
+    // CHANGE-054: the button was a no-op; it now calls store.reset(). Prove the
+    // wiring by seeding an active session and asserting it clears on click.
+    const user = userEvent.setup();
+    useChatStore.setState({ activeSessionId: "sess_4tk2p" });
+    expect(useChatStore.getState().activeSessionId).toBe("sess_4tk2p");
+    render(<SessionList />);
+    await user.click(screen.getByRole("button", { name: /New session/i }));
+    expect(useChatStore.getState().activeSessionId).toBeNull();
+  });
 });

--- a/frontend/tests/unit/chat_v2/components/TurnList.test.tsx
+++ b/frontend/tests/unit/chat_v2/components/TurnList.test.tsx
@@ -72,10 +72,13 @@ describe("TurnList (Sprint 57.21 Day 2)", () => {
     useChatStore.getState().reset();
   });
 
-  test("empty turns shows echo_demo hint empty-state", () => {
+  test("empty turns shows mode-aware hint empty-state (real_llm + echo_demo)", () => {
     render(<TurnList />);
     expect(screen.getByText(/Type a message below to start/)).toBeInTheDocument();
-    expect(screen.getByText("echo hello")).toBeInTheDocument();
+    // Honest-surface (CHANGE-054): empty state now explains BOTH modes instead of
+    // only teaching echo_demo — real_llm (live) vs echo_demo (offline mock).
+    expect(screen.getByText("real_llm")).toBeInTheDocument();
+    expect(screen.getByText("echo_demo")).toBeInTheDocument();
   });
 
   test("user role dispatches → UserTurn with display name + role pill + text", () => {
@@ -101,7 +104,8 @@ describe("TurnList (Sprint 57.21 Day 2)", () => {
   test("agent role dispatches → AgentTurn with turn # badge + thinking block", () => {
     useChatStore.setState({ turns: [agentTurn()] });
     render(<TurnList />);
-    expect(screen.getByText("incident-responder")).toBeInTheDocument();
+    // Honest-surface (CHANGE-054): neutral "agent" label, not the fixture persona.
+    expect(screen.getByText("agent")).toBeInTheDocument();
     expect(screen.getByText("turn a1")).toBeInTheDocument();
     expect(screen.getByText("stop: end_turn")).toBeInTheDocument();
     expect(screen.getByText("Initial analysis")).toBeInTheDocument();
@@ -145,7 +149,8 @@ describe("TurnList (Sprint 57.21 Day 2)", () => {
     });
     render(<TurnList />);
     expect(screen.getByText("Jamie Liu")).toBeInTheDocument();
-    expect(screen.getByText("incident-responder")).toBeInTheDocument();
+    // Honest-surface (CHANGE-054): neutral "agent" label, not the fixture persona.
+    expect(screen.getByText("agent")).toBeInTheDocument();
     expect(screen.getByText("HITL approval required")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to PR #253. After that merged, opening `/chat-v2` revealed it was not a usable testing surface: a fixture session list with a **dead** "New session" button, and **no visible LLM output** / no way to tell demo from real. Investigation confirmed all of it — plus the root cause of the missing output: the agent's **final text answer was never rendered** (the Block union had no answer block, so a plain Q&A turn rendered an empty body).

Frontend-only. No backend / API / SSE change.

## The 5 fixes (all browser-verified against real Azure gpt-5.2)

1. **`New session` wired** — now calls `store.reset()` (was a no-op button); `reset()` also zeroes the turn counter. Verified: 2 turns → 0, empty state, `○ idle`.
2. **Default mode `echo_demo` → `real_llm`** + clarity — mode-button tooltips (offline mock vs live Azure) + an inline note when `echo_demo` is active ("echoes your input — switch to real_llm for a live answer"). Verified: `real_llm` active by default; note appears on `echo_demo`.
3. **Honest labels** — header model badge shows the real model (`currentModel` captured from `llm_request.model`, e.g. `gpt-5.2`) instead of hardcoded `claude-haiku-4-5`; agent label `incident-responder` → `agent` (header + per-turn). Verified: badge shows `gpt-5.2` after a run.
4. **Session list `DEMO` badge** — the fixture list is unmistakably demo (existing AP-2 banner preserved). Real persisted list stays deferred (`AD-ChatV2-SessionList-Backend`).
5. **Render the agent's final answer** (root of "can't see the LLM output") — new `AnswerBlock` type + component; `chatStore.llm_response` pushes an answer block from `ev.data.content`; `Block` dispatcher + `InspectorTurn` handle the new type. Verified: "What is 2+2?" → **answer block renders `4`** (was invisible before).

## Scope note

The user scoped fixes 1–4. Fix **5** (answer rendering) was discovered during browser verification — it is the actual root of complaint "can't see the LLM output", is pure-frontend (same class as 1–4), and without it the surface still can't show answers. Surfaced transparently rather than folded in silently.

## Verification

- Gates: `tsc -b && vite build` ✓ · `vitest` 762 passed ✓ · `check:mockup-fidelity` ✓ (styles-mockup.css byte-identical; hardcoded-color baseline 53 unchanged — all additions use `var(--*)`) · `eslint src` no errors.
- Browser smoke on `/chat-v2` (real Azure gpt-5.2): default real_llm, echo note toggle, real `gpt-5.2` badge + `agent` label, `DEMO` badge, answer block renders `4`, New session clears the conversation.
- Test updates (deliberate behavior change): `ChatHeader.test.tsx` / `TurnList.test.tsx` label+copy assertions; `SessionList.test.tsx` + New-session reset test; `chat-v2-real-backend.spec.ts` stale comment.
- Detail: `claudedocs/4-changes/feature-changes/CHANGE-054-chat-v2-honest-testing-surface.md`.

## Deferred (not in this PR)

Real persisted session list with click-to-load history — needs backend `GET /api/v1/sessions` (`AD-ChatV2-SessionList-Backend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)