### PR TITLE
fix(tool-layer): chat python_sandbox runs on Docker — FIX-033 + numpy + print hint

### DIFF
--- a/backend/src/agent_harness/tools/exec_tools.py
+++ b/backend/src/agent_harness/tools/exec_tools.py
@@ -4,6 +4,11 @@ Purpose: python_sandbox built-in tool (ToolSpec + handler).
 Category: 範疇 2 (Tool Layer)
 Scope: Phase 51 / Sprint 51.1 Day 3.4
 Created: 2026-04-30
+Last Modified: 2026-06-18
+
+Modification History (newest-first):
+    - 2026-06-18: FIX-033 — description: script-not-REPL must-print() + numpy-available hint
+    - 2026-04-30: Initial creation (Sprint 51.1 Day 3.4)
 """
 
 from __future__ import annotations
@@ -27,10 +32,13 @@ ToolHandler = Callable[[ToolCall], Awaitable[str]]
 PYTHON_SANDBOX_SPEC: ToolSpec = ToolSpec(
     name="python_sandbox",
     description=(
-        "Execute Python code in a wall-time / memory-limited subprocess. "
-        "Returns JSON with stdout / stderr / exit_code / duration_seconds / "
-        "killed_by_timeout. Use for ad-hoc computation; not for filesystem "
-        "or network side-effects (best-effort isolation; Phase 53.x adds Docker)."
+        "Execute Python code in an isolated, wall-time / memory-limited sandbox "
+        "(Docker container when available). Returns JSON with stdout / stderr / "
+        "exit_code / duration_seconds / killed_by_timeout. IMPORTANT: the code "
+        "runs as a SCRIPT (python <file>), NOT a REPL — a bare final expression "
+        "is NOT shown. You MUST call print() on any value you want to read back "
+        "in stdout. numpy is available. Use for ad-hoc computation; not for "
+        "filesystem or network side-effects."
     ),
     input_schema={
         "type": "object",

--- a/backend/src/business_domain/_register_all.py
+++ b/backend/src/business_domain/_register_all.py
@@ -22,9 +22,10 @@ Lifecycle:
     each domain's mock_executor.py gets swapped.
 
 Created: 2026-04-30 (Sprint 51.0 Day 3)
-Last Modified: 2026-06-15
+Last Modified: 2026-06-18
 
 Modification History:
+    - 2026-06-18: FIX-033 — chat python_sandbox → Docker default_sandbox() (Win Selector fail)
     - 2026-06-15: Sprint 57.118 — opt-in skill_registry also registers run_skill_script (exec)
     - 2026-06-13: Sprint 57.113 — opt-in skill_registry (registers read_skill lazy-load tool)
     - 2026-06-12: Sprint 57.107 (B3) — opt-in handoff_targets (registers spec-only handoff)
@@ -66,6 +67,7 @@ from agent_harness.tools import (
 )
 from agent_harness.tools.echo_tool import ECHO_TOOL_SPEC, echo_handler
 from agent_harness.tools.note_tool import NOTE_TOOL_SPEC, note_handler
+from agent_harness.tools.sandbox import SandboxBackend, default_sandbox
 
 from ._service_factory import BusinessServiceFactory
 
@@ -81,6 +83,27 @@ from .rootcause.tools import register_rootcause_tools
 
 # Default mock backend URL (overridable per-call)
 DEFAULT_MOCK_URL = "http://localhost:8001"
+
+
+# === Shared python_sandbox backend (Docker when reachable) ===================
+# Why (drive-through 2026-06-18 / FIX-033): the chat 主流量 wired python_sandbox to the
+# LEGACY SubprocessSandbox (register_builtin_tools default). On Windows uvicorn's
+# SelectorEventLoop, SubprocessSandbox.execute's asyncio.create_subprocess_exec raises
+# NotImplementedError (empty message) at 0ms -> surfaced as "unknown tool error", so
+# python_sandbox never ran on chat. default_sandbox() returns DockerSandbox when the
+# daemon is reachable (loop-agnostic: docker SDK via asyncio.to_thread) and falls back to
+# SubprocessSandbox on hosts without Docker (CI parity preserved). W4P-3 audit already
+# mandates Docker for production; SubprocessSandbox is "decorative on Windows".
+# Process-wide singleton (mirrors skills/tool.py) probes Docker once, not per request.
+_shared_sandbox_singleton: SandboxBackend | None = None
+
+
+def _get_shared_sandbox() -> SandboxBackend:
+    """Return the process-wide python_sandbox backend (Docker when reachable, else Subprocess)."""
+    global _shared_sandbox_singleton
+    if _shared_sandbox_singleton is None:
+        _shared_sandbox_singleton = default_sandbox()
+    return _shared_sandbox_singleton
 
 
 def register_all_business_tools(
@@ -262,6 +285,7 @@ def make_default_executor(
             handlers,
             memory_retrieval=memory_retrieval,
             memory_layers=widened_layers,
+            sandbox_backend=_get_shared_sandbox(),
         )
     else:
         # echo_tool (50.1 built-in for bring-up tests; migrated out of _inmemory in 51.1)

--- a/claudedocs/4-changes/bug-fixes/FIX-033-chat-python-sandbox-docker-wiring.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-033-chat-python-sandbox-docker-wiring.md
@@ -1,0 +1,62 @@
+# FIX-033: chat python_sandbox 在 Windows Selector loop 上 0ms「unknown tool error」
+
+**Date**: 2026-06-18
+**Sprint**: drive-through finding (ad-hoc; not a sprint)
+**Scope**: 範疇 2 (Tool Layer) — `python_sandbox` SandboxBackend wiring on chat 主流量
+
+## Problem
+
+chat-v2 主流量上,agent 呼叫 `python_sandbox` 工具(批准後)立即 `0ms` 失敗,UI 顯示 `unknown tool error`,工具從未真正執行。agent 連續換方法重試仍全失敗,無法產出統計結果。drive-through 發現(真 UI + 真後端 + 真 LLM)。
+
+## Root Cause
+
+決定性確認(用後端同一支 `Python312\python.exe` 重現):
+
+```
+PROACTOR  → OK   exit=0  stdout='227.0 222.0208 128.0 920.0'   # 正確
+SELECTOR  → RAISED NotImplementedError ('')                     # 0ms,空訊息
+```
+
+因果鏈:
+1. chat path 的 `python_sandbox` 落到 **`SubprocessSandbox`**:`business_domain/_register_all.py::make_default_executor` 呼叫 `register_builtin_tools(...)` **未傳 `sandbox_backend`** → `exec_tools.py:75` `backend or SubprocessSandbox()`。
+2. `SubprocessSandbox.execute` 用 `asyncio.create_subprocess_exec`(`sandbox.py:153`)。
+3. uvicorn 在 **Windows SelectorEventLoop** 上跑 → `create_subprocess_exec` 立即拋 `NotImplementedError`(`str()` 為空)。
+4. 空訊息 → `loop.py:3061` `error=result.error or "unknown tool error"` → UI 顯示「unknown tool error」、`0ms`。
+
+補充:`SandboxBackend` 的 W4P-3 audit 註解早已載明 SubprocessSandbox 在 Windows「decorative / PRODUCTION-UNSAFE」、「PRODUCTION DEPLOY MUST USE DockerSandbox」。Docker daemon 在跑、image `ipa-v2-sandbox:latest`(177MB)已建好,但 chat path 未接 Docker。前次「219.93 vs 227.0」即工具失敗後 agent 退回錯誤心算的產物(非 LLM 轉述失真)。
+
+## Solution
+
+`business_domain/_register_all.py`:
+- 新增 import `from agent_harness.tools.sandbox import SandboxBackend, default_sandbox`。
+- 新增 process-wide lazy singleton `_get_shared_sandbox()`(鏡像 `skills/tool.py:153-161`;`default_sandbox()` 只探測 Docker 一次,非每請求)。
+- `make_default_executor` 的 `register_builtin_tools(...)` 加 `sandbox_backend=_get_shared_sandbox()`。
+
+設計理由:
+- `default_sandbox()` Docker 可達回 **DockerSandbox**(loop-agnostic:docker SDK 經 `asyncio.to_thread`,不碰 `create_subprocess_exec`),不可達 fallback `SubprocessSandbox`(**CI 行為不變**)。
+- 只改 `make_default_executor` 接線點(chat / child / teammate executors),**不改** `make_python_sandbox_handler` 全域預設 → 直接呼叫該 factory 的既有測試不受影響(surgical)。
+
+## Verification
+
+- 重現腳本(Proactor vs Selector)+ UI drive-through 觀察(見 `claudedocs/5-status/chat-v2-python-sandbox-drivethrough-20260618.md`)。
+- gate:black/isort/flake8/mypy 乾淨;`test_builtin_tools` + business_domain 工廠/模式 + chat keystone wiring + main flow = **58 tests passed**。
+- **修後 drive-through(已執行,真 UI + 真後端重啟 + 真 LLM gpt-5.2)**:
+  - 乾淨重啟後端(殺 reloader 56292 + 清 57.97 孤兒 worker 46056),新進程 48612/17376 跑新碼。
+  - 重跑 T1,批准 python_sandbox → **工具真的在 Docker 執行**:tool result 帶 `duration_seconds≈0.5-0.6`、真實 `exit_code`/`stderr`;**「0ms unknown tool error」完全消失**。
+  - ✅ **FIX-033 scope(讓 python_sandbox 在 chat 真正執行)達成並驗證。**
+
+### ⚠️ 下游新問題(FIX-033 之外,獨立 issue)
+
+修好 wiring 後 drive-through 揭露 2 個 end-to-end 仍未通的下游問題(與本 FIX 無關,留待後續決定):
+1. **sandbox image 缺 numpy**:`ipa-v2-sandbox:latest` 無 numpy → agent 的 numpy code 第一次回 `ModuleNotFoundError`(exit_code=1)。
+2. **腳本執行 vs REPL 語意**:python_sandbox 跑 `python main.py`(腳本),agent 程式碼以**裸表達式結尾**(如 `(q1,q3,iqr,lb,ub,anom)`)無 `print()` → exit_code=0 但 **stdout 空** → agent 拿不到結果而反覆重試。
+   - 可能解:tool description 明示「必須 print()」,或 sandbox 包裝成 auto-display 最後一個表達式(REPL 式)。
+
+## Impact
+
+Backend-only。影響 chat / child / teammate executors 的 `python_sandbox`(改用 Docker)。Docker 不可達環境(CI)維持 SubprocessSandbox 行為,向後相容。無 migration、無 schema、無 frontend 改動。
+
+## Related
+- `claudedocs/5-status/chat-v2-python-sandbox-drivethrough-20260618.md`(完整發現 + 證據)
+- `agent_harness/tools/sandbox.py`(SandboxBackend / default_sandbox / W4P-3 audit 註解)
+- `agent_harness/skills/tool.py:153-161`(被鏡像的 singleton 模式)

--- a/claudedocs/5-status/chat-v2-python-sandbox-drivethrough-20260618.md
+++ b/claudedocs/5-status/chat-v2-python-sandbox-drivethrough-20260618.md
@@ -1,0 +1,104 @@
+# Chat-V2 Drive-Through 發現:python_sandbox 在 chat 主流量壞掉(Windows Selector loop)
+
+**Date**: 2026-06-18
+**Type**: Drive-Through finding / Bug diagnosis (fix pending user decision)
+**Scope**: 範疇 2 (Tool Layer) — python_sandbox / SandboxBackend wiring on chat 主流量
+**Verifier**: 真 UI(Playwright)+ 真後端(uvicorn :8000)+ 真 LLM(Azure gpt-5.2),dan@acme.com / acme-prod
+
+---
+
+## 背景
+
+接續對 chat-v2 主流量做「營運分析師資料分析」drive-through(T1:14 天 p95 延遲 → 要 agent 用 Python 算 mean/std/min/max + 找異常)。目的之一是定位上次「agent 答 219.93 但正確值 = 227.0」的根因(python 算錯 vs LLM 轉述失真)。
+
+---
+
+## 哪些控件/流程「真的能用」(drive-through PASS)
+
+| 項目 | 結果 |
+|------|------|
+| dev-login(dan@acme.com / acme-prod / admin) | ✅ 可登入 |
+| New session 按鈕 | ✅ 真的開乾淨對話(非死控件) |
+| mode = real_llm | ✅ 藍色高亮 active(非 echo_demo) |
+| 送出訊息 → agent 串流 | ✅ 正常 |
+| python_sandbox 觸發 HITL 暫停(MEDIUM / always_ask) | ✅ Approval 卡片正確出現 |
+| HITL **Approve & continue** | ✅ 有效(loop 恢復) |
+| HITL **Reject** | ✅ 有效(decision=REJECTED → loop 結束) |
+| Loop 事件流 / Inspector Turn metadata(tokens/model/trace_id) | ✅ 正確渲染 |
+
+---
+
+## 哪個壞了(drive-through FAIL)
+
+**`python_sandbox` 工具實際執行時立即 `0ms` 失敗,UI 顯示 `unknown tool error`,從未真正執行。**
+
+- agent 連續 3 次嘗試(z-score 法 → IQR 法 → 第 3 次),每次批准後都 ERROR,陷入「失敗→換方法重試→再要批准」迴圈;最終 Reject 後 loop 收場,**沒有產出任何統計答案**。
+- 後端 `tool_call_request` 帶的程式碼/資料**完全正確**(`[142,138,...,510]`),所以不是資料錯。
+
+---
+
+## 根因(決定性確認)
+
+### 因果鏈
+1. chat path 的 `python_sandbox` 寫死用 **`SubprocessSandbox`**,不是 `default_sandbox()`/Docker
+   - `business_domain/_register_all.py::make_default_executor` 呼叫 `register_builtin_tools(...)` 時**未傳 `sandbox_backend`**
+   - `tools/__init__.py:89` `make_python_sandbox_handler(sandbox_backend=None)`
+   - `exec_tools.py:75` `sandbox = backend or SubprocessSandbox()` → 落到 SubprocessSandbox
+2. `SubprocessSandbox.execute` 用 `asyncio.create_subprocess_exec`(`sandbox.py:153`)
+3. chat 後端 uvicorn 跑在 **Windows SelectorEventLoop** 上 → `create_subprocess_exec` **立即拋 `NotImplementedError`(訊息為空字串)**
+4. 空訊息 → `loop.py:3061` `error=result.error or "unknown tool error"` → UI 顯示「unknown tool error」,`0ms`
+
+### 決定性重現(用後端同一支 python `Python312\python.exe`)
+```
+PROACTOR  → OK   exit=0  stdout='227.0 222.0208 128.0 920.0'   # mean=227.0 正確
+SELECTOR  → RAISED NotImplementedError ('')                     # 空訊息,0ms
+```
+
+→ **python 沒算錯**(Proactor 下精確算出 227.0);問題是**工具在 chat 後端的 Selector loop 上根本沒跑**。
+→ 上次「219.93」= 工具失敗後 agent 退回(錯誤)心算,**不是 LLM 轉述失真**。
+
+### 補充
+- Docker **正在跑**(server 29.5.2,8 容器),sandbox image `ipa-v2-sandbox:latest`(177MB)**已建好** —— 但 chat path 不會用到 Docker。
+- sprint 57.118 的「REAL Docker sandbox」是另一個工具 `run_skill_script`(用 `default_sandbox()`→Docker),不是 python_sandbox。
+- `SandboxBackend` 自己的 W4P-3 audit 註解已明載:SubprocessSandbox 在 Windows 上「decorative」、PRODUCTION-UNSAFE,「PRODUCTION DEPLOY MUST USE DockerSandbox」。
+
+---
+
+## 修法選項(待用戶決定)
+
+| 選項 | 改動 | 評估 |
+|------|------|------|
+| **A(建議)Docker 接線** | `make_default_executor` 把 `register_builtin_tools(..., sandbox_backend=<shared DockerSandbox>)`(經 `default_sandbox()`,做成 process-wide singleton 仿 skills/tool.py) | ✅ 對齊 codebase 自身產線意圖;Docker+image 已就緒;loop-agnostic(用 `asyncio.to_thread`+docker SDK,不碰 `create_subprocess_exec`)。需驗:per-request 不重複 ping Docker |
+| B 改 uvicorn 用 Proactor loop | 啟動時 `WindowsProactorEventLoopPolicy()` | ⚠️ 脆弱(uvicorn 可能覆寫);可能影響 Windows DB driver;只解 dev 環境 |
+| C SubprocessSandbox loop-agnostic | `sandbox.py` 在獨立 thread 用 Proactor loop 跑子程序 | 自包含,但 SubprocessSandbox 仍無隔離(audit 判 unsafe);治標 |
+
+---
+
+## 修後驗證(FIX-033 + Fix A numpy + Fix B print)— T1/T2/T3 全通 ✅
+
+採選項「修 A+B 再完成三輪」:
+- **Fix A**:`docker/sandbox/Dockerfile` 加 `pip install numpy`,rebuild `ipa-v2-sandbox:latest`(numpy 2.4.6;硬化條件下實測 mean 227.0 ✅)。
+- **Fix B**:`exec_tools.py` `PYTHON_SANDBOX_SPEC.description` 明示「腳本執行非 REPL、必須 print()、numpy 可用」。
+- 乾淨重啟後端(過程踩到並修正了過度激進的孤兒判定:detached 啟動的新進程 launcher 已死,不可當孤兒;應以 StartTime 早於本次重啟判定)。
+
+修後真 UI + 真後端 + 真 LLM gpt-5.2 三輪結果(每輪 HITL Approve,數字均獨立驗算):
+
+| 輪 | 驗證重點 | 結果 |
+|----|---------|------|
+| **T1** | 工具真執行 + 計劃 + 正確統計 | python_sandbox 在 Docker 跑(無 error)、agent 宣告計劃、stdout `mean 227.0`、agent 答案 **227.0**(= stdout = 獨立計算);IQR 異常 第8天(920)+第14天(510),z-score 第8天。**1 次工具呼叫完成**、Verification passed。「219.93」根除。 |
+| **T2** | 跨輪記憶 + 重判 | agent 回想 T1 數據,套新 2σ 規則:門檻 **671.0416**,真正異常**僅第8天920**(510 未達);LLM Judge 0.99。 |
+| **T3** | 記憶複用 + 多步比較 | 一次算兩週:w1(227.0/671.04/第8天)+ w2(297.214/357.919/1013.05/第2天1250);結論「兩週各1異常天,但第二週均值更高波動更大 → 第一週較健康」;全數字獨立驗算一致;LLM Judge 0.99。 |
+
+→ **端到端展示成立**:計劃宣告 / python_sandbox 真執行 / HITL 可控 / 跨輪記憶 / 多步推理 / 驗證迴圈,全部真實運作且數字正確。
+
+## 證據檔
+- `dt-01-after-login-new-session.png`(real_llm 確認)
+- `dt-02-t1-typed.png`(輸入正確)
+- `dt-03-t1-after-send.png`(HITL 暫停 + python code)
+- `dt-04-t1-python-sandbox-broken-end.png`(修前:3 次 ERROR + REJECTED 收場)
+- `dt-05-t1-fix033-docker-executes-but-numpy-and-print.png`(FIX-033 後:Docker 執行但 numpy 缺 + 不 print)
+- `dt-06-t1-success-227.png`(A+B 後:227.0 正確 + Verification passed)
+- `dt-07-t3-cross-week-memory-success.png`(T3 跨週記憶比較成功)
+
+## 註:工具污染(context-mode plugin)
+本次測試在 Claude Code 工具層(Bash/Read/PowerShell)出現 prompt-injection canary 污染(來自 context-mode plugin),詳見 `memory/feedback_context_mode_plugin_prompt_injection.md`。**app 的 UI/SSE(經 Playwright 讀取)全程乾淨**,故以上 app 行為判讀不受污染影響;所有 shell 輸出均已掃 canary 確認乾淨後採信。

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -33,6 +33,12 @@ RUN apt-get update \
 RUN useradd --uid 65534 --no-create-home --shell /bin/false sandbox \
     || true  # tolerate distros where uid 65534 already exists as nobody
 
+# numpy: LLM-generated analysis code reaches for numpy by default. Without it,
+# python_sandbox runs but every numpy script fails ModuleNotFoundError (FIX-033
+# drive-through 2026-06-18). Installed as root (before USER drop); read-only
+# runtime rootfs still allows import from system site-packages.
+RUN pip install --no-cache-dir numpy
+
 # /sandbox holds the user code at runtime, mounted at exec time.
 WORKDIR /sandbox
 


### PR DESCRIPTION
## Summary

Drive-through (real UI + real backend + real LLM gpt-5.2) found `python_sandbox` failing **0ms with "unknown tool error"** on the chat 主流量 — the tool never executed, and the agent fell back to (wrong) mental math. This PR makes `python_sandbox` actually run on chat.

## Root cause

`make_default_executor` wired `python_sandbox` to the legacy `SubprocessSandbox` (the `register_builtin_tools` default). On Windows uvicorn's **SelectorEventLoop**, `SubprocessSandbox.execute`'s `asyncio.create_subprocess_exec` raises `NotImplementedError` (empty `str()`) at 0ms → surfaced as the generic `"unknown tool error"`.

Deterministic repro (backend's own python):
```
PROACTOR  → OK   exit=0  stdout='227.0 222.0208 128.0 920.0'   # correct
SELECTOR  → RAISED NotImplementedError ('')                     # 0ms, empty msg
```

→ The prior **"219.93 vs 227.0"** mystery was the agent's mental-math fallback after the tool silently failed, **not** LLM transcription drift.

## Changes

- **FIX-033** (`business_domain/_register_all.py`): chat/child/teammate executors now wire `python_sandbox` to `default_sandbox()` via a process-wide lazy singleton (mirrors `skills/tool.py`). `DockerSandbox` is loop-agnostic (docker SDK via `asyncio.to_thread`); falls back to `SubprocessSandbox` on Docker-less hosts so **CI behaviour is unchanged**. Surgical: only the `make_default_executor` wiring point changes; `make_python_sandbox_handler`'s global default is untouched.
- **Fix A** (`docker/sandbox/Dockerfile`): install `numpy` in the sandbox image (LLM analysis code reaches for numpy by default); image `ipa-v2-sandbox:latest` rebuilt.
- **Fix B** (`agent_harness/tools/exec_tools.py`): `python_sandbox` description now states it runs as a **SCRIPT (not a REPL)** — a bare final expression is not shown, so the model must `print()`; and that numpy is available.

## Verification

- `black` / `isort` / `flake8` / `mypy --strict` clean (374 files)
- V2 architecture lints: **10/10 green** (`scripts/lint/run_all.py`)
- `pytest`: **2747 passed + 5 skipped**
- **Drive-through T1/T2/T3 all PASS** (real UI + real backend + real Azure gpt-5.2): `python_sandbox` runs in Docker; `mean = 227.0` = stdout = independent calc; cross-turn memory + multi-step comparison + verification loop all real.

Backend-only; no migration / schema / frontend change. Not a sprint — ad-hoc drive-through bug fix (FIX-033).

🤖 Generated with [Claude Code](https://claude.com/claude-code)