### PR TITLE
docs(status): refresh A/B/C integration-gap inventory to Sprint 57.86 truth

### DIFF
--- a/claudedocs/5-status/README-integration-gap-abc.md
+++ b/claudedocs/5-status/README-integration-gap-abc.md
@@ -1,12 +1,13 @@
 # A+B+C 整合缺口分析 — README Index
 
-**Purpose**: 索引 2026-05-31~06-01 完成的「整合缺口盤點」16 份核心分析（A 接線缺口 6 + B 優化 4 + C 研究 5 + 1 份 A+B+C 總 capstone），附每項當前狀態（A 區更新至 Sprint 57.73；B/C 截至 57.70）。
+**Purpose**: 索引 2026-05-31~06-01 完成的「整合缺口盤點」16 份核心分析（A 接線缺口 6 + B 優化 4 + C 研究 5 + 1 份 A+B+C 總 capstone），附每項當前狀態（A 區更新至 Sprint 57.73；B/C 更新至 57.86）。
 **Category / Scope**: Status / Integration-gap inventory (Area A/B/C)
 **Created**: 2026-06-02
-**Last Modified**: 2026-06-03
+**Last Modified**: 2026-06-06
 **Status**: Active
 
 > **Modification History**
+> - 2026-06-06: B/C status refreshed to Sprint 57.86 truth — B-7 CLOSED (57.81), B-8 CLOSED (57.82+57.83 flip enabled), C-11 loop LIVE + UI-driven real_llm verified (chat-v2 #253/#254), C-12 backend invites+password-login shipped (57.85/57.86), C-15 billing Outbox CLOSED (57.84); 鑰匙鏈 ①功能閉 + ②code 層全閉; §當前對齊摘要 + Capstone 優先序 marked done (06-03 narrative kept as audit trail)
 > - 2026-06-03: Area A status synced to Sprint 57.73 (A-4 / A-5 / A-6 rows + 剩餘 line + §當前對齊摘要 addendum) — A 區主 slice 全 ship，僅 4 個 Phase-2/deferred AD 餘留；C-11 real-LLM cost-ledger row-count leg now green (process-state resolved, PR #238)
 > - 2026-06-02: Initial creation — index 16 core + 2 supporting docs；status snapshot post-Sprint 57.70
 
@@ -18,8 +19,8 @@
 
 **核心洞察（capstone）**：多數缺口是「**已建好沒接通**」或「**有意 interim debt**」，真正從零做的極少。15 項收斂成 **兩條鑰匙鏈**：
 
-- **鑰匙鏈 ①｜real-LLM 上線束** — 鑰匙 = **C-11**（A 區所有 wiring 的真實驗收前提）
-- **鑰匙鏈 ②｜billing 正確性束** — **B-7 + B-8 + C-15**（cost_ledger 雙扣 / budget 失效）
+- **鑰匙鏈 ①｜real-LLM 上線束** — 鑰匙 = **C-11**（A 區所有 wiring 的真實驗收前提）→ **🟢 功能已閉**（loop LIVE + UI 驅動已驗 57.79 + chat-v2 #253/#254；剩 CI 排程待 Azure secrets）
+- **鑰匙鏈 ②｜billing 正確性束** — **B-7 + B-8 + C-15**（cost_ledger 雙扣 / budget 失效）→ **🟢 code 層全閉**（57.81 / 57.82 / 57.83 / 57.84）
 
 ---
 
@@ -27,7 +28,7 @@
 
 > 「功能蓋好了，但沒接上 agent loop 主流量」。進度最快，已近收尾。
 
-| ID | 主題 | 檔案 | 狀態（至 57.70） | Sprint |
+| ID | 主題 | 檔案 | 狀態（至 57.73） | Sprint |
 |----|------|------|------------------|--------|
 | A-1 | Cat 3 Memory loop 注入 | `cat3-memory-loop-injection-analysis-20260531.md` | ✅ T1/T2 shipped | 57.64 / 57.65 |
 | A-2 | Cat 5 PromptBuilder（拱心石） | `cat5-promptbuilder-loop-injection-analysis-20260531.md` | ✅ T1/T2 shipped | 57.64 / 57.65 |
@@ -42,12 +43,12 @@
 
 ## Area B — 優化 / 移除冗餘（4 份）
 
-> 釐清「已建好沒接通 / 有意 debt / 已過時前提」。目前只動了 B-10。
+> 釐清「已建好沒接通 / 有意 debt / 已過時前提」。**B-7 / B-8 / B-10 已關閉；B-9 達 22/22 PARITY（剩 4 條二階債）→ Area B code 層全閉。**
 
-| ID | 主題 | 檔案 | 狀態（至 57.70） |
+| ID | 主題 | 檔案 | 狀態（至 57.86） |
 |----|------|------|------------------|
-| B-7 | Cat 8 ErrorBudget Redis wiring | `cat8-errorbudget-redis-wiring-analysis-20260531.md` | ❌ 未排程（另揪出 `handler.py:218` 每請求 new `InMemoryBudgetStore` → budget 連單實例都失效）|
-| B-8 | Verification 預設開啟 | `cat10-verification-default-enable-analysis-20260601.md` | ⏸️ 有意 deferred（3 個 launch-blocker；維持 `AD-Cat10-Wire-1-Production`）|
+| B-7 | Cat 8 ErrorBudget Redis wiring | `cat8-errorbudget-redis-wiring-analysis-20260531.md` | ✅ **CLOSED 57.81** — wire `RedisBudgetStore` 單例 + `_wire_error_budget()` startup（修「每請求 new `InMemoryBudgetStore` → budget 連單實例都失效」AP-2 bug；`AD-ErrorBudget-Redis-Wiring`）|
+| B-8 | Verification 預設開啟 | `cat10-verification-default-enable-analysis-20260601.md` | ✅ **CLOSED 57.82+57.83** — judge token → cost_ledger（leg-1）+ data-gated flip `chat_verification_mode` 預設→`enabled`（leg-2，real-Azure FP 0%）；`AD-Cat10-Wire-1-Production` 關閉 |
 | B-9 | Mockup re-point 真實狀態 | `b9-mockup-repoint-status-analysis-20260601.md` | ✅ 大部分完成（22/22 PARITY）· 剩 4 條二階債未排程 |
 | B-10 | verifier_factory 去留 | `cat10-verifier-factory-disposition-analysis-20260531.md` | ✅ 已刪除（REFACTOR-006）|
 
@@ -57,13 +58,13 @@
 
 > 需研究釐清真實狀態，或需外部輸入才能動工。全為純研究，尚無實作。
 
-| ID | 主題 | 檔案 | 狀態（至 57.70） |
+| ID | 主題 | 檔案 | 狀態（至 57.86） |
 |----|------|------|------------------|
-| C-11 | real-LLM e2e 驗證 | `c11-real-llm-e2e-analysis-20260601.md` | ⭐ gate 早建好（57.6）· 缺 3 個 Azure Secrets · **零 code、capstone 最高優先** |
-| C-12 | IAM Block B/C（invites/註冊/MFA） | `c12-iam-block-bc-analysis-20260601.md` | 前端已 ship · 後端有意缺（Phase 58）|
+| C-11 | real-LLM e2e 驗證 | `c11-real-llm-e2e-analysis-20260601.md` | 🟡 **大部分達成** — pricing 修好（57.79）+ 真 loop LIVE 驗證（cost_ledger Δ=2）+ **UI 驅動 real_llm 已驗**（chat-v2 #253 unmocked 回歸網 + #254 honest testing surface）· **殘留**：CI real-LLM 排程仍待 3 個 Azure Secrets |
+| C-12 | IAM Block B/C（invites/註冊/MFA） | `c12-iam-block-bc-analysis-20260601.md` | 🟡 **後端開工** — invites（57.85）+ password-login（57.86）後端已 ship · register / MFA 後端仍 deferred（Phase 58）|
 | C-13 | 缺核心頁 agents / workflows | `c13-agents-workflows-pages-analysis-20260601.md` | `agents` 改名 + 57.70 補 catalog 後端 · `workflows` 仍全缺 |
 | C-14 | 企業合規軸（SOC2/PDPA/CRA/AI Act） | `c14-compliance-axis-analysis-20260601.md` | 程式 0% · 地基齊（WORM audit + hash chain + RLS + PIIRedactor）|
-| C-15 | DevOps IaC/DR + Data platform | `c15-devops-data-platform-analysis-20260601.md` | Bicep IaC 已有 · DR/Outbox/analytics 缺（**cost_ledger 雙扣風險**）|
+| C-15 | DevOps IaC/DR + Data platform | `c15-devops-data-platform-analysis-20260601.md` | 🟡 **billing leg CLOSED** — transactional billing Outbox（57.84）修掉 cost_ledger 雙扣風險 · Bicep IaC 已有未驗證部署 · DR/multi-region/WAL/analytics 仍缺（外部阻擋）|
 
 ---
 
@@ -75,13 +76,13 @@
 
 ### Capstone 建議優先序
 
-1. **⭐1 C-11** 啟用 real-LLM（零 code，只缺 Azure secrets）
-2. **拱心石 bundle**：A-2 T1 + A-1 T1 + A-3a
-3. **billing 正確性 spike**：B-7 + B-8 + C-15（cost_ledger）
-4. schema codegen + 視覺 CI（A-5b）
-5. tracer（A-4）/ admin-tenants 重掛（A-6a）
-6. C-12 invites / C-13 agents 後端
-7. 後排（待外部輸入）：C-14 合規 / workflows / DR
+1. **⭐1 C-11** 啟用 real-LLM — 🟢 功能已閉（pricing 57.79 + loop LIVE + UI 驅動已驗 #253/#254）· 剩 CI 排程待 Azure secrets
+2. **拱心石 bundle**：A-2 T1 + A-1 T1 + A-3a — ✅ shipped（57.64-65）
+3. **billing 正確性 spike**：B-7 + B-8 + C-15（cost_ledger）— ✅ code 層全閉（57.81 / 57.82 / 57.83 / 57.84）
+4. schema codegen + 視覺 CI（A-5b）— ✅ shipped（57.67）
+5. tracer（A-4）/ admin-tenants 重掛（A-6a）— ✅ shipped（57.71 / 57.73）
+6. C-12 invites / C-13 agents 後端 — 🟡 invites + password-login ship（57.85 / 57.86）· register/MFA 後端 + `workflows` 仍缺
+7. 後排（待外部輸入）：C-14 合規 / workflows / DR — ❌ 未動（外部阻擋）
 
 ---
 
@@ -94,7 +95,7 @@
 
 ---
 
-## 當前對齊摘要（截至 Sprint 57.70）
+## 當前對齊摘要（截至 Sprint 57.86）
 
 **主線未偏離** — 57.64→57.70 正在執行 capstone 優先序 #2「拱心石 bundle」及其延伸（A-3b HANDOFF、A-5a/b schema codegen、57.70 觸及 C-13 agents 後端）。
 
@@ -105,3 +106,9 @@
 **次要偏離**：A-6a（最便宜 ½ 天贏面）與 A-4 被跳過，優先做了較貴的 A-3b（3 個 sprint）；非錯誤，但低成本項在積壓。
 
 **2026-06-03 更新（post-57.73）**：A 區主 slice 已全部 ship（A-4 tracer 57.71、A-5c Inspector Tree 57.72、A-6a/b 57.73），上述積壓的低成本項已清。**C-11 real-LLM 鑰匙鏈部分達成** —— 閉環 LIVE + 已驗證，`cost_ledger` row-count leg 經重啟驗證轉綠（process-state，非 code bug；PR #238），剩 $ 值=0（pricing-key）屬 billing 束。A 區剩餘僅 4 個 Phase-2/deferred AD（見上表「A 區剩餘」）。
+
+**🟢 2026-06-06 更新（post-57.86）— 上述兩條 strategic gap 均已關閉**（§101-103 的「尚未做 / 完全未動」敘述保留作 audit trail，已被本段取代）：
+- **鑰匙鏈 ② billing 正確性束（B-7 + B-8 + C-15-billing）= code 層全閉**：B-7 per-request budget 失效 bug 修好（57.81 wire RedisBudgetStore 單例）· B-8 judge token → cost_ledger + 預設 flip enabled（57.82 + 57.83，real-Azure FP 0%）· cost_ledger 雙扣以 transactional billing Outbox 修掉（57.84）· C-11 pricing-key $0 bug 修好（57.79，`unit_cost>0` LIVE 驗）。殘留非阻擋：per-verifier 成本歸因粒度延後。
+- **鑰匙鏈 ① real-LLM 上線束（C-11）= 功能已閉**：真 Azure agent loop 端到端 LIVE（perceive→reason→tool→observe，cost_ledger Δ=2）+ **UI 驅動 real_llm 已驗**（chat-v2 瀏覽器跑通 echo + 2× guardrail block + business tool + Cat 10 verification，涵蓋 Cat 1/2/4/5/6/7/9/10/12；#254 把 `/chat-v2` 變誠實 real_llm 測試面）+ 新增 unmocked 回歸網 `chat-v2-real-backend.spec.ts`（#253）。**殘留**：CI real-LLM 排程仍 commented out（待 3 個 GitHub Azure secrets）· HITL pause + Cat 8 retry 廣度未在 runtime 驗（需改 code / 停 mock infra）。詳見 `v2-overall-progress-gap-assessment-20260606.md` §2/§4。
+- **C-12 IAM 後端開工**：invites（57.85）+ local credentials/password-login（57.86）後端已 ship；register / MFA / recovery 後端仍 deferred（Phase 58）。
+- **下一個真正的待辦重心**（皆非 billing/real-LLM 束）：C-13 `workflows` 頁全缺（greenfield 前+後）· C-14 合規程式 0%（外部法規阻擋）· C-15 DR/IaC 部署未驗（Azure provisioning 外部阻擋）· C-12 register/MFA 後端。

--- a/claudedocs/5-status/v2-overall-progress-gap-assessment-20260606.md
+++ b/claudedocs/5-status/v2-overall-progress-gap-assessment-20260606.md
@@ -101,7 +101,7 @@ A-1 Memory / A-2 PromptBuilder / A-5 events→SSE 完整接通。刻意保留:A-
 
 ### Area C(5 研究)— 🟡 混合
 - **C-11** real-LLM e2e — pricing-correctness leg 57.79 closed;真 loop **LIVE 已驗**(Δ=2)。但 CI 排程 gate 仍 commented out(等 Azure secrets,Phase 58)。
-- **C-12** IAM Block B/C — invites 57.85 closed;password-login 57.86 **(注意:source 尚未進工作樹,疑為未 merge 分支)**;register/MFA 後端刻意 deferred(Phase 58)。
+- **C-12** IAM Block B/C — invites 57.85 closed;password-login 57.86 **已 merge(PR #252,merge commit `5b5cc5ff`;2026-06-06 更新,原評估寫於 HEAD f61df966 時誤判為未 merge)**;register/MFA 後端刻意 deferred(Phase 58)。
 - **C-13** agents/workflows 頁 — `agents` 已改名為 `/orchestrator`+`/subagents`;**`/workflows` 完全不存在**(無頁/路由/mockup/後端)。
 - **C-14** 合規軸 — **程式 0%**(SOC2/PDPA/CRA/AI-Act);地基齊(WORM audit + SHA-256 hash chain + RLS + PIIRedactor);GDPR erasure 僅 pseudocode。外部阻擋(法規查證)。
 - **C-15** DevOps/Data — billing Outbox 57.84 closed(修雙扣);Bicep IaC 已有但未驗證部署;DR/multi-region/WAL/analytics 0%(Azure provisioning 外部阻擋)。
@@ -135,7 +135,7 @@ A-1 Memory / A-2 PromptBuilder / A-5 events→SSE 完整接通。刻意保留:A-
 | Quota(每 plan 限額) | 🟡 partial | 只強制 tokens/day;cost_usd/day + 並發 session caps 未強制 |
 | Billing / cost-ledger + outbox | 🟡 partial | cost-ledger + transactional outbox ship;Stripe/invoice = Stage 2 |
 | SLA monitoring | ✅ done(backend) | recorder + 月報 + violation severity |
-| IAM(C-12) | 🟡 partial | JWT+OIDC(WorkOS)+DB-RBAC+invites ship;register/MFA 後端 deferred;**RBAC `has_permission()` 仍 stub 回 False**;57.86 source 疑未 merge |
+| IAM(C-12) | 🟡 partial | JWT+OIDC(WorkOS)+DB-RBAC+invites(57.85)+password-login(57.86,**已 merge** PR #252)ship;register/MFA 後端 deferred;**RBAC `has_permission()` 仍 stub 回 False** |
 | 合規(C-14) | ❌ missing(僅地基) | 程式 0%;WORM+hash chain+PIIRedactor 地基真;GDPR erasure pseudocode |
 | DevOps/DR(C-15) | 🟡 partial | Bicep IaC 在但未驗證部署;deploy pipeline disabled;DR/multi-region/WAL = 0 |
 
@@ -153,7 +153,7 @@ A-1 Memory / A-2 PromptBuilder / A-5 events→SSE 完整接通。刻意保留:A-
 ### 建議優先序(候選,非 sprint 承諾)
 1. ✅ **(2026-06-06 已完成)** **手動 UI smoke** —— 真 `.env` 啟動後端、開 `/chat-v2`、dev-login、mode toggle 到 `real_llm`、Send、觀察串流 agent 回應。已執行並通過(真 gpt-5.2,見 §2 頂部)。
 2. ✅ **(2026-06-06 已完成,commit `7cb633e9`)** **unmocked 的 chat-v2 e2e** —— `chat-v2-real-backend.spec.ts`,echo_demo 對 live 後端,opt-in `RUN_CONNECTIVITY`(CI 保持 hermetic),驗證通過。
-3. **修 cost_ledger $0**(model/pricing key 4-way 不一致;`AD-Cost-Ledger-Model-Pricing-Key-Mismatch` 仍開)—— loop 會動,但帳算 $0。
+3. ✅ **(已完成,57.79 CHANGE-047)** **修 cost_ledger $0** —— `AD-Cost-Ledger-Model-Pricing-Key-Mismatch` 已 closed(pricing-key date-suffix normalize);real-Azure `unit_cost>0` LIVE 驗(與 §4 C-11 一致;原 §7 寫「仍開」為與 §4 矛盾的筆誤,2026-06-06 校正)。
 4. 🟡 **(2026-06-06 部分完成)** **real-LLM 廣度驗證**:guardrail block ×2 + business tool + verification 已從 UI 實證;**殘留** HITL(需 wire tool guardrail / 改 code)、Cat 8 error/retry(需停 mock :8001,observability 弱)。
 5. **啟用 e2e-real-llm-smoke CI 排程**(提供 Azure secrets)—— 給已證實的路徑加回歸網。
 6. 後排(外部輸入):`/workflows` 頁、IAM register/MFA 後端、C-14 合規(先 GDPR erasure endpoint)、DR/部署。


### PR DESCRIPTION
## docs(status): refresh A/B/C integration-gap inventory to Sprint 57.86 truth

純文件刷新，無 code / API / CI 變動。

### 起因
審視另一 session 合併的 chat-v2 work（#253 honest e2e regression net + #254 honest testing surface）時，順手發現權威 A/B/C 清單 `README-integration-gap-abc.md` 凍結在 ~57.70/57.73，其 B/C 狀態欄已與 git history 不符（57.79-86 的關閉未反映）。

### chat-v2 對 B/C 的影響（分析結論）
- **只推進 C-11**：UI 驅動 real_llm 現已驗證（#254 把 `/chat-v2` 變誠實 real_llm 測試面 + #253 加 unmocked 回歸網）。C-11 唯一殘留（CI 排程待 Azure secrets）不變。
- **不 reopen 任何 B 項**（B-8 verification 在 UI run 被再確認，但維持 closed），其他 C 項無影響。
- `AD-ChatV2-SessionList-Backend` 是 57.21/57.30 的舊 carryover，已登錄，非新項。

### `README-integration-gap-abc.md` 刷新（A 區僅一處 57.70→57.73 表頭一致性修正）
- **B-7** ✅ CLOSED 57.81（RedisBudgetStore wiring；原「未排程」）
- **B-8** ✅ CLOSED 57.82+57.83（judge→cost_ledger + flip default enabled；原「有意 deferred」）
- **C-11** 🟡 大部分達成：pricing 修好(57.79) + loop LIVE + UI 驅動 real_llm 已驗(#253/#254)；殘留 CI 排程待 Azure secrets（原「零 code、只缺 Azure secrets」）
- **C-12** 🟡 後端開工：invites(57.85) + password-login(57.86) ship；register/MFA 仍 deferred（原「後端有意缺」）
- **C-15** 🟡 billing leg CLOSED 57.84（transactional Outbox 修雙扣風險；原「Outbox 缺 / 雙扣風險」）
- 兩條鑰匙鏈標記為「①功能閉 / ②code 層全閉」+ Capstone 優先序加 ✅ 標 + §當前對齊摘要新增 2026-06-06 addendum（06-03 敘述保留作 audit trail）

### `v2-overall-progress-gap-assessment-20260606.md` 修 3 處 stale
- C-12「57.86 source 疑未 merge」(§4 + §6 共 2 處) → 已 merge（PR #252，merge commit `5b5cc5ff`）
- §7 item 3「`AD-Cost-Ledger-Model-Pricing-Key-Mismatch` 仍開」與 §4「57.79 closed」矛盾 → 校正為已 closed

### 驗證
無 code / 測試 / CI 變動（2 個 `.md`，+31/-24）。`next-phase-candidates.md` 逐 sprint carryover log 已是最新（到 57.86），未動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
