### PR TITLE
chore(rules): add Drive-Through Acceptance hard constraint — features must be driven, not just gated

### DIFF
--- a/.claude/rules/sprint-workflow.md
+++ b/.claude/rules/sprint-workflow.md
@@ -913,6 +913,13 @@ Every commit must pass:
    - Parent independent re-verify: re-run every gate yourself; treat the agent's "all green" as unverified until reproduced (57.66 stringified-float / 57.67 flat-vs-nested / 57.68 wrong isolation culprit were all caught this way).
    - Tooling: if Bash `grep` output looks corrupted (e.g. token substitution), re-read via a dedicated reader (Read/Grep tool) before acting on it (Sprint 57.70).
 
+8. **Drive-Through Acceptance — user-facing features must be DRIVEN, not just gated** (2026-06-06; closes AD-Drive-Through-Acceptance; full rationale CLAUDE.md §Drive-Through Acceptance Hard Constraint + `memory/feedback_drive_through_over_paper_metrics.md`)
+   - Any feature a human reaches through the UI MUST be verified by actually driving the real UI (dev server) + real backend + real LLM (NOT echo/mock) through its primary path BEFORE it can be marked done. Gate-pass + curl prove the parts work / the API responds; NEITHER proves the car drives.
+   - Walk every control on the path: clickable? has an effect? label real (not hardcoded / fixture)? does the result actually render? (chat-v2 escape 2026-06-06: dead "New session" button + fixture session list + hardcoded `claude-haiku-4-5` badge + agent answer never rendered — all AP-4 Potemkin sitting on the 主流量, all green on every gate. PR #253 also wrote "~80-85% working" off curl-only verification with "UI 驅動未做" self-noted — exactly the trap.)
+   - Do NOT write "verified" / "~X% working" for anything whose drive-through layer wasn't actually run — write "未驗證 (gate-only)" instead. Backend-not-ready widgets: render per mockup with fixture data BUT label DEMO (or leave blank) — never let fixture masquerade as real.
+   - Evidence: screenshot + "observed vs intended flow" diff into progress.md / CHANGE record.
+   - Scope: applies to any task touching a user-facing surface (frontend page / SSE-driven flow / API a human drives via UI). Pure-backend / pure-infra tasks that no human drives through a UI are exempt — but their reports MUST say "gate-only verified", not imply usability.
+
 ---
 
 ## Prohibited Actions
@@ -925,6 +932,7 @@ Every commit must pass:
 - ❌ Code before plan + checklist exist
 - ❌ Commit secrets, large binaries, generated files
 - ❌ Scope creep without updating plan
+- ❌ Mark a user-facing feature done — or report it "verified / ~X% working" — without an actual drive-through (real UI + real backend + real LLM); gate-pass / curl is NOT drive-through (AD-Drive-Through-Acceptance; see Before Commit item 8)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,38 @@ V2 嚴格按以下範疇組織代碼，**禁止跨範疇雜湊**：
 
 ---
 
+## Drive-Through Acceptance Hard Constraint（必守）⭐⭐⭐
+
+> 本項目的開發**不能只看字面上的數據**。gate 全綠（mypy / pytest / Vitest / lint / mockup-fidelity）只證明「零件對」與「API 會回應」，**不證明「人能真的用」**。
+> 任何 user-facing feature 在標 done 前，必須有人**實際開著真 UI + 真後端 + 真 LLM 走完流程**，並比對「實際發生 vs 預期流程」。完整根因 + chat-v2 五個 Potemkin 證據：[`memory/feedback_drive_through_over_paper_metrics.md`](memory/feedback_drive_through_over_paper_metrics.md)。
+
+### 「驗證」有三層，gate 只覆蓋前兩層
+
+| 層級 | 證明的事 | 工具 |
+|------|---------|------|
+| **Gate 層** | 零件正確 | mypy / pytest / Vitest / lint / mockup byte-identical |
+| **Curl/probe 層** | API 會回應 | curl / httpx probe / e2e against API |
+| **Drive-Through 層** ⭐ | **整台車能開、體驗符合預期** | 真 UI（Playwright/browser MCP 或人）+ 真後端 + 真 LLM，截圖 + 行為對照 |
+
+「主流量驗證原則」（約束 2）要求的是第 3 層；「**能**驗證」**不等於**「**已**驅動驗證」。
+
+### 禁止項（紙上談兵來源）
+
+- ❌ gate 過了就標「verified / ~X% working」——drive-through 沒做一律寫「未驗證 (gate-only)」
+- ❌ 用 curl/probe 通過 API 當「功能能用」
+- ❌ 死控件（無 onClick）/ fixture 假資料 / 寫死或誤導標籤 / 結果不渲染——全是 AP-4 Potemkin
+- ❌ 後端沒接就用假資料但**不標示** demo（要嘛標 DEMO，要嘛留白，不可假裝真）
+
+### Drive-Through DoD（每個 user-facing feature task）
+
+1. 開真 UI（dev server）+ 真後端 + 真 LLM（非 echo/mock），走完該 feature 主路徑
+2. 逐控件確認：可點、有效果、標籤真實、結果真的渲染
+3. 截圖 +「實際發生 vs 預期流程」對照記入 progress.md / CHANGE 紀錄
+4. 發現 Potemkin（死控件 / 假資料 / 誤導標籤 / 不渲染）→ 修到能用才算 done
+5. 強制 gate：見 [`.claude/rules/sprint-workflow.md`](.claude/rules/sprint-workflow.md) §Before Commit Checklist item 8（AD-Drive-Through-Acceptance）
+
+---
+
 ## 「Check Existing Before Building」— V2 版
 
 建任何新 infra 前，**權威排序**：


### PR DESCRIPTION
## What

Records the 2026-06-06 user correction as a hard constraint: **this project's development cannot rely on paper / literal metrics alone.**

Gate-pass (mypy / pytest / Vitest / lint / mockup-fidelity) proves the *parts* are correct; curl/probe proves the *API responds*. **Neither proves a human can actually use the feature.**

## Why (trigger)

chat-v2 (PR #254) had 5 AP-4 Potemkin defects sitting on the 主流量 while every gate was green:
- dead "New session" button (no onClick)
- fixture session list masquerading as real
- hardcoded `claude-haiku-4-5` model badge on a real gpt-5.2 run
- the agent's final answer never rendered

And PR #253's gap report wrote "~80-85% working" off curl-only verification, with "UI 驅動未做" self-noted — exactly the trap.

## Changes (2 files)

- **CLAUDE.md** — new `## Drive-Through Acceptance Hard Constraint` section (parallel to Mockup-Fidelity): 3 verification layers (gate / curl / drive-through) + 禁止項 + DoD.
- **.claude/rules/sprint-workflow.md** — Before-Commit item 8 (drive-through gate for user-facing features) + matching Prohibited Action. `AD-Drive-Through-Acceptance`.

Full single-source rationale + evidence lives in Claude Code local memory (`memory/feedback_drive_through_over_paper_metrics.md` + MEMORY.md pointer) — not in this repo, per the existing `feedback_*` convention.

## Verification

Docs / rules-only change (no code). Per the very rule it adds, this is "gate-only / drive-through N/A" — markdown content + insertion points reviewed; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)