### PR TITLE
chore(docs): drop dangling V1-era PoC worktree refs from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,9 +232,10 @@ V2 嚴格按以下範疇組織代碼，**禁止跨範疇雜湊**：
 
 1. **`agent-harness-planning/` 21 份 V2 規劃**（20 規劃 + 1 review；最高權威）
 2. **Sprint 49.1+ plan/checklist** — 當前迭代決定
-3. **PoC worktrees 驗證模式** — poc-tools / intent-classifier / memory-system / subagent-control / KB enterprise
-4. **Phase 48 LLM-native orchestrator + 7 YAML configs**（已落地新基礎）
-5. **既有 V2 代碼**（archive 範圍外的部分）
+3. **Phase 48 LLM-native orchestrator + 7 YAML configs**（已落地新基礎）
+4. **既有 V2 代碼**（archive 範圍外的部分）
+
+> **註（2026-06-07）**：V1 末期的 PoC 驗證 worktrees（poc-tools / intent-classifier / memory-system / subagent-control / KB enterprise）已移除（皆為 pre-V2 / V1 相關）；其驗證的模式已落地 V2（Cat 2 Tool / Cat 3 Memory / Cat 11 Subagent），findings 仍保存於 `docs/07-analysis/poc-agent-team/` 與 `docs/07-analysis/claude-agent-study/`。
 
 ### ⛔ 禁止反模式
 
@@ -459,7 +460,7 @@ claudedocs/
 - **Never Delete Tests**: 不刪測試 / 不關測試 / 不跳測試
 - **Never Delete Docs**: 未授權不刪文件
 - **Never Delete Checklist Items**: 只能 `[ ]` → `[x]`，不能刪除未勾選項（Phase 42 Sprint 147 違規前車之鑑）
-- **Check Existing Before Building**: 建新 infra 前，先查 V2 21 份規劃 + Sprint plan + PoC worktrees（**不是查 MAF/AG-UI/SDK** — 它們已封存於 archived/）
+- **Check Existing Before Building**: 建新 infra 前，先查 V2 21 份規劃 + Sprint plan（**不是查 MAF/AG-UI/SDK** — 它們已封存於 archived/；V1 末期 PoC 驗證 worktrees 已於 2026-06-07 移除，模式已落地 V2）
 
 ---
 


### PR DESCRIPTION
## Summary

Doc cleanup following this session's branch/worktree housekeeping. The V1-era PoC/research validation worktrees were removed; this updates the one operational doc that still referenced them.

## Context

While cleaning up stale local branches/worktrees, we verified (by commit timeline) that these were all created **before V2 launched** (activity 2026-03-22 → 04-20; V2 formal start = 2026-04-28, commit `9bf8fe83`) and are V1-related:

- `poc/agent-team`, `poc/anthropic-chatclient`, `poc/unified-tools`
- `research/knowledge-base-enterprise`, `research/memory-system-enterprise`
- `feature/subagent-count-control`

Their local branches + worktrees were removed this session (and `origin/research/memory-system-enterprise`, the only one with a remote, was deleted). Repo is now down to `main` only (12 branches → 1; 11 worktrees → 1).

## Change

`CLAUDE.md` was the **only operational doc** with dangling references to those worktrees (`§Check Existing Before Building`, 2 spots). Updated per option B (remove + historical note):

- Dropped the `PoC worktrees 驗證模式 — poc-tools / intent-classifier / memory-system / subagent-control / KB enterprise` item from the authority-ordering list (renumbered).
- Added a historical note: these pre-V2 / V1 PoC worktrees were removed 2026-06-07; their validated patterns landed in V2 Cat 2 (Tool) / Cat 3 (Memory) / Cat 11 (Subagent); findings preserved in `docs/07-analysis/poc-agent-team/` + `docs/07-analysis/claude-agent-study/`.
- Adjusted the inline `Check Existing Before Building` line in §Developer Preferences.

## Left intact (historical record — Never-Delete-Docs)

A repo-wide grep found 26 other files referencing these names, all **historical** and intentionally preserved: `CLAUDE.backup-*` (frozen snapshot), `docs/07-analysis/V9/**` (V1 baseline analysis), `docs/07-analysis/poc-agent-team|claude-agent-study|POC-test/**` (the extracted PoC findings — the durable value), `docs/09-git-worktree-working-folder/**` (then-merge-process records), V1 sprint checklists. Editing those would rewrite history. `.claude/rules/` and `agent-harness-planning/` (V2 authority docs) had **zero** hits.

## Scope

Docs-only, 1 file (`CLAUDE.md`, +5/-4). No code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
