### PR TITLE
docs(status): consolidated agent-harness UX & reliability research + V2 mapping

### DIFF
--- a/claudedocs/1-planning/agent-harness-ux-research-20260622.md
+++ b/claudedocs/1-planning/agent-harness-ux-research-20260622.md
@@ -1,0 +1,334 @@
+# 企業級 AI Agent Harness：使用體驗與可靠性優化研究（2024-2026）
+
+**Purpose**: 市場/學術 deep research — 蒐集對「伺服器端企業 agent 平台」開發有幫助、且有實證支持的最新方向，對應 V2 11+1 範疇。
+**Category / Scope**: Research / Reference（informs next-phase direction，非 sprint plan）
+**Created**: 2026-06-22
+**Last Modified**: 2026-06-22
+**Status**: Active
+**Method**: deep-research workflow（客製化：8 搜尋角度、分批 3+3+2 節流、後段驗證減量為每角度 1 票輕驗證、1 綜合 agent）；17 agents / 82 tool calls / 66 findings。
+
+> **Modification History**
+> - 2026-06-22: Add cross-ref to same-day panorama+mapping + flag self-conditioning overclaim
+> - 2026-06-22: Initial creation — deep-research workflow output（rate-limit-aware, light-verify variant）
+
+> **⚠️ 證據品質提醒**：多數可靠性數字來自 Anthropic 自家 eval 或單篇 preprint self-report，是 directional / order-of-magnitude，非外部可重現 benchmark。§五 明確標出哪些 citation 已逐字核實、哪些 unverified / mis-attributed、哪些是 vendor marketing。引用前請先讀 §五。
+
+> **🔗 相關研究（同日 2026-06-22，~70% 重疊，建議一起讀）**
+> 本文是當日**第二次** deep-research run。先前已有一組**更完整、且有 file:line 程式碼 grounding** 的姊妹研究（落地對照權威性高於本文）：
+> - [ai-agent-harness-market-research-panorama-20260622.md](../5-status/ai-agent-harness-market-research-panorama-20260622.md) — 中立全景，含 **28 條 claim 級**對抗驗證
+> - [ai-agent-harness-research-vs-v2-mapping-20260622.md](../5-status/ai-agent-harness-research-vs-v2-mapping-20260622.md) — 14 findings × V2 11+1 對照（可操作性最強，有 `loop.py:行號` grounding）
+>
+> **本文真正的增量（panorama 未涵蓋）**：§六 來源 37 Cat 12 標準化於 OTel GenAI semantic conventions、來源 25 ACON 量化壓縮目標帶、ICLR2024「Cannot」×EMNLP2024「Key-Condition」self-correction 分界線、MAST failure catalog + tool-description lint。
+> **本文盲點（panorama 有、本文漏）**：安全「限制非偵測」+ 6 種抗注入結構模式（arXiv 2506.08837）——Cat 9 方向**以 panorama finding 14 為準**。
+> **⚠️ 已知矛盾（以 panorama 為準）**：§2.2「CoT thinking 消除 self-conditioning」標 **[強] 為 overclaim**；panorama §被否決 #2 的 claim 級對抗驗證已否決「thinking 完全消除 self-conditioning」（vote 0-1）。此處應降為 **[中/開放問題]**。
+
+---
+
+## 一、執行摘要 — 最高價值且有實證支持的方向
+
+1. **Bounded single TAO/ReAct loop 是有實證背書的預設架構，subagent fork 應該 GATE 在 task type + token budget 之後，而非反射式提升準確率。[強]**
+   在相同 thinking-token budget 下，single-agent 在 multi-hop reasoning 上持平或略勝 multi-agent；Anthropic 自家數據顯示 token usage 單獨解釋 ~80% 的 multi-agent 表現變異、且成本約為一般 chat 的 15x。本專案的 bounded max_turns + per-send budgeting + value-gated subagent-spawn 設計被直接驗證。
+
+2. **長程任務失敗主要是 EXECUTION 問題、不是 planning 問題；更好的 planner 不會修好多輪退化——harness 必須外部化狀態並在每個 bounded burst 重新 ground。[強]**
+   即使把正確 plan 與 knowledge 交給模型，single-step 近乎完美的模型仍在 ~15 turns 內掉到 50% 以下（arXiv 2509.09677，已 spot-check）。這是 bounded-burst + cross-turn rehydration + compaction 設計的直接實證依據。
+
+3. **Self-correction loop 必須由 EXTERNAL verifiable signal 驅動（tool error / test pass-fail / key-condition check / 獨立 judge），裸 re-prompt 不只是中性、會讓答案變差。[強]**
+   ICLR 2024「Cannot Self-Correct」vs EMNLP 2024「Can with Key-Condition Verification」這一對是可引用的分界線，直接驗證本專案 verification-ESCALATE 要求真實 judge 失敗（而非 self-reflection）的設計。
+
+4. **Approval fatigue 是已量測的一階風險：使用者批准 ~93% 的 permission prompt——HITL gate 應只在高 blast-radius（tier-3）動作觸發，配 deny-first guardrail 而非逐動作確認。[強]**
+   Anthropic 自家 classifier 也有 ~17% false-negative，R-Judge 顯示 8 個 LLM 的 risk-awareness「遠非完美」。結論：LLM judge 不能是唯一 gate，需 rules-based + LLM-judge + 確定性 human escalation 的 defense-in-depth。
+
+5. **pass^k（k 次重複的一致性）應成為平台主要 eval 指標，而非單次 pass@1 / drive-through-once。[強]**
+   τ-bench：GPT-4o retail ~61% pass@1 但 pass^8 <25%。一個 drive-through 過一次的 feature，跨 tenant 重複跑仍可能不可靠——這正是 bounded-loop + per-tenant-replay 場景。
+
+6. **Cat 12 tracing 應標準化在 OpenTelemetry GenAI semantic conventions（invoke_agent → chat → execute_tool）上，content capture 預設關閉。[強]**
+   `finish_reasons` = `tool_calls` vs `stop` 與本專案 while-true loop 的 stop_reason 分支 1:1 對應；`captureContent` opt-in 預設與既有 multi-tenant PII/GDPR + PIIRedactor 規則吻合，同時滿足 provider-neutrality（約束 3）。
+
+7. **Compaction 應採「分層、依風險排序」策略，且有可量化目標帶。[強（ACON 已驗證）/ 中（部分技法）]**
+   ACON（arXiv 2510.00615，Microsoft，已驗證）：15+ step agent 可削減 26–54% peak token 而不損準確率；distilled compressor 保留 >95% 效能、~99% API 成本下降。順序建議：(1) tool-result clearing 最先（最便宜、最低損、無同步 LLM 呼叫），(2) deterministic eviction（審計友善），(3) 才用 lossy LLM summarization。
+
+8. **Tool-description 品質與 clean scoped subagent context 是高槓桿、可量測的可靠性槓桿。[中]**
+   Anthropic 報告：用模型改寫 flawed tool description 帶來 ~40% 後續任務完成時間下降（單一 vendor 數據點）；strip orchestrator routing/handoff metadata 出 worker context（LangChain）可避免 translation overhead 與 self-conditioning。支持一個 tool-description lint/review step。
+
+---
+
+## 二、各維度發現
+
+### 2.1 Agent loop 架構與控制模式（agent-loop）
+
+核心訊息：bounded single loop 是有實證的預設；multi-agent 的優勢主要來自 aggregate compute 與 parallel context，不是 orchestrator 的「聰明」。長程一致性靠外部化狀態 + rehydration + compaction，不是靠更長的單次 run。
+
+- 相同 thinking-token budget 下，single-agent 在 multi-hop reasoning 持平或略勝 sequential MAS（FRAMES 1000-token：0.680 vs 0.670；MuSiQue 4-hop：0.407 vs 0.320）——margin 小，正確描述是「match or modestly beats」。¹
+- Multi-agent 在 Anthropic 內部 research eval 勝 single-agent Opus 4 達 90.2%，但 token usage 單獨解釋 ~80% 變異、成本 ~15x chat。² 這是 compute、不是 orchestration 魔法。
+- 架構由 task 決定：isolated subagent 適合 independent-thread/parallel 任務，但在需要共享單一連貫 context 的 shared-state 任務上會 break——「the task picks the architecture」。³
+- 強模型上 plan-then-act 持平或略勝 interleaved ReAct（GPT-4o）；goal-state reflection（ReflAct）勝 baseline ~33.1%——建議每個 turn 錨定 goal/state 而非冗長 CoT。⁴ [中]
+- RP-ReAct（planner/supervisor over bounded ReAct executor）在 enterprise 任務優於 flat ReAct——對應本專案 hybrid orchestrator，但屬單篇 self-report。⁵ [中]
+- Agent-controlled（非 threshold-triggered）compaction：在 safe task boundary 觸發，報告 22.7% token 下降且無準確率損失——但來源為單一 practitioner blog，數字當假設、非目標。⁶ [弱]
+- 長程 agent 靠 explicit state-rehydration artifact（progress log + feature list + git）在每個 fresh-context session 開頭讀回；two-role split（initializer vs per-feature coding agent）。⁷
+- End-to-end behavioral verification 是獨立且必要的 loop step：agent 可靠地改 code 但常沒注意「feature 其實沒 work」，除非明確被要求用 browser automation 驅動。⁷ 獨立佐證本專案的 Drive-Through Acceptance 約束。
+
+### 2.2 Intent recognition、planning 與 task decomposition（planning-decomposition）
+
+核心訊息：長程失敗是 execution 而非 planning 問題；self-conditioning（自己的錯誤留在 context 會招致更多錯誤）不被 model scale 修好；CoT thinking 是執行長度的最大單一槓桿。explicit externalized task primitive 是 load-bearing 的反 early-stop 機制。
+
+- 長程退化即使給對 plan + knowledge 仍發生：Qwen3-32B H₀.₅ ~15 turns、Qwen3-4B ~6 turns；frontier models without thinking 多在 ~4 step/turn 失敗。⁸
+- Self-conditioning：注入更多 prior error 單調惡化 turn-100 準確率，200B+ 仍 susceptible；CoT thinking 消除 self-conditioning 並大幅延長單輪執行長度。⁸ [強]
+- Thinking/CoT 是最大槓桿：GPT-5 (thinking) 維持 2,176 sequential steps、Claude-4 Sonnet 432 steps，without thinking「a few steps」。⁸ 支持 provider-neutral thinking-budget toggle 作為一級 harness 旋鈕。
+- Plan-then-Execute（分離 Planner/Executor + localized replanning）是 long-horizon web navigation 的可重現 SOTA pattern；hierarchical milestone decomposition 進一步改善——來源為 aggregator，特定 SOTA 主張視為單一聚合源。⁹ [中]
+- Anthropic harness：initializer 寫 200+ feature JSON（全預標 failing 作為完成準則）+ progress 檔，one-feature-at-a-time + 結構性拒絕 early termination——具體的 externalized TodoWrite-style primitive。⁷ ¹⁰
+- Claude Code「Tasks」以 DAG（含 explicit blocking）建模、跨 session/subagent/context window 協調——比 flat list 更具表達力（單一 secondary 來源）。¹¹ [中]
+- Compaction（高保真摘要後 reinitiate 新 window）是 Anthropic 點名的長程一致性「first lever」，配 NOTES.md-style note-taking。¹⁰
+- 失敗歸因研究將 long-horizon breakdown 拆成 memory / reflection / planning / action 四模組——支持以模組邊界建 Cat 12 observability（單一來源，具體計數未獨立核實）。¹² [中]
+- Receding-horizon replanning（只 commit 下一個 action、每次 transition 後 replan）在 noisy evaluation 下勝過 brittle 的長期 commitment——原理強、特定 paper（arXiv 2601.22311）未核實。¹³ [中]
+
+### 2.3 Multi-agent orchestration 與 delegation（multi-agent）
+
+核心訊息：把 subagent spawning 當成 explicit cost/budget 決策；依 coupling（非 capability）路由；coordination 集中化、verification per-step；tool-description 品質與 clean context 是 first-class artifact。
+
+- Orchestrator-worker（Opus 4 lead + Sonnet 4 subagents）勝 single Opus 4 達 90.2%，但 token usage 解釋 ~80% 變異。² [強]
+- 成本：multi-agent ~15x chat token、single ~4x；只建議用在 outcome value 超過 token cost 的場景。² [強]
+- Multi-agent 不適合 tightly-coupled work（多 inter-agent dependency / 低真實平行度 / 需共享 context）；Anthropic 點名 coding 為弱契合。³ [強]
+- Decentralized/swarm 拓樸放大錯誤 ~17.2x vs single-agent baseline，centralized orchestrator 收斂到 ~4.4x（arXiv 2603.04474，單篇 2026 preprint，確切數字未獨立核實）。¹⁴ [中]
+- 在每個 primary agent 後插 verification agent，攔下 96.4% 注入錯誤（為 paper 對其他 2025 ICML 工作的 secondary citation，百分比未核實）——方向（per-step 勝 final-only verification）成立。¹⁴ [中]
+- MAST：1,600+ annotated trace、7 框架、14 failure mode、3 類（spec/design、inter-agent misalignment、verification/termination）——大多失敗是 orchestration/spec bug 而非 base-model 弱。¹⁵ [強]
+- Self-conditioning + recursive context reuse 造成 cascading amplification——支持 clean scoped subagent context、scrub prior error（term/attribution 應再核）。¹⁵ [中]
+- τ-bench (retail)：0-1 distractor domain 時 single-agent 勝 supervisor/swarm，2+ distractor 才反轉；supervisor 損失來自 translation overhead + handoff message 汙染 worker context——可重用修法：strip routing/handoff metadata 出 worker context（單一 vendor benchmark）。¹⁶ [中]
+- 用模型改寫 flawed tool description → 後續任務完成時間 ~40% 下降；poor tool description 造成 catastrophic failure（單一 Anthropic 數據點，magnitude 視為 anecdotal）。² [強（質性）/ 弱（量級）]
+
+### 2.4 Tool execution 可靠性 + verification/self-correction loop（tool-verification）
+
+核心訊息：可驗證的分界是「self-correction 需要 EXTERNAL signal」。intrinsic self-reflection（裸 re-prompt）neutral-to-harmful。tool error 是你已有的最高品質 external signal。
+
+- Intrinsic self-correction（無 external signal）一致地失敗、常退化推理準確率，會把對的答案改成錯的（ICLR 2024）。¹⁷ [強]
+- Evaluator-optimizer（generator LLM + 獨立 evaluator LLM in loop）僅在「有明確準則 / 迭代有可量測價值 / evaluator 能給有用回饋」三條件成立時建議——Anthropic guidance（非 benchmark）。¹⁸ [強]
+- 分離 guardrail model 與 response model（一個答、另一個 screen）勝過單一 call 兼任——Anthropic 報告之 tendency。¹⁸ [中]
+- 自主 tool agent 有 compounding error，建議 sandboxed testing + HITL checkpoint before irreversible action + Zero-Trust least-privilege——對應本專案 HITL pause/resume + permission-policy + tool-sandbox triad。¹⁸ [強]
+- 對 tool error 的 structured reflection（先診斷具體錯誤再 retry）可量測強化 tool-interaction 可靠性（arXiv 2509.18847，含 Tool-Reflection-Bench）；error taxonomy：invocation / parameter / wrong-tool / failed-API——但增益部分來自 RL training，scope 限 trained-reflection regime。¹⁹ [強（trained regime）]
+- 分界線是 verification/key-condition signal 的存在：有 key-condition verification 時 LLM 可 self-correct，無則不能（EMNLP 2024）——告訴 verifier 該檢查 task 的 key constraint（schema / required field / tool-arg constraint），而非「這答案好嗎」。²⁰ [強]
+- 社群視 self-correction 為 contested、condition-dependent——支持保守、不行銷「autonomous self-correction」為 blanket capability（其中一個 citation 標籤被 conflate，substance 正確）。²¹ [中]
+- Tool-use eval 已成熟到 stable、大規模、mirror-real-API benchmark（StableToolBench / MirrorAPI ~7,000+ API）——支持 golden-fixture / `@pytest.mark.benchmark` regression（確切 API 數視為近似）。²² [中]
+
+### 2.5 Long-running agents：memory + context 管理/compaction（memory-context）
+
+核心訊息：context degradation 是 length-driven（context rot），不只是 relevance-driven。三個 named pattern（compaction / structured note-taking / sub-agent isolation）直接對應 Cat 4 / Cat 3 / Cat 11。
+
+- Context rot：window token 數增加，recall 準確率下降；歸因 n² attention + 多在較短序列訓練；Anthropic 稱 context engineering 為 agent engineer 的「#1 job」。²³ [強]（「context rot」部分是 framing 用語，底層退化已被實證。）
+- 三 pattern：(1) compaction（摘要近滿 context 後 reinitiate，保留架構決策/未解 bug/實作細節）、(2) structured note-taking（外部 memory）、(3) sub-agent isolation（只回 1,000–2,000 token 摘要）；compaction 調參順序「先 maximize recall、再 iterate precision」。²³ [強]
+- Tool-result clearing 是最安全、最低風險的 compaction 形式，已作為 Claude Developer Platform 一級 feature（Anthropic 自家 framing，機制低爭議）。²⁴ [強]
+- ACON：15+ step agent peak token 削 26–54% 且 task success 持平或改善（AppWorld 56.5% vs 56.0%、OfficeBench ~30%、8-Objective QA 54.5% token + 61.5% dependency 削減）。²⁵ [強（已驗證 arXiv 2510.00615 + 官方實作）]
+- ACON distilled compressor 保留 >95% teacher 效能、~99% API 成本下降；compression 甚至改善 small-model agent（AppWorld +32.4% relative，透過 context-distraction mitigation）——支持 provider-neutral、per-tenant/turn 跑便宜 distilled model 的 compactor。²⁵ [強]
+- Lost-in-the-middle 是 U-shape positional bias（primacy + recency over middle），2024 work 顯示可 calibrate；後續發現 bias 不限於 middle，更 pervasive——支持 prompt construction（Cat 5）把最相關 memory + 當前 task 放 context 邊緣。²⁶ [強]
+- 結構化/typed eviction（CWL：typed dependency graph + deterministic graduated eviction）被提議優於 summarization，避免 unpredictable lossiness / structural destruction / blocking cost / compression-induced hallucination——**citation（arXiv 2606.11213）未驗證，原理可信、paper 待核**。²⁷ [弱]
+- Just-in-time retrieval（保留 lightweight identifier、runtime 用 tool hydrate）是建議的 memory pattern，接受較慢 runtime exploration 換 cleaner context——Anthropic-sourced 半段強；學術 formalization（arXiv 2512.05470）未驗證。²³ [中]
+
+### 2.6 HITL、permissions、guardrails 與企業治理（governance-permissions）
+
+核心訊息：approval fatigue 是量測的一階風險；tiered permission + deny-first + 雙向 screening 是可重用 blueprint；LLM judge 不能是唯一 gate；guardrail 必須 pre-execution 攔截。
+
+- 使用者批准 ~93% 的 permission prompt，prompt 越多注意力越少——interrupt 只在 real-downside 動作觸發。²⁸ [強]（單一 vendor 內部統計，但 load-bearing。）
+- 兩段式 classifier：full pipeline ~0.4% FP 但 ~17% FN（「the honest number」）；classifier strips assistant reasoning/tool result 以防 self-justification——classifier 是 defense-in-depth 一層、永不替代 sandbox。²⁸ [強]
+- Tiered permission：(1) safe-tool allowlist auto-run、(2) in-project file ops（version-control 可審）、(3) transcript-classifier-gated shell/external-API/out-of-project——只有 tier-3 到 gate。²⁸ [強]
+- Defense-in-depth 雙向：input-side prompt-injection probe（screen tool OUTPUTS 進 context）+ output-side classifier（screen tool CALLS before execution），sandbox 作 containment。²⁸ [強]
+- HITL pause/resume 本質是 state-persistence/checkpointing：`interrupt()` 存 state 到 checkpoint、標記 interrupted、後續 `resume`；四種 decision type：approve / reject / review-and-edit-state / review-tool-call——對應 Cat 7 state mgmt + checkpointer，特別是「edit before proceeding」超越二元 approve/reject（LangGraph 單一 authoritative 來源）。²⁹ [強]
+- Runtime monitoring 必要：post-hoc sandbox benchmark（AgentHarm / ToolEmu / R-Judge）在 action 後評估、無法在 production 阻止 harm——guardrail/verification 必須 in-loop pre-execution 攔截（AgentMonitor attribution 為 extrapolation，引用前再核）。³⁰ [中]
+- R-Judge：8 個 LLM 的 risk-awareness「遠非完美」——LLM-as-guardrail 不能是唯一 control，需 rules-based + LLM-judge + human escalation。³¹ [強]
+- ToolEmu（LM-emulated sandbox）：human review 認 68.8% 的 ToolEmu-identified failure 為真實 agent failure——可作 red-team permission policy 的 pre-production pattern（為作者自家 human-eval）。³² [強]
+
+### 2.7 Observability、tracing 與 agent evaluation（observability-eval）
+
+核心訊息：pass^k 為主要指標；tracing 標準化在 OTel GenAI conventions；MAST 14 failure mode 作 negative-test catalog；加 fault/perturbation 軸 + behavioral consistency。
+
+- τ-bench pass^k 揭露 pass@1 隱藏的 reliability gap：GPT-4o ~61% pass@1 retail 但 pass^8 <25%；引入 pass^k 衡量跨 k 次 trial 的一致性。³³ [強]
+- Reliability 隨複雜度 super-linear 退化、對 pass@1 不可見；perturbation（ε=0.2：96.9%→88.1%）與 infra-fault（λ）軸造成額外大幅下降——建議 eval harness 加 ε / λ 軸。**注意：finding 把兩篇 2026 paper conflate，'23,392 episodes' 與所引 URL 似乎 mis-attributed；技術結論成立、citation precision 不成立。**³⁴ [中]
+- MAST 14 failure mode / 3 類，1,600+ trace、Cohen's Kappa = 0.88、NeurIPS 2025 spotlight——對應 Cat 11 / Cat 10 的 negative-test catalog。³⁵ [強]
+- MAST 附 validated LLM-as-a-Judge pipeline，自動分類 trace 到 14 mode——可作 SSE/loop trace 的 offline post-run failure-classifier blueprint（judge 準確率視為 paper-reported）。³⁶ [強]
+- OTel GenAI semantic conventions（CNCF / GenAI SIG since 2024-04）定義標準 agent span 階層：invoke_agent → chat → execute_tool；已被 Google Cloud / AWS / Azure / Datadog 採用——保持 provider-neutral、避免 vendor lock-in（conventions 仍部分 experimental）。³⁷ [強]
+- 具體 attribute：`gen_ai.request.model`、`gen_ai.usage.input_tokens`/`output_tokens`、`gen_ai.response.finish_reasons`（`stop` vs `tool_calls`），histogram `gen_ai.client.operation.duration` + `gen_ai.client.token.usage`——`finish_reasons`='tool_calls' vs 'stop' 與 while-true loop 的 stop_reason 分支 1:1。³⁷ [強]
+- Safe-by-default content capture：convention 預設不捕捉 prompt content / tool argument（可含敏感資料），須明確 opt-in `captureContent`——與 multi-tenant PII/GDPR + PIIRedactor 對齊（span 結構/token/latency/finish_reason always-on，payload 按 per-tenant policy gate、預設 off）。³⁷ [強]
+- Behavioral consistency 是獨立可量測軸（agent 會「跟自己不同意」），應與 task success 分開追蹤，配 pass^k——概念成立，特定 paper（arXiv 2602.11619）未獨立核實。³⁸ [中]
+
+### 2.8 Agent UX：trust、transparency、controllability、steerability（agent-ux-trust）
+
+核心訊息：trust 是 trajectory 而非固定狀態；graduated trust spectrum + deny-first 勝二元 autonomy；denial 是 routing signal 不是 hard stop；transparency 要 glanceable + 暴露 effective context。
+
+- Auto-approve rate 從 <50 session 的 ~20% 升到 750 session 的 >40%；整體 ~93% 批准——per-action confirmation 作為唯一 safety 機制「behaviorally unreliable」（已逐字對 arXiv 2604.14228 核實）。³⁹ [強]
+- Graduated trust spectrum（plan / default / acceptEdits / auto / dontAsk / bypassPermissions）+ deny-first：deny rule 無條件勝 allow rule，未識別動作 escalate 而非靜默執行，跨七層 parallel safety——deny rule 永遠 win、unknown tool call 預設 fail-closed 到 HITL。³⁹ [強]
+- Denial 是 routing signal 不是 hard stop：把 denial reason 餵回 loop 讓下一輪 re-plan（對應 verification-ESCALATE coach-retry）；sibling abort controller 在 Bash error 時殺掉 in-flight 子程序。³⁹ [強]
+- File-based append-only transparency（可讀/可編/可版本控制的 config + JSONL transcript）以表達力換 auditability + user control，支持 resume/fork/rewind；subagent 只回 summary text——對 DB-backed memory 是張力：用 inspector UI 暴露 agent 的 effective context（注入的 memory layer、compaction summary）。³⁹ [強]
+- 串流 discrete progress state（done/running/blocked/next）讓使用者及早抓問題；token-level streaming 的多 progress state 由 arXiv 2604.14228 獨立佐證——**但「going silent erodes trust」這句的 agentic-design.ai 來源未在 fetch 時找到，視為 weak/mis-sourced，核心想法靠 arXiv 半段存活**。⁴⁰ [弱（特定引述）/ 強（streaming-state 半段）]
+- Binary confidence indicator（confident / not sure）讓使用者決策更快、progressive autonomy 減摩擦——**none of the three specifics 在所引 agentic-design.ai 頁面找到，視為 unverified-as-stated；方向建議（coarse confident/uncertain 勝 raw score、earned-trust ramp）合理但勿引此來源**。⁴⁰ [弱]
+- Trust mis-calibration 來自未浮現的 LLM uncertainty；granular/contextual/actionable feedback + passage-level uncertainty visualization + multi-agent validation（MAVS）助 calibrate——Visible Language 為真實 peer-reviewed 期刊、單一來源未 corroborate。⁴¹ [中]
+- Capability amplification 有 comprehension cost：~27% Claude-Code-assisted task 是沒工具不會嘗試的工作，但 AI-assisted developer comprehension test 低 17%（兩個不同來源拼接：27% 為 Anthropic 內部 132-engineer 自陳、17% 引自獨立研究）——UX 要 build operator understanding、不只 throughput。³⁹ [強（兩數字已逐字核實，但勿當單一量測過度倚賴）]
+
+---
+
+## 三、跨維度主題 — 反覆出現的共識與張力
+
+**主題 1：Multi-agent 的價值是 compute，不是 orchestration 魔法——且何時「有害」可被路由規則明確化。**
+agent-loop、multi-agent、observability 三個維度一致：token usage 解釋 ~80% multi-agent 變異（²）、~15x 成本（²）、coupling-heavy 任務 single-agent 勝（³ ¹⁶）、decentralized swarm 放大錯誤 ~17.2x（¹⁴）。共識路由規則：**依 coupling 而非 capability 路由**——independent-thread/breadth-first → fork；shared-state/dependency-heavy → single bounded loop 或 handoff with shared memory。本專案把 subagent 當 explicit cost/budget 決策（surface 15x multiplier 進 audit/billing）有直接背書。
+
+**主題 2：Self-correction 的限制有清晰、可引用的分界——external verifiable signal。**
+tool-verification、planning-decomposition、governance、agent-ux 四個維度交會：intrinsic self-reflection 退化（¹⁷ ⁸ self-conditioning），但 key-condition verification（²⁰）、tool error（¹⁹）、denial-as-routing-signal（³⁹）這些 external signal 讓 correction 可靠。張力：verification agent 本身（LLM judge）也不可靠（R-Judge ³¹、17% FN ²⁸）。**解法是 defense-in-depth**：rules-based verifier（檢查 checkable condition）優先、LLM judge 次之、確定性 human escalation 兜底——而非把信心押在單一 model gate。
+
+**主題 3：Context rot 是真實且 length-driven，應對是分層、可審計、依風險排序的 compaction。**
+memory-context、planning-decomposition、agent-loop 三維度一致點名 context 管理為一級工程問題（²³ 為「#1 job」）。self-conditioning（⁸ ¹⁵）給了「為何要 prune failed branch」的實證。可量化目標帶來自 ACON（²⁵，已驗證）：~25–55% peak token 削減而不損準確率。張力：lossy LLM summarization 有 compression-induced hallucination（²⁷），對企業 audit 不友善——因此順序應為 **tool-result clearing → deterministic/typed eviction → 才 LLM summarization**。
+
+**主題 4：approval fatigue 與 transparency 的雙向張力——「太多 prompt」與「太少可見性」都侵蝕信任。**
+governance（²⁸ 93% 批准）與 agent-ux（³⁹ 同一 93% + auto-approve trajectory）一致：per-action confirmation 不可靠。但「going silent erodes trust」（⁴⁰，來源 weak）與 comprehension cost（³⁹，17% 較低）顯示反面：純黑箱 auto-execution 也有害。**綜合**：deny-first guardrail（少 prompt、高保護）+ glanceable progress streaming（多可見性、少 transcript 滑動）+ 暴露 effective context 的 inspector（build understanding）。
+
+**主題 5：long-horizon 失敗是 execution 問題——externalized state + bounded burst + rehydration 是跨維度共識。**
+planning-decomposition（⁸ execution-not-planning）、agent-loop（⁷ rehydration artifact）、memory-context（²³ note-taking）三維度收斂到同一架構結論，直接驗證本專案 bounded max_turns + cross-turn rehydration + compaction。附帶共識：**explicit task primitive（feature list / progress 檔 / DAG）是 load-bearing 的反 early-stop 機制**，本專案缺 CC-style TodoWrite 是真實 gap。
+
+**主題 6：empirical eval 必須超越 pass@1 / drive-through-once。**
+observability（³³ pass^k）與本專案既有 Drive-Through Acceptance 文化互補但不重疊：drive-through 證一次能用，pass^k 證跨重複 run 可靠。配 behavioral consistency（³⁸）、fault/perturbation 軸（³⁴）、MAST failure catalog（³⁵）形成完整 reliability science。
+
+---
+
+## 四、對本專案的具體建議（對應 11+1 範疇）
+
+### Cat 1 Orchestrator Loop (TAO/ReAct)
+- **吻合**：bounded single while-true loop 被 ¹ ⁸ 直接驗證為有實證的預設架構；receding-horizon（每 turn 從 fresh observation re-derive plan，cheap replanning ¹³）天然契合 stop_reason-driven loop。
+- **可採納 pattern**：每個 turn 錨定 goal/state（ReflAct ⁴）而非冗長 CoT；denial-as-routing-signal（³⁹）——HITL REJECT / guardrail block 時把 denial reason append 成 observation message 讓下一輪 re-plan。
+- **Thin spike**：sibling abort controller——在一批 tool call 中某個 error 時，殺掉同批 in-flight tool 執行而非讓 doomed batch 跑完（³⁹）。
+- **落差/gap**：缺 CC-style explicit task primitive（⁷ ¹⁰ ¹¹）；若新增，採 **DAG/dependency model（含 explicit blocking）優於 flat list**，更契合 fork/teammate/handoff + HITL gating。建議走 thin vertical spike → retrospective → design note。
+
+### Cat 2 Tool Layer
+- **可採納 pattern**：tool error structured reflection（¹⁹）——on tool error，把 STRUCTURED error（invocation / parameter / wrong-tool / failed-API taxonomy）餵回 loop 作 observation，而非「try again」；這正是 self-correction provably helps 的 regime（²⁰）。
+- **Thin spike**：tool-description lint/review step——精確、測過的 tool description 是 first-class artifact（²，~40% 提速數據點，質性強）。
+- **可採納 pattern**：golden-fixture + `@pytest.mark.benchmark` regression，mirror StableToolBench/MirrorAPI 的測試集（²²）量測 provider-neutral adapter 的 tool-call reliability。
+
+### Cat 3 Memory（5 scope × 3 time scale）
+- **吻合**：cross-turn rehydration 被 ⁷（progress artifact）+ ²³（structured note-taking）背書。
+- **可採納 pattern**：just-in-time / reference-based retrieval（²³）——存 lightweight identifier（path / query / ID），runtime 用 tool hydrate，而非 eager 注入所有 memory layer，減 token 壓力。
+- **Thin spike**：把 subagent return 契約固定為 condensed summary（1,000–2,000 token，²³），避免 detailed context 汙染 parent。
+
+### Cat 4 Context Mgmt（含 compaction / prompt caching）
+- **吻合**：active per-turn token budgeting + AP-7「Context Rot Ignored」被 ²³ 直接驗證；compaction ≥3-turn 門檻與 Anthropic「first lever」一致（¹⁰）。
+- **可採納 pattern（分層、依風險排序）**：(1) tool-result clearing 最先（²⁴，最低損、無同步 LLM 呼叫）→ (2) deterministic/typed eviction 用於需 auditability 處（²⁷，原理可信、citation 待核）→ (3) 才 lossy LLM summarization。
+- **可量化目標**：ACON（²⁵）給目標帶——compactor 應能削 ~25–55% peak token 而不損準確率；採「failure-driven guideline refinement」作 compactor 調參 loop；compaction 跑 cheap distilled model（>95% 保留、~99% 成本下降）契合 cost-tiered model policy。
+- **Thin spike（弱證據、當假設測量）**：把 compaction 暴露為 agent-invokable tool 在 safe task boundary 觸發（⁶，22.7% 數字僅 blog，當 hypothesis），對照現行 75k/≥3-turn 固定門檻——量測是否避免「切斷一輪 tool sequence」。
+- **Prompt construction 連動（Cat 5）**：lost-in-the-middle（²⁶）——把最相關 memory + 當前 task 放 context 邊緣，視 compaction 為縮短 recall 最弱的 middle。
+
+### Cat 5 Prompt Construction
+- **可採納 pattern**：positional ordering——decision-relevant 內容放 primacy/recency 位置（²⁶）；goal-state anchoring 入 system/turn prompt（⁴）。
+- **吻合**：centralized PromptBuilder（AP-8）與「prompt 組裝唯一入口」原則，配 memory layer 注入有 unit-test 驗證。
+
+### Cat 6 Output Parsing
+- **可採納 pattern**：以 `finish_reasons`（`stop` vs `tool_calls`）作 stop_reason 來源並標準化命名（³⁷），使 cost-attribution / compaction telemetry 可流入任何 APM。
+
+### Cat 7 State Mgmt（含 Reducer + transient/durable）
+- **吻合**：HITL pause/resume 本質是 checkpointing（²⁹）——pause/resume 需 durable state + checkpointer。
+- **可採納 pattern**：四種 HITL decision type（approve / reject / **review-and-edit-state** / review-tool-call，²⁹）作 resume API 契約；特別補上「edit before proceeding」超越二元 approve/reject。
+
+### Cat 8 Error Handling
+- **可採納 pattern**：tool error taxonomy（¹⁹）+ retry policy；bounded max_turns 作 compounding-error containment（¹⁸）。
+- **可採納 pattern**：模組級 failure attribution（memory/reflection/planning/action，¹²）餵入 structured replanning 而非 blind retry。
+
+### Cat 9 Guardrails & Safety
+- **可採納 pattern（first-class 要求）**：雙向 screening（²⁸）——prompt-injection probe on tool OUTPUTS + classifier on tool CALLS before execution，sandbox 作 containment。
+- **關鍵實作細節**：任何 LLM judge 要 **strip agent 自己的 reasoning/tool output** 出 judge context 以防 self-justification（²⁸）。
+- **保留意見**：LLM judge 不可為唯一 gate（³¹ R-Judge、²⁸ 17% FN）；deny rule 無條件勝 allow rule、unknown tool call fail-closed（³⁹）。
+- **Thin spike**：ToolEmu-style LM-emulated sandbox red-team permission policy（³²，~69% real-failure validity 作 calibration baseline）。
+
+### Cat 10 Verification Loops
+- **吻合**：verification-ESCALATE 要求真實 judge 失敗（非 self-reflection）被 ¹⁷ + ²⁰ 這對直接驗證——這是最 design-actionable 的 finding。
+- **可採納 pattern**：verifier 圍繞 **checkable condition** 建（schema satisfaction / required field / tool-arg constraint，²⁰），優先 RulesBasedVerifier + constraint-check，LLMJudge 用在準則明確處（¹⁸ 三條件）。
+- **可採納 pattern**：per-step verification（subagent return → lead synthesis 之間插 verifier，¹⁴），而非僅 final-only。
+- **Thin spike**：基於既有 LLMJudgeVerifier + Sprint 57.111 judge benchmark harness，建 offline LLM-as-a-Judge failure classifier，以 MAST 14 mode（³⁵ ³⁶）分類 persisted SSE/loop trace。
+
+### Cat 11 Subagent Orchestration（4 模式，無 worktree）
+- **吻合**：fork/teammate/handoff 的 summary-only return（²³）+ centralized orchestrator 拓樸（¹⁴ 收斂錯誤到 ~4.4x）被背書。
+- **可採納路由規則**：依 coupling 路由——independent/breadth-first → fork；dependency-heavy/shared-state → single loop（³ ¹⁶）；distractor domain <2 時不 fork（¹⁶ 的 threshold heuristic，視為 indicative）。
+- **可採納 pattern**：strip orchestrator routing/handoff metadata 出 worker context（¹⁶），給 forked subagent clean scoped context（避免 self-conditioning ¹⁵）。
+- **可採納 pattern**：把 subagent-spawn 當 value-gated + token-budgeted 決策，surface 15x multiplier 進 audit/billing（²）。
+
+### Cat 12 Observability / Tracing（cross-cutting）
+- **可採納 pattern（最高優先）**：標準化在 OTel GenAI semantic conventions（invoke_agent → chat → execute_tool span tree；`gen_ai.*` attribute，³⁷）——滿足 provider-neutrality（約束 3）、CNCF-backed、避免 bespoke schema。
+- **吻合**：`captureContent` 預設 off（³⁷）與 multi-tenant PII/GDPR + PIIRedactor 對齊——span 結構/token/latency/finish_reason always-on，payload capture 按 per-tenant policy gate。
+- **可採納 eval pattern**：pass^k（³³）作主要 metric；加 fault-injection（λ）+ perturbation（ε）軸（³⁴，注意 citation 已 conflate）；behavioral consistency check（重複同一 send N 次、diff loop trace，³⁸）抓 verification-ESCALATE / subagent routing 的 non-determinism——廉價地 leverage 既有 trace persistence。
+- **可採納 pattern**：以 MAST 3 類 / 14 mode 為 negative-test catalog instrument failure attribution（memory vs planning vs action，¹²）。
+
+### 與既有設計的整體 alignment 結論
+- **強 alignment（外部實證佐證既有方向）**：bounded-burst + rehydration（⁷ ⁸ ²³）、HITL pause/resume as checkpointing（²⁹）、Drive-Through Acceptance（⁷）、verification 需 external signal（¹⁷ ²⁰）、compaction ≥3 turns（¹⁰ ²⁵）、PII content-capture off-by-default（³⁷）。
+- **可採納的明確 gap**：(1) explicit task primitive（DAG 優於 flat list）；(2) Cat 12 標準化在 OTel GenAI conventions；(3) pass^k 入 eval harness；(4) 分層 compaction（tool-result clearing 先行）；(5) tool-description lint step。
+- **建議當假設測量、勿當目標的弱證據項**：agent-invokable compaction 的 22.7% 數字（⁶）、typed eviction 的 CWL paper（²⁷）、binary confidence UX（⁴⁰）。
+
+---
+
+## 五、證據品質與保留意見
+
+**Vendor / practitioner 來源（非 peer-reviewed 實證，方向可信但數字應 hedge）**
+- Anthropic engineering posts（multi-agent research system ²、effective harnesses ⁷ ¹⁰、context engineering ²³、Building Effective Agents ¹⁸、auto-mode ²⁸、tool-result clearing ²⁴）：first-party、廣泛引用、credible，但 90.2% / 15x / 4x / ~40% / 93% / 17% 多為 Anthropic 自家 internal eval 或單一 improvement cycle 的 self-report，是 directional / order-of-magnitude，非外部可重現 benchmark。
+- LangChain（multi-agent benchmark ¹⁶、interrupt HITL ²⁹）：credible practitioner / vendor docs，但 ¹⁶ 是單一 self-published vendor benchmark，distractor-domain threshold 視為 indicative，有 framing incentive。
+- Nicolas Bustamante blog（agent-controlled compaction ⁶）：**最弱來源**，22.7%-token-reduction-with-no-accuracy-loss 是單一 practitioner 無 published methodology / benchmark 的自陳；質性洞見成立、數字勿當已確立證據。
+
+**Unverified / mis-attributed citations（引用前必須再核）**
+- **arXiv 2606.11213（CWL / structured eviction，²⁷）**：ID = 2026-06（本月），fetch 未 corroborate，title / method 未確認——**原理可信，paper citation unconfirmed，勿當 authoritative 引用**。
+- **arXiv 2512.05470（file-system-as-memory，²³ 學術半段）**：未獨立核實（ID 為 2025-12 有效日期但 paper 未確認）；Anthropic-sourced 半段強，學術 citation 為弱環節。
+- **observability finding 的 ε/λ reliability（³⁴）**：finding 把兩篇 2026 paper conflate，'23,392 episodes' 與所引 URL（arXiv 2603.29231）似 mis-attributed（ε 數字應屬 ReliabilityBench arXiv 2601.06112）——**技術結論（加 ε/λ 軸）成立，citation precision 不成立**。
+- **arXiv 2601.22311（receding-horizon，¹³）與 2512.03560（RP-ReAct，⁵）與 2602.11619（behavioral consistency ³⁸）**：很新 / 未來日期 preprint，未獨立核實；底層原理（MPC-style replanning / planner-supervisor / consistency as distinct axis）合理，但 empirical strength 倚賴單篇 self-report。
+- **self-correction critical survey citation（²¹）**：URL（arXiv 2410.20513）對應「Self-correction is Not An Innate Capability」而非通常引用的 Pan et al. TACL critical survey（arXiv 2308.03188）；兩者被 conflate，substance 正確、一個 citation mislabeled。
+- **R-Judge AgentMonitor attribution（³⁰）**：「AgentMonitor uses an LLM to monitor and halt unsafe actions」讀來像 related-work extrapolation 而非 R-Judge 自身核心結論，引用前再核。
+- **self-conditioning term/attribution（multi-agent ¹⁵）**：term 與 attribution（指向 MAST URL）muddled，讀來更像 Spark-to-Fire 的 cascade theme，引用前 double-check。
+
+**特別標示 weak / mis-sourced（agent-ux）**
+- **agentic-design.ai 來源（⁴⁰，findings 5 & 6）**：「going silent erodes trust」「binary confidence 讓使用者決策更快」「autonomy without transparency creates friction」三項 specifics 在 fetch 該頁時 **未找到**，讀來 embellished / mis-attributed；**勿引用 binary-confidence「decided faster」為 established result**。方向建議（coarse confident/uncertain 勝 raw score、earned-trust ramp、glanceable progress streaming）仍合理，但 streaming-state 半段靠 arXiv 2604.14228（已逐字核實）獨立存活，非靠這些來源。
+
+**已獨立驗證 / 高信心（可放心引用）**
+- arXiv 2604.14228（Dive into Claude Code，³⁹ ⁴⁰）：20%→40% / 93% / 七 permission mode / deny-first / 27% / 17% 等多項已逐字對 paper 核實。
+- arXiv 2510.00615（ACON，²⁵）：WebSearch 驗證為真（Microsoft，有官方實作），26–54% peak-token-reduction + >95% retention + ~99% cost 由多個獨立 summary 佐證。
+- arXiv 2503.13657（MAST，³⁵ ³⁶）：真實、well-known、NeurIPS 2025；1,600+ trace / 7 框架 / 14 mode / Kappa 0.88 準確。
+- arXiv 2406.12045（τ-bench，³³）、arXiv 2310.01798（Cannot Self-Correct，¹⁷）、2024.emnlp-main.714（Key Condition Verification，²⁰）、arXiv 2406.16008（Lost/Found in the Middle，²⁶）、ToolEmu / R-Judge（³¹ ³²）：landmark / widely-replicated。
+- OTel GenAI conventions（³⁷）：真實、active CNCF SIG（conventions 仍部分 experimental，但架構建議 sound）。
+- arXiv 2509.09677（Long Horizon Execution，⁸）、2604.02460（Single vs Multi-Agent，¹）、2509.18847（Structured Reflection，¹⁹）：已 spot-check / WebSearch 驗證為真。
+
+**研究盲點**
+- 多數可靠性數字來自 Anthropic 自家 eval 或單篇 self-report，缺第三方獨立重現。
+- 2026 年 preprint（含 multi-agent error-cascade、reliability science、structured eviction）尚未被獨立 replicate，確切百分比（17.2x / 4.4x / 96.4% / 22.7% / 23,392）應引方向、hedge 數字。
+- enterprise multi-tenant 場景下的 pass^k / fault-injection 實證仍稀少——本專案的 trace persistence 反而是少數能廉價產生這類數據的位置。
+
+---
+
+## 六、來源清單（去重，僅列實際引用的真實 URL）
+
+1. https://arxiv.org/html/2604.02460v1 — Single-Agent LLMs Outperform Multi-Agent Systems on Multi-Hop Reasoning Under Equal Thinking Token Budgets (2026)
+2. https://www.anthropic.com/engineering/multi-agent-research-system — How we built our multi-agent research system (Anthropic, 2025)
+3. https://theaiengineer.substack.com/p/how-anthropic-built-multi-agent-deep — Anthropic's Multi-Agent Research Architecture Explained (2025)
+4. https://arxiv.org/pdf/2505.15182 — ReflAct: World-Grounded Decision Making in LLM Agents via Goal-State Reflection (2025)
+5. https://arxiv.org/abs/2512.03560 — Reason-Plan-ReAct: A Reasoner-Planner Supervising a ReAct Executor for Complex Enterprise Tasks (2025) [unverified]
+6. https://nicolasbustamante.com/blog/long-running-agent-engineering — Long Running Agent Engineering (Nicolas Bustamante, 2025) [weak — single blog]
+7. https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents — Effective harnesses for long-running agents (Anthropic, 2025)
+8. https://arxiv.org/html/2509.09677v3 — The Illusion of Diminishing Returns: Measuring Long Horizon Execution in LLMs (2025)
+9. https://www.emergentmind.com/topics/plan-then-execute-llm-agents — Plan-then-Execute LLM Agents (survey of Plan-and-Act, EAGLET, HiPlan) (2025) [aggregator]
+10. https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents — Effective context engineering for AI agents (Anthropic, 2025)
+11. https://venturebeat.com/orchestration/claude-codes-tasks-update-lets-agents-work-longer-and-coordinate-across — Claude Code's 'Tasks' update (VentureBeat, 2026) [single secondary source]
+12. https://arxiv.org/pdf/2509.25370 — Where LLM Agents Fail and How They Can Learn from Failures (2025) [counts unverified]
+13. https://arxiv.org/html/2601.22311 — Why Reasoning Fails to Plan: A Planning-Centric Analysis of Long-Horizon Decision Making in LLM Agents (2026) [paper unverified]
+14. https://arxiv.org/html/2603.04474v1 — From Spark to Fire: Modeling and Mitigating Error Cascades in LLM-Based Multi-Agent Collaboration (2026) [specific figures unverified]
+15. https://arxiv.org/html/2503.13657v1 — Why Do Multi-Agent LLM Systems Fail? (MAST) (2025)
+16. https://www.langchain.com/blog/benchmarking-multi-agent-architectures — Benchmarking Multi-Agent Architectures (LangChain, 2025) [single vendor benchmark]
+17. https://arxiv.org/abs/2310.01798 — Large Language Models Cannot Self-Correct Reasoning Yet (ICLR 2024)
+18. https://www.anthropic.com/research/building-effective-agents — Building Effective Agents (Anthropic, 2024)
+19. https://arxiv.org/pdf/2509.18847 — Failure Makes the Agent Stronger: Structured Reflection for Reliable Tool Interactions (2025)
+20. https://aclanthology.org/2024.emnlp-main.714/ — Large Language Models Can Self-Correct with Key Condition Verification (EMNLP 2024)
+21. https://arxiv.org/pdf/2410.20513 — Self-correction is Not An Innate Capability in Language Models (2024) [citation conflated with TACL survey]
+22. https://arxiv.org/html/2507.21504v1 — Evaluation and Benchmarking of LLM Agents: A Survey (2025) [API count approximate]
+23. https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents — (同 10)
+24. https://platform.claude.com/cookbook/tool-use-context-engineering-context-engineering-tools — Context engineering: memory, compaction, and tool clearing (Claude Cookbook, 2025)
+25. https://arxiv.org/html/2510.00615 — ACON: Optimizing Context Compression for Long-horizon LLM Agents (2025) [verified]
+26. https://arxiv.org/abs/2406.16008 — Found in the Middle: Calibrating Positional Attention Bias Improves Long Context Utilization (2024)
+27. https://arxiv.org/html/2606.11213 — Beyond Compaction: Structured Context Eviction for Long-Horizon Agents (2026) [paper unverified]
+28. https://www.anthropic.com/engineering/claude-code-auto-mode — How we built Claude Code auto mode (Anthropic, 2025)
+29. https://www.langchain.com/blog/making-it-easier-to-build-human-in-the-loop-agents-with-interrupt — Making it easier to build human-in-the-loop agents with interrupt (LangChain, 2024)
+30. https://arxiv.org/html/2401.10019v3 — R-Judge: Benchmarking Safety Risk Awareness for LLM Agents (2024) [AgentMonitor attribution to verify]
+31. https://aclanthology.org/anthology-files/anthology-files/pdf/findings/2024.findings-emnlp.79.pdf — R-Judge (EMNLP 2024 Findings)
+32. https://openreview.net/forum?id=GEcwtMk1uA — Identifying the Risks of LM Agents with an LM-Emulated Sandbox (ToolEmu) (2024)
+33. https://arxiv.org/abs/2406.12045 — τ-bench: A Benchmark for Tool-Agent-User Interaction in Real-World Domains (2024)
+34. https://arxiv.org/pdf/2603.29231 — Beyond pass@1: A Reliability Science Framework for Long-Horizon LLM Agents (2026) [citation conflated; ε figures likely from ReliabilityBench]
+35. https://arxiv.org/abs/2503.13657 — Why Do Multi-Agent LLM Systems Fail? (MAST taxonomy) (2025)
+36. https://github.com/multi-agent-systems-failure-taxonomy/MAST — MAST GitHub (2025)
+37. https://opentelemetry.io/blog/2026/genai-observability/ — Inside the LLM Call: GenAI Observability with OpenTelemetry (2026)
+38. https://arxiv.org/pdf/2602.11619 — When Agents Disagree With Themselves: Measuring Behavioral Consistency in LLM-Based Agents (2026) [paper unverified]
+39. https://arxiv.org/html/2604.14228v1 — Dive into Claude Code: The Design Space of Today's and Future AI Agent Systems (2026) [verified verbatim]
+40. https://agentic-design.ai/patterns/ui-ux-patterns — UI/UX & Human-AI Interaction — Agentic Design Patterns (2025) [weak — specific quotes not found on page]
+41. https://www.visible-language.org/Issue-59-2/addressing-uncertainty-in-llm-outputs-for-trust-calibration-through-visualization-and-user-interface-design.pdf — Addressing Uncertainty in LLM Outputs for Trust Calibration (Visible Language 59.2, 2025) [single source, uncorroborated]

--- a/claudedocs/5-status/README.md
+++ b/claudedocs/5-status/README.md
@@ -3,10 +3,13 @@
 **Purpose**: `claudedocs/5-status/` 全部文件的總索引（每檔 1 行主題 + 狀態），解決「靠檔名認不出主題」問題。
 **Category / Scope**: Status index (cross-cutting)
 **Created**: 2026-06-12
-**Last Modified**: 2026-06-12
+**Last Modified**: 2026-06-22
 **Status**: Active
 
 > **Modification History**
+> - 2026-06-22: 群組 2 +1 行 — `ai-agent-harness-consolidated-analysis-20260622.md`(三份綜合主文件,標為入口)
+> - 2026-06-22: 群組 2 +2 行 — `ai-agent-harness-market-research-panorama-20260622.md`(2026 外部市場/學術研究全景 14 findings)+ `ai-agent-harness-research-vs-v2-mapping-20260622.md`(14 findings × V2 落地對照 + 5 大機會)
+> - 2026-06-19: 群組 2 +1 行 — `cc-long-running-loop-source-analysis-20260619.md`(CC v2.1.88 長運行 loop 力學剖析,接 cc-parity + cc-source-blueprint 三份互補鏈）
 > - 2026-06-12: Initial creation (docs-reorg REFACTOR-007) — 7 主題群索引 + 命名規則
 
 ---
@@ -57,11 +60,15 @@
 | `v2-overall-progress-gap-assessment-20260606.md` | 11+1 範疇整體進度 gap 評估 | Active |
 | `agent-harness-cc-parity-20260607.md` | CC v2.1.88 部件級對照（核心 loop 達標 + C 類 5 缺口）| Active（local，未 commit）|
 | `cc-source-blueprint-pause-resume-phases-20260608.md` | CC 源碼證偽：非 6-phase、無 durable resume | Active（local，未 commit）|
+| `cc-long-running-loop-source-analysis-20260619.md` | CC v2.1.88 `query.ts` 逐段親讀：agent loop 為何能長運行（無 maxTurns + 5 層壓縮管線 + 7 continue 自癒站點 + 6hr 重試/30s 心跳 + 2 自主續跑引擎）+ 何時停（end_turn 唯一退出信號 / maxTurns / 中斷 / 不可恢復錯誤 / permission 特例）| Active |
 | `v2-architecture-flow-visualization-20260607.md` | V2 架構 / 流程視覺化 | Active（local，未 commit）|
 | `runtime-verification-20260530.md` | V2 runtime 實證驗證（實驗證據）| 快照 |
 | `subagent-tree-relay-diagnostic-20260617.md` | `AD-Subagent-Child-Event-SSE-Relay` drive-through 診斷：node-level (57.95) + depth-1 (57.96) 已修；depth>1 = YAGNI-by-design | ✅ AD CLOSED |
 | `chat-v2-agent-loop-capability-drivethrough-20260618.md` | chat-v2 主流量 agent loop 子能力多輪 drive-through（工具/subagent/verification/HITL/escalate 暫停/handoff/injection/long-run/compaction）+ CC 長運行誠實評估（§3 三缺口）| Active |
 | `task-primitive-thin-spike-eval-20260618.md` | 缺口①評估：顯式 task primitive（類 CC TodoWrite）—— 推薦做 thin spike（DB-backed store + rehydrate + drive-through gate）；非冗餘、非邊際、與 max_turns/調度器缺口正交 | Active（評估） |
+| `ai-agent-harness-consolidated-analysis-20260622.md` | ⭐ **三份綜合主文件（讀這一份 = 讀完三份）**：執行摘要 9 條 + 8 維度全景 + 11+1 範疇落地對照（✅/⚠️/❌/💡 + file:line）+ 6 跨維度主題 + 8 優先機會 + 證據品質 + thinking×self-conditioning 矛盾調和 | ⭐ 入口 |
+| `ai-agent-harness-market-research-panorama-20260622.md` | 2026 外部市場/學術研究全景（中立）：14 findings（reliability≠capability、self-conditioning、任務拆解最高槓桿、naive memory 有害、6 種抗注入結構模式…）+ 證據強度分級 + 30 來源 | Active（外部研究·細節後備） |
+| `ai-agent-harness-research-vs-v2-mapping-20260622.md` | 上述 14 findings × V2（11+1 範疇 + server-side governance + max_turns=8）落地對照（✅/⚠️/❌/💡）+ 5 大機會（任務原語 / 可靠性實測 / 安全結構限制 / verify 清 context / 壓縮階梯）| Active（對照） |
 
 ## 群組 3｜Cat 10 Verification 量測
 

--- a/claudedocs/5-status/ai-agent-harness-consolidated-analysis-20260622.md
+++ b/claudedocs/5-status/ai-agent-harness-consolidated-analysis-20260622.md
@@ -1,0 +1,304 @@
+# AI Agent Harness — 使用體驗與工程可靠性綜合分析(2024–2026)
+
+**Purpose**: 把同日 3 份 deep-research 產出整合成**單一完整、全面的主分析文件**:中立市場/學術全景(實證方向)+ V2 11+1 範疇落地對照(✅/⚠️/❌/💡 + file:line)+ 跨維度主題 + 優先機會 + 證據品質。讀這一份 = 讀完三份的綜合。
+**Category / Scope**: Status / Consolidated research + V2 mapping (cross-cutting)
+**Created**: 2026-06-22
+**Last Modified**: 2026-06-22
+**Status**: Active (snapshot)
+**Grounding**: (1) claim 級對抗驗證 deep-research(28 claim / 14 findings)+(2) 8 角度輕驗證 deep-research(41 來源 / 66 findings)+(3) 3 個 Explore agent 對 `backend/src/agent_harness/` 的 file:line 勘查 + 本項目權威文件(task-primitive eval / cc-long-running / cc-parity)。
+
+> **Modification History**
+> - 2026-06-22: Initial creation — 整合 panorama + mapping + ux-research 三份為單一主文件;調和 self-conditioning×thinking 矛盾;統一信度系統
+
+> **本文整合的 3 份來源(均保留,作為細節/grounding 後備)**
+> - [`ai-agent-harness-market-research-panorama-20260622.md`](ai-agent-harness-market-research-panorama-20260622.md) — 中立全景,**28 條 claim 級對抗驗證**(信度最嚴)
+> - [`ai-agent-harness-research-vs-v2-mapping-20260622.md`](ai-agent-harness-research-vs-v2-mapping-20260622.md) — 14 findings × V2,**file:line grounding**(落地最強)
+> - [`../1-planning/agent-harness-ux-research-20260622.md`](../1-planning/agent-harness-ux-research-20260622.md) — 8 角度 / 41 來源,**per-Cat 可操作 pattern + 證據品質審查最細**
+
+---
+
+## 0. 怎麼讀(統一信度系統)
+
+兩次 research 用了不同分級,本文統一為:
+
+| 標記 | 意義 | 證據門檻 |
+|------|------|---------|
+| 🟢 **實證** | arXiv 受控實驗 / 大規模數據,且已 spot-check 或 claim 級對抗驗證通過 | 高 |
+| 🟡 **共識/自報** | 廠商 blog / 單篇 preprint self-report / 觀點性最佳實踐 | 中(方向可信,數字 hedge) |
+| 🔴 **開放/爭議** | 缺對照實驗、citation 未核實,或對抗驗證否決 | 低(當假設,勿當結論) |
+
+落地對照標記:✅ 已具備 · ⚠️ 部分 · ❌ 缺口 · 💡 機會。
+
+> ⚠️ **全文通則**:多數「可靠性數字」(90.2% / 15× / 93% / 40% / 22.7% / 17.2x)來自 Anthropic 自家 eval 或單篇 preprint self-report,是 **directional / order-of-magnitude,非外部可重現 benchmark**。引用前先讀 §6 證據品質。
+
+---
+
+## 1. 執行摘要
+
+截至 2026 年,改善 agent 系統「使用體驗」與「工程可靠性」的主戰場,已從「**能不能做**」轉向「**能不能可靠地長時間做**」。九條最高價值且有(不同強度)實證支持的方向:
+
+1. **Bounded single TAO/ReAct loop 是有實證背書的預設架構**;multi-agent 的優勢主要來自 aggregate compute(token usage 單獨解釋 ~80% 變異)而非 orchestration 魔法,subagent 應 **gate 在 task coupling + token budget 之後**,而非反射式提升準確率。🟢
+2. **長程任務失敗主要是 EXECUTION 而非 PLANNING 問題**——即使給對的 plan + knowledge,單步近乎完美的模型仍在 ~15 turns 內掉到 50% 以下;更好的 planner 救不了多輪退化,**harness 必須外部化狀態 + 在每個 bounded burst 重新 ground**。🟢
+3. **Reliability ≠ Capability,且兩者隨任務時長系統性發散**;`pass^k`(k 次重複一致性)應成為平台主要 eval 指標,而非單次 `pass@1` / drive-through-once(τ-bench:GPT-4o ~61% pass@1 但 pass^8 <25%)。🟢
+4. **Self-correction 必須由 EXTERNAL verifiable signal 驅動**(tool error / test pass-fail / key-condition check / 獨立 judge);裸 re-prompt 不只中性、會把對的答案改錯。ICLR2024「Cannot」× EMNLP2024「Can with Key-Condition」是可引用的分界線。🟢
+5. **Self-conditioning(自己的錯誤留在 context 招致更多錯誤)不被 model scale 修好**——retry / verification 重試**不能把失敗 trace 留在 context**。🟢(但「thinking 完全消除 self-conditioning」是 overclaim,見 §7)
+6. **Context rot 是 length-driven**(非只 relevance-driven);compaction 應**分層、依風險排序、有量化目標帶**:tool-result clearing → deterministic eviction → 才 LLM summarization(ACON:削 26–54% peak token 不損準確率)。🟢
+7. **安全要「限制(restrict)而非僅偵測(detect)」**——agent 攝入不可信輸入後,須在**結構上**使其無法觸發有副作用動作(6 種抗注入設計模式);偵測式 guardrail(regex / LLM judge)「inherently brittle」,LLM judge 不能是唯一 gate。🟢
+8. **Approval fatigue 是已量測的一階風險**:使用者批准 ~93% permission prompt → HITL gate 只在高 blast-radius(tier-3)動作觸發,配 **deny-first** guardrail 而非逐動作確認。🟡(單一 vendor 統計但 load-bearing)
+9. **Cat 12 tracing 應標準化在 OpenTelemetry GenAI semantic conventions**(invoke_agent → chat → execute_tool;content capture 預設 off),天然對齊 provider-neutrality + multi-tenant PII/GDPR。🟢
+
+**對 V2 的一句話**:V2 在**可靠性「機械底座」與「企業治理」上普遍領先研究的範例**(durable HITL pause、多租戶 guardrail、5-scope memory、drive-through 文化),但在**長程可靠性的「實測驗證(pass^k)」、「結構化任務脊椎(task primitive)」、「安全結構限制」、「壓縮階梯化」、「OTel 標準化」上有明確空缺**——恰好都是研究指出的高槓桿區。
+
+---
+
+## 2. 研究全景(8 維度,中立)
+
+### 2.1 Agent loop 架構與控制模式 🟢
+- 相同 thinking-token budget 下,single-agent 在 multi-hop reasoning **持平或略勝** sequential MAS(FRAMES 0.680 vs 0.670;MuSiQue 4-hop 0.407 vs 0.320)——margin 小,正確描述是「match or modestly beats」🟢
+- Agent = **LLM 在環境回饋下於 `while`-loop 用工具**;每步取 **ground truth**(工具結果/程式執行)評估進度。Anthropic 二分:**workflow**(預定義 code path)vs **agent**(LLM 動態自主)🟢
+- 架構由 task 決定:**「the task picks the architecture」**——isolated subagent 適合 independent/parallel,shared-state/dependency-heavy 任務會 break 🟢
+- 強模型上 plan-then-act 持平或略勝 interleaved ReAct;goal-state reflection(ReflAct)勝 baseline ~33.1% → 建議每 turn 錨定 goal/state 而非冗長 CoT 🟡
+- End-to-end behavioral verification 是獨立必要的 loop step(agent 常改完 code 卻沒注意 feature 沒 work)→ 獨立佐證 drive-through 約束 🟡
+
+### 2.2 Intent / Planning / Task decomposition 🟢
+- **長程退化即使給對 plan + knowledge 仍發生**(Qwen3-32B H₀.₅ ~15 turns;frontier without thinking 多在 ~4 步失敗)🟢
+- **Self-conditioning**:注入更多 prior error 單調惡化 turn-100 準確率,200B+ 仍易受 🟢
+- **Thinking/CoT 是執行長度的最大單一槓桿**:GPT-5(thinking)維持 2,176 sequential steps、Claude-4 Sonnet 432 steps,without thinking「a few steps」🟢 → 支持 provider-neutral thinking-budget toggle 作一級旋鈕。**但「CoT 完全消除 self-conditioning」是 overclaim(見 §7,降為 🔴 開放)**
+- **Explicit externalized task primitive 是 load-bearing 的反 early-stop 機制**:Anthropic harness 用 initializer 寫 200+ feature JSON(全預標 failing 作完成準則)+ progress 檔 + one-feature-at-a-time + 結構性拒絕 early termination 🟡;Claude Code「Tasks」以 **DAG(含 explicit blocking)** 建模,比 flat list 更具表達力 🟡
+- Receding-horizon replanning(只 commit 下一個 action、每 transition 後 replan)在 noisy 評估下勝 brittle 長期 commitment 🟡(原理強、特定 paper 未核實)
+
+### 2.3 Multi-agent orchestration 與 delegation 🟢🟡
+- Orchestrator-worker(Opus 4 lead + Sonnet 4 subagents)勝 single Opus 4 達 **90.2%**,但 **token usage 解釋 ~80% 變異**🟡(內部不可重現 eval)
+- 成本:multi-agent **~15× chat token**、single ~4×;只建議 outcome value 超過 token cost 時用 🟢
+- 不適合 tightly-coupled work(多 inter-agent dependency / 需共享 context);Anthropic 點名 **coding 為弱契合** 🟢
+- 拓樸:decentralized/swarm 放大錯誤 ~17.2x,centralized orchestrator 收斂到 ~4.4x 🟡(單篇 2026 preprint,數字未核實);per-step verification 勝 final-only 🟡
+- **MAST**(1,600+ trace、7 框架、14 failure mode、3 類:spec/design、inter-agent misalignment、verification/termination):**多數失敗是 orchestration/spec bug 而非 base-model 弱** 🟢(NeurIPS 2025,Kappa 0.88)
+- τ-bench:0–1 distractor 時 single-agent 勝 supervisor/swarm,2+ distractor 才反轉;supervisor 損失來自 translation overhead + handoff message 汙染 worker context → **strip routing/handoff metadata 出 worker context** 🟡
+- **Handoff = tool call 機制**:OpenAI Agents SDK 把委派做成 `transfer_to_xxx` tool call,重用一般 tool-use 機制 🟢
+- 用模型改寫 flawed tool description → 後續任務完成時間 **~40% 下降** 🟡(單一 Anthropic 數據點,量級當 anecdotal)
+
+### 2.4 Tool execution + verification / self-correction 🟢
+- **Intrinsic self-correction(無 external signal)一致失敗、常退化準確率**,會把對的答案改錯(ICLR 2024)🟢
+- **分界線 = key-condition verification 的存在**:有則 LLM 可 self-correct,無則不能(EMNLP 2024)→ verifier 應檢查 task 的 **key constraint**(schema / required field / tool-arg constraint),而非「這答案好嗎」🟢
+- Evaluator-optimizer 僅在三條件成立時建議:有明確準則 / 迭代有可量測價值 / evaluator 能給有用回饋 🟡(Anthropic guidance)
+- 對 tool error 的 **structured reflection**(先診斷具體錯誤再 retry;taxonomy:invocation / parameter / wrong-tool / failed-API)可量測強化可靠性(BFCL v3:Qwen3-4B 16.25%→20.75%;Repair@5 6.8%→26.4%)🟢——**但增益部分來自 RL training,scope 限 trained-reflection regime**
+- Tool-use eval 已成熟到 mirror-real-API 規模(StableToolBench / MirrorAPI ~7,000+ API)→ 支持 golden-fixture + `@pytest.mark.benchmark` regression 🟡
+
+### 2.5 Long-running:memory + context / compaction 🟢
+- **Context rot**:window token 數增加 → recall 準確率下降(歸因 n² attention + 多在較短序列訓練);Anthropic 稱 context engineering 為 agent engineer「#1 job」🟢
+- 三 named pattern:(1) **compaction**(摘要近滿後 reinitiate,保留架構決策/未解 bug/實作細節)、(2) **structured note-taking**(外部 memory)、(3) **sub-agent isolation**(只回 1,000–2,000 token 摘要)🟢
+- **Tool-result clearing 是最安全、最低風險的 compaction**(已是 Claude Developer Platform 一級 feature)🟢
+- **ACON**(arXiv 2510.00615,Microsoft,已驗證):15+ step agent 削 **26–54% peak token** 且 success 持平或改善;distilled compressor 保留 **>95%** 效能、**~99%** API 成本下降 → 支持 per-tenant/turn 跑便宜 distilled model 的 compactor 🟢
+- **Lost-in-the-middle**:U-shape positional bias(primacy + recency over middle),可 calibrate → 把最相關 memory + 當前 task 放 context 邊緣 🟢
+- **Just-in-time retrieval**(保留 lightweight identifier、runtime 用 tool hydrate)是建議的 memory pattern 🟡
+- Naive episodic memory scratchpad(每輪注入、無限成長)**從不改善長程,還傷害 10 模型中 6 個** 🟢——⚠️ 限「naive episodic」+「長程」,**不否定** scoped / 有 expiration / 階層摘要的重設計記憶
+- Structured/typed eviction(typed dependency graph + deterministic graduated eviction)被提議優於 summarization 🔴(citation 2606.11213 未核實,原理可信)
+
+### 2.6 HITL / permissions / guardrails / 企業治理 🟢🟡
+- **Approval fatigue**:使用者批准 **~93%** permission prompt → interrupt 只在 real-downside 動作觸發 🟡(單一 vendor 內部統計,load-bearing)
+- 兩段式 classifier:full pipeline ~0.4% FP 但 **~17% FN**(「the honest number」)→ **classifier 是 defense-in-depth 一層,永不替代 sandbox** 🟢
+- **Tiered permission**:(1) safe-tool allowlist auto-run、(2) in-project file ops(version-control 可審)、(3) transcript-classifier-gated shell/external-API → **只有 tier-3 到 gate** 🟡
+- **Defense-in-depth 雙向**:input-side prompt-injection probe(screen tool OUTPUTS 進 context)+ output-side classifier(screen tool CALLS before execution),sandbox 作 containment 🟡
+- **安全核心原則:「限制非偵測」**——agent 攝入不可信輸入後,須在結構上使其無法觸發有副作用動作。**6 種抗注入設計模式**(各以 agent 通用性換安全保證):Action-Selector / Plan-Then-Execute / LLM Map-Reduce / **Dual LLM**(privileged + quarantined 分離、結果符號化)/ Code-Then-Execute / Context-Minimization 🟢(arXiv 2506.08837,AgentDojo/Microsoft)
+- **LLM judge 不能是唯一 gate**(R-Judge:8 LLM risk-awareness「遠非完美」)→ rules-based + LLM-judge + 確定性 human escalation 🟢
+- HITL pause/resume **本質是 checkpointing**;四種 decision type:approve / reject / **review-and-edit-state** / review-tool-call(「edit before proceeding」超越二元)🟢
+- Runtime monitoring 必要:post-hoc sandbox benchmark(AgentHarm/ToolEmu/R-Judge)在 action 後評估、無法 production 阻止 harm → guardrail 必須 **in-loop pre-execution 攔截** 🟡
+
+### 2.7 Observability / tracing / evaluation 🟢
+- **pass^k 為主要指標**:τ-bench GPT-4o ~61% pass@1 retail 但 **pass^8 <25%** 🟢
+- Reliability 隨複雜度 **super-linear 退化、對 pass@1 不可見**;建議 eval harness 加 perturbation(ε)+ infra-fault(λ)軸 🟡(citation 有 conflate,技術結論成立)
+- **OTel GenAI semantic conventions**(CNCF SIG since 2024-04):標準 span 階層 invoke_agent → chat → execute_tool;`gen_ai.*` attribute;**`finish_reasons`=`tool_calls` vs `stop` 與 while-true loop stop_reason 1:1**;**content capture 預設 off**(`captureContent` opt-in)對齊 PII/GDPR 🟢
+- **MAST 14 failure mode** 作 negative-test catalog;附 validated LLM-as-a-Judge pipeline 可自動分類 trace 🟢
+- Behavioral consistency 是獨立可量測軸(agent 會「跟自己不同意」),應與 task success 分開追蹤 🟡
+
+### 2.8 Agent UX:trust / transparency / controllability 🟢🔴
+- **Auto-approve rate 從 <50 session 的 ~20% 升到 750 session 的 >40%**;整體 ~93% 批准 → per-action confirmation 作唯一 safety 機制「behaviorally unreliable」🟢(arXiv 2604.14228 已逐字核實)
+- **Graduated trust spectrum**(plan / default / acceptEdits / auto / dontAsk / bypassPermissions)+ **deny-first**:deny rule 無條件勝 allow rule,未識別動作 escalate 而非靜默執行(fail-closed)🟢
+- **Denial 是 routing signal 不是 hard stop**:把 denial reason 餵回 loop 讓下一輪 re-plan(對應 verification-ESCALATE coach-retry)🟢
+- File-based append-only transparency(可讀/可編/可版本控制 config + JSONL transcript)以表達力換 auditability + user control → 對 DB-backed memory 是張力:**用 inspector UI 暴露 agent 的 effective context**(注入的 memory layer、compaction summary)🟢
+- 串流 discrete progress state(done/running/blocked/next)讓使用者及早抓問題 🟡(部分特定引述 weak/mis-sourced,streaming-state 半段靠 arXiv 2604.14228 存活)
+- Capability amplification 有 comprehension cost:~27% Claude-Code-assisted task 是沒工具不會嘗試的工作,但 AI-assisted developer comprehension test 低 17% → **UX 要 build operator understanding,不只 throughput** 🟢(兩數字已逐字核實,但勿單一過度倚賴)
+- Binary confidence indicator / 「going silent erodes trust」🔴(agentic-design.ai 來源 specifics 未在頁面找到,方向合理但勿引此來源)
+
+---
+
+## 3. V2 落地對照(11+1 範疇,✅/⚠️/❌/💡 + file:line)
+
+> 驗證層級:**程式碼 grounding(file:line)**,非 drive-through。標 ✅ 者若要宣稱「使用者真的能用」,以 `chat-v2-agent-loop-capability-drivethrough-20260618.md` 為準。
+
+### 計分卡
+
+| 範疇 | 判定 | 一句話 |
+|------|------|--------|
+| Cat 1 Orchestrator Loop | ✅ + 💡 | while-true + ground truth 回注齊;缺 task primitive |
+| Cat 2 Tool Layer | ✅ + 💡 | JSON-schema ToolSpec + Docker sandbox 硬化;可加 structured-error reflection + tool-desc lint |
+| Cat 3 Memory | ✅⚠️ | 5-scope × 3-timescale(semantic STUB);避開 naive scratchpad,但每輪檢索有 overhead |
+| Cat 4 Context Mgmt | ⚠️ + 💡 | 單層 compaction + masking + prompt cache;缺分層階梯 + 量化目標 |
+| Cat 5 Prompt Construction | ✅ + 💡 | 單一 PromptBuilder 入口;可加 positional ordering |
+| Cat 6 Output Parsing | ✅ | native tool calls;可標準化 finish_reasons |
+| Cat 7 State Mgmt | ✅ | transient/durable 分離 + checkpointer;可補 edit-before-proceed |
+| Cat 8 Error Handling | ✅⚠️ | retry matrix + circuit breaker + budget;教練式重試但 self-conditioning 殘留風險 |
+| Cat 9 Guardrails & Safety | ⚠️ + 💡 | 混合層防線(含 regex 偵測);可往「結構限制」6 模式升級 |
+| Cat 10 Verification | ✅ + 💡 | in-loop verify gate + self-correction;可改 key-condition verifier + pass^k |
+| Cat 11 Subagent | ✅ + 💡 | FORK/TEAMMATE/AS_TOOL 真子 loop,深度=1;可加 coupling-based 路由 + clean context |
+| Cat 12 Observability | ✅ + 💡 | TraceContext + OTel wrapper;可標準化在 GenAI semantic conventions |
+
+### Cat 1 — Orchestrator Loop ✅ + 💡
+- ✅ 主迴圈 `while True:` 由 stop_reason 驅動(`loop.py:2074`),非固定步 pipeline → 避開 AP-1;工具結果 `Message(role="tool")` 回注 + `turn_count++` continue(`loop.py:2791-3110`)= 每步 ground truth
+- ✅ 機械底座 = 研究的「邊界重啟」:`max_turns=8` 有界爆發(`handler.py:710`;loop ctor 預設 50 `loop.py:323`)+ 跨輪 rehydration(`DBMessageStore.load()` `message_store.py:93-113`、`loop.py:1937-1947`)
+- ❌💡 **缺 explicit task primitive**(`task-primitive-eval` §1.2:無 `LoopState.plan` / `tasks:[{id,status}]`)→ 研究發現 2.2 指其為 load-bearing 反 early-stop;若做,**DAG(含 explicit blocking)優於 flat list**,契合 fork/handoff + HITL gating;走 thin spike(DB-backed store + run-start rehydrate)
+- 💡 可採納:每 turn 錨定 goal/state(ReflAct)而非冗長 CoT;denial-as-routing-signal(HITL REJECT/guardrail block 把 denial reason append 成 observation 讓下輪 re-plan);sibling abort controller(同批 tool 一個 error 殺掉同批 in-flight)
+
+### Cat 2 — Tool Layer ✅ + 💡
+- ✅ ToolSpec = JSON Schema Draft 2020-12 register-time 驗證(`registry.py`);DockerSandbox 硬化(`--network=none`/`--cap-drop=ALL`/`read-only`/uid=65534/pids-limit `sandbox.py:219-392`);risk level + ToolHITLPolicy(`hitl.py`)
+- 💡 可採納:**tool error structured reflection**——on error 把 STRUCTURED error(invocation/parameter/wrong-tool/failed-API taxonomy)餵回 loop 作 observation(這正是 self-correction provably helps 的 regime);**tool-description lint/review step**(~40% 提速數據點,質性強);golden-fixture + `@pytest.mark.benchmark` 鏡像 StableToolBench
+
+### Cat 3 — Memory ✅⚠️
+- ✅ 5 scope(system/tenant/role/user/session)× 3 time scale(`memory/_abc.py:46-66`);**非有害 naive scratchpad**:summary 上限 200 字元 + per-turn 2000-token budget cap(低 confidence 先砍 `builder.py:246-257`、`453-520`)= 研究建議的「scoped + expiration + 預算化」重設計
+- ⚠️ 仍付每輪檢索+注入成本(query-time 固定檢索);**semantic time scale 是 STUB**(Qdrant 回空,51.2)→ 實際只有 2 個 time scale 運作
+- 💡 可採納:**just-in-time / reference-based retrieval**(存 identifier,runtime 用 tool hydrate);固定 subagent return 契約為 1,000–2,000 token condensed summary
+
+### Cat 4 — Context Mgmt ⚠️ + 💡(高優先)
+- ✅ StructuralCompactor(`structural.py:104-207`)+ observation masking(舊工具結果墓碑化 `observation_masker.py`)+ prompt caching(`cache_manager.py:49-127`,tenant-first hash)
+- ⚠️ **單層**:token>75% **或** turn>30(`compactor/_abc.py:60-74`),chat 還要 ≥3 user turns 才實際壓。研究 + cc-long-running 都指出 CC 是 **5 層階梯**
+- 💡 **分層、依風險排序**(研究強共識):(1) tool-result clearing 最先(最低損、無同步 LLM 呼叫)→(2) deterministic/typed eviction(審計友善)→(3) 才 lossy LLM summarization;**量化目標帶 ACON 削 ~25–55% peak token 不損準確率**;compaction 跑 cheap distilled model(對應 multi-model profile)
+- 💡 條件性:5 層對短 chat 是過度工程,**只在走長 autonomous task 時才需要**(cc-long-running 已點明「放寬 max_turns 前先補壓縮階梯」)
+
+### Cat 5 — Prompt Construction ✅ + 💡
+- ✅ 單一 PromptBuilder 入口(`builder.py:169-351`,AP-8),memory layers 注入有測試
+- 💡 可採納:**positional ordering**——decision-relevant 內容放 primacy/recency(lost-in-the-middle);goal-state anchoring 入 system/turn prompt
+
+### Cat 6 — Output Parsing ✅
+- ✅ native tool calls、無 regex(`parser.py:56-98`)
+- 💡 以 `finish_reasons`(`stop` vs `tool_calls`)作 stop_reason 來源並標準化命名(OTel),使 telemetry 可流入任何 APM
+
+### Cat 7 — State Mgmt ✅
+- ✅ DefaultReducer sole-mutator(`reducer.py:69-166`)+ DBCheckpointer transient/durable 分離(`checkpointer.py:94-281`);HITL pause/resume = checkpointing 本質
+- 💡 補上四種 HITL decision type 的 **review-and-edit-state**(「edit before proceeding」超越二元 approve/reject)作 resume API 契約
+
+### Cat 8 — Error Handling ✅⚠️
+- ✅ retry matrix(`retry.py:71-82`:TRANSIENT max3 / LLM_RECOVERABLE max2 / HITL/FATAL max0)+ circuit_breaker(3 態)+ tenant error budget + terminator(優先序);工具失敗合成帶診斷 ToolResult(`loop.py:2976-2983`)= 研究「retry 要帶診斷」
+- ⚠️💡 **self-conditioning 殘留風險**:verification 修正迴圈把失敗答案 + 修正提示一起 append 進 context 再 continue(`loop.py:2617-2626`);研究示「context 留著自己的錯誤 → 後續惡化,放大模型救不了」→ 💡 評估重試時**清掉失敗答案**(只留「目標 + 為何上次不對」精煉版)
+- 💡 模組級 failure attribution(memory/reflection/planning/action)餵 structured replanning 而非 blind retry
+
+### Cat 9 — Guardrails & Safety ⚠️ + 💡(高優先)
+- ✅「限制」部分:capability matrix(8 能力 role/scope `capability_matrix.py`)+ per-tenant HITLPolicy(`hitl.py:82-189`)+ 高風險 → HITL escalate + Docker sandbox + destructive→HIGH(57.124);4 個 escalate 點(input/between-turns/tool/output `loop.py:634-1620`)
+- ⚠️ **重度依賴「偵測」**:RiskyActionDetector = 13 條 regex(`risky_action_detector.py:84-157`)= 研究說「inherently brittle」;架構 ≈ context-minimization + guardrail gatekeeping + HITL escalation 混合層,**非** 6 模式任何單一純結構模式(無 plan 層、無 dual-LLM)
+- 💡 **最有價值升級**:對「不可信輸入(RAG/外部資料)觸發副作用」威脅,從「加 detector」轉「結構限制」(Dual LLM:quarantined 處理不可信、結果符號化、privileged 不直接看原文;或 Plan-Then-Execute:執行期 plan 不可被 injection 改);雙向 screening(probe tool OUTPUTS + classifier tool CALLS);LLM judge 要 strip agent 自己 reasoning 防 self-justification;deny rule 無條件勝 allow + unknown tool fail-closed
+
+### Cat 10 — Verification Loops ✅ + 💡
+- ✅ in-loop verify gate(`loop.py:1770` `_cat10_verify_gate()`)+ RulesBasedVerifier(`rules_based.py:37-77`)+ LLMJudgeVerifier(`llm_judge.py:57-121`)+ self-correction 重試(預設 2 次 `loop.py:2617-2687`)+ verification-ESCALATE(57.99)。verification-ESCALATE 要求真實 judge 失敗(非 self-reflection)= 研究 ICLR2024×EMNLP2024 分界線直接驗證
+- ⚠️ self-correction 是 prompt-based coach feedback,非 RL-trained → 可能拿不到論文增益幅度
+- 💡 可採納:verifier 圍繞 **checkable condition**(schema/required field/tool-arg constraint),優先 RulesBased + constraint-check、LLMJudge 用準則明確處;per-step verification(subagent return → lead synthesis 間插);基於 Sprint 57.111 judge benchmark harness 建 offline MAST-14-mode failure classifier
+
+### Cat 11 — Subagent Orchestration ✅ + 💡
+- ✅ FORK/TEAMMATE/AS_TOOL 真子 loop(`fork.py:101-224`、`teammate.py`、`as_tool.py:46-114`),深度結構性限制 1(`fork.py:21`);SSE relay(`fork.py:90-98`,57.96);HANDOFF = loop output classifier 攔截 → `stop_reason="handoff"`(⚠️ 與 OpenAI「handoff=tool call」不同實作)
+- ⚠️ V2 未對自己 multi-agent 做增益實測(共識採用非實證)
+- 💡 可採納:**依 coupling 路由**(independent→fork;dependency-heavy/shared-state→single loop);**strip orchestrator routing/handoff metadata 出 worker context**(避免 self-conditioning);subagent-spawn 當 value-gated + token-budgeted,surface 15× multiplier 進 audit/billing(已有 cost_ledger)
+
+### Cat 12 — Observability ✅ + 💡(高優先)
+- ✅ TraceContext propagation + OTelTracer wrapper(`tracer.py:57-149`)+ 5 must-have spans 線上
+- 💡 **標準化在 OTel GenAI semantic conventions**(invoke_agent → chat → execute_tool;`gen_ai.*` attribute)→ 滿足約束 3 + CNCF-backed + 避免 bespoke schema;`captureContent` 預設 off 對齊 PII/GDPR;**pass^k 作主要 metric** + fault(λ)/perturbation(ε)軸 + behavioral consistency check(重複同 send N 次 diff trace)+ MAST 3 類/14 mode 作 negative-test catalog
+
+---
+
+## 4. 跨維度主題(6 條反覆出現的共識/張力)
+
+1. **Multi-agent 的價值是 compute,不是 orchestration 魔法**——token usage 解釋 ~80% 變異、~15× 成本、coupling-heavy 任務 single-agent 勝、swarm 放大錯誤。路由規則:**依 coupling 而非 capability 路由**。
+2. **Self-correction 的限制有清晰可引用的分界 = external verifiable signal**——intrinsic self-reflection 退化,但 key-condition / tool error / denial-as-routing 讓 correction 可靠。張力:verification agent 自己也不可靠 → **defense-in-depth**(rules-based 優先、LLM judge 次之、human escalation 兜底)。
+3. **Context rot 真實且 length-driven**——應對是分層、可審計、依風險排序的 compaction(tool-result clearing → deterministic eviction → LLM summarization);self-conditioning 給了「為何要 prune failed branch」的實證。
+4. **approval fatigue 與 transparency 的雙向張力**——「太多 prompt」與「太少可見性」都侵蝕信任。綜合:**deny-first guardrail(少 prompt、高保護)+ glanceable progress streaming(多可見性)+ 暴露 effective context 的 inspector**。
+5. **long-horizon 失敗是 execution 問題**——externalized state + bounded burst + rehydration 是跨維度共識,直接驗證 V2 設計;附帶:explicit task primitive 是 load-bearing 反 early-stop 機制(V2 真實 gap)。
+6. **empirical eval 必須超越 pass@1 / drive-through-once**——drive-through 證一次能用,**pass^k 證跨重複 run 可靠**;配 behavioral consistency + fault/perturbation 軸 + MAST catalog 形成完整 reliability science。
+
+---
+
+## 5. 優先機會(綜合排序)
+
+| 優先 | 機會 | 範疇 | 研究背書 | V2 現況 | 已識別? |
+|------|------|------|---------|---------|---------|
+| **1** | **顯式任務原語(DAG-based,非 flat list)** | Cat 1/3/7 | 發現 2.2 load-bearing 反 early-stop | 有 restart 底座、缺 decompose 結構 | ✅ task-primitive thin-spike eval |
+| **2** | **pass^k 可靠性實測入 eval harness** | Cat 12 | 發現 2.7 reliability≠capability | drive-through 是 pass@1 式單次 | ❌ 研究新增視角 |
+| **3** | **安全從「偵測」轉「結構限制」(評估 6 模式)** | Cat 9 | 發現 2.6 restrict not detect | RiskyActionDetector 是 regex 偵測 | ⚠️ 方向需修正 |
+| **4** | **分層 compaction(tool-result clearing 先行)+ ACON 目標帶** | Cat 4 | 發現 2.5 + ACON 26–54% | 單層 75%/turn>30 | ✅ cc-long-running 條件性 |
+| **5** | **Cat 12 標準化在 OTel GenAI conventions** | Cat 12 | 發現 2.7 CNCF-backed | 自有 wrapper,非標準 schema | ❌ ux-research 新增 |
+| **6** | **verification 重試清掉失敗 context(防 self-conditioning)** | Cat 8/10 | 發現 2.2 self-conditioning | append 失敗答案再改 | ❌ 研究新增視角 |
+| **7** | **tool-description lint + structured-error reflection** | Cat 2 | 發現 2.3/2.4 | 無 desc lint | ❌ ux-research 新增 |
+| **8** | **key-condition verifier(取代「這答案好嗎」)** | Cat 10 | 發現 2.4 EMNLP2024 分界 | LLMJudge 偏整體判斷 | ⚠️ 可精緻化 |
+
+**兩個 V2 強過研究範例、應守住的地方**:
+- **durable 可治理 HITL pause**(比 LangGraph/CC 都重,多租戶 SaaS 正確選擇)
+- **5-scope 記憶隔離**(比 CC 單一 MEMORY.md 嚴謹;別為學 ACE scoring 弱化隔離)
+
+---
+
+## 6. 證據品質與保留意見(引用前必讀)
+
+**已獨立驗證 / 高信心(可放心引用)🟢**
+- arXiv 2604.14228(Dive into Claude Code):20%→40% / 93% / 七 permission mode / deny-first / 27% / 17% 已逐字核實
+- arXiv 2510.00615(ACON):Microsoft,有官方實作,26–54% / >95% / ~99% 多源佐證
+- arXiv 2503.13657(MAST):NeurIPS 2025,1,600+ trace / 14 mode / Kappa 0.88
+- arXiv 2406.12045(τ-bench)、2310.01798(Cannot Self-Correct ICLR2024)、2024.emnlp-main.714(Key-Condition EMNLP2024)、2406.16008(Lost/Found in the Middle)、ToolEmu / R-Judge、OTel GenAI conventions、2509.09677(Long Horizon Execution)、2604.02460(Single vs Multi-Agent)、2509.18847(Structured Reflection):landmark / 已 spot-check
+
+**Vendor / practitioner 自報(方向可信,數字 hedge)🟡**
+- Anthropic engineering posts(multi-agent 90.2% / 15× / 4×、tool-desc ~40%、auto-mode 93% / 17% FN、context engineering、tool-result clearing):first-party,多為內部 eval / 單一 improvement cycle self-report,非外部可重現 benchmark
+- LangChain(multi-agent benchmark、interrupt HITL):單一 vendor benchmark,有 framing incentive
+
+**Unverified / mis-attributed / weak(引用前必須再核)🔴**
+- Nicolas Bustamante blog(agent-controlled compaction 22.7%):**最弱**,無 published methodology,數字當 hypothesis
+- arXiv 2606.11213(CWL/structured eviction)、2512.05470(file-system-as-memory 學術半段)、2601.22311(receding-horizon)、2512.03560(RP-ReAct)、2602.11619(behavioral consistency):未獨立核實,原理可信、empirical 倚賴單篇 self-report
+- observability ε/λ reliability:兩篇 2026 paper conflate,「23,392 episodes」與所引 URL(2603.29231)似 mis-attributed(ε 數字應屬 ReliabilityBench 2601.06112)——**技術結論成立,citation precision 不成立**
+- self-correction critical survey(2410.20513 vs 通常引用的 Pan et al. 2308.03188):citation conflated
+- agentic-design.ai(binary confidence / 「going silent erodes trust」):specifics 未在頁面找到,**勿引此來源**,方向建議靠 arXiv 2604.14228 獨立存活
+- multi-agent 17.2x / 4.4x / 96.4%:單篇 2026 preprint,引方向、hedge 數字
+
+**研究盲點**
+- 多數可靠性數字缺第三方獨立重現
+- enterprise multi-tenant 場景下的 pass^k / fault-injection 實證稀少——**V2 的 trace persistence 反而是少數能廉價產生這類數據的位置**(= 機會 2 的價值)
+- **UX 層幾乎無對照硬實證**(透明度/HITL/可視化對 end-user 信任的量化影響)——研究藍海
+
+---
+
+## 7. 已調和的矛盾:thinking/CoT × self-conditioning
+
+兩次 research 在此衝突,本文調和如下(**以 claim 級對抗驗證為準**):
+
+| 子主張 | 信度 | 說明 |
+|--------|------|------|
+| Self-conditioning 存在,且**不被 model scale 修好** | 🟢 | 兩份一致 + claim 級驗證通過 |
+| Thinking/CoT **大幅延長單輪執行長度**(GPT-5 thinking 2,176 steps vs without 「a few」) | 🟢 | 同篇 2509.09677,方向強 |
+| Thinking/CoT **完全消除 self-conditioning** | 🔴 開放 | ux-research §2.2 標 [強],但 **panorama claim 級對抗驗證否決此 overclaim(vote 0-1)**;降為開放問題 |
+
+**正確讀法**:thinking 是執行長度的最強單一槓桿(值得做 provider-neutral thinking-budget toggle),但**「完全消除 self-conditioning」未被確立**——所以**仍要在架構上防 self-conditioning**(retry/verification 別把失敗 trace 留 context),不能依賴「開 thinking 就沒事」。
+
+---
+
+## 8. 開放問題
+
+1. **UX 硬實證缺口**:無對照實驗證明特定透明度/HITL/可視化如何量化改善 end-user 信任與介入效率
+2. **Reasoning/thinking 能否真正解決長程可靠性與 self-conditioning?**(§7 爭議)
+3. **任務拆解的「實測」增益?**(13–42pp 為理論投影,未計 overhead)
+4. **記憶系統正確設計**:重設計記憶(階層摘要/scoped/expiration)能否在長程帶來淨增益?(論文明列未來工作)
+5. **異步 multi-agent 編排**(AutoGen v0.4 / Google ADK A2A)能否突破「實時協調是開放問題」+ 克服 ~15× token 代價?
+6. **DAG vs flat-list task primitive 在多租戶 server 形態的最小可行形狀?**(task-primitive eval 推薦先 thin spike 量測 load-bearing)
+
+---
+
+## 9. 來源清單(去重)
+
+**Primary / 已驗證**
+- Anthropic: [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) · [Multi-Agent Research System](https://www.anthropic.com/engineering/multi-agent-research-system) · [Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) · [Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) · [Claude Code Auto Mode](https://www.anthropic.com/engineering/claude-code-auto-mode) · [Measuring Agent Autonomy](https://www.anthropic.com/research/measuring-agent-autonomy) · [Claude Code Sandboxing](https://anthropic.com/engineering/claude-code-sandboxing) · [Context Engineering Cookbook](https://platform.claude.com/cookbook/tool-use-context-engineering-context-engineering-tools)
+- OpenAI: [Agents SDK – Handoffs](https://openai.github.io/openai-agents-python/handoffs/)
+- LangChain: [LangGraph Durable Execution](https://docs.langchain.com/oss/python/langgraph/durable-execution) · [Benchmarking Multi-Agent Architectures](https://www.langchain.com/blog/benchmarking-multi-agent-architectures) · [HITL with interrupt](https://www.langchain.com/blog/making-it-easier-to-build-human-in-the-loop-agents-with-interrupt)
+- arXiv(已驗證/landmark): [2604.14228 Dive into Claude Code](https://arxiv.org/html/2604.14228v1) · [2510.00615 ACON](https://arxiv.org/html/2510.00615) · [2503.13657 MAST](https://arxiv.org/abs/2503.13657) · [2406.12045 τ-bench](https://arxiv.org/abs/2406.12045) · [2310.01798 Cannot Self-Correct](https://arxiv.org/abs/2310.01798) · [2024.emnlp-main.714 Key-Condition](https://aclanthology.org/2024.emnlp-main.714/) · [2406.16008 Found in the Middle](https://arxiv.org/abs/2406.16008) · [2509.09677 Long Horizon Execution](https://arxiv.org/html/2509.09677v3) · [2604.02460 Single vs Multi-Agent](https://arxiv.org/html/2604.02460v1) · [2509.18847 Structured Reflection](https://arxiv.org/pdf/2509.18847) · [2603.29231 Beyond pass@1](https://arxiv.org/pdf/2603.29231) · [2506.08837 Securing LLM Agents](https://arxiv.org/abs/2506.08837) · [2401.10019 R-Judge](https://arxiv.org/html/2401.10019v3) · [ToolEmu](https://openreview.net/forum?id=GEcwtMk1uA) · [2503.14499 METR](https://arxiv.org/abs/2503.14499)
+- Microsoft: [Magentic-UI Report](https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/magentic-ui-report.pdf)
+- OTel: [GenAI Observability with OpenTelemetry](https://opentelemetry.io/blog/2026/genai-observability/)
+- Sierra: [tau-bench](https://sierra.ai/blog/tau-bench-shaping-development-evaluation-agents)
+
+**未核實 / weak(🔴,引用前再核)**:Cognition「Don't Build Multi-Agents」、Nicolas Bustamante blog、arXiv 2606.11213 / 2512.05470 / 2601.22311 / 2512.03560 / 2602.11619 / 2603.04474、agentic-design.ai、Visible Language 59.2、VentureBeat Claude Code Tasks、各 aggregator/blog 綜述
+
+---
+
+## 10. 統計
+- 整合 3 份來源:claim 級驗證 28 claim / 14 findings + 8 角度 41 來源 / 66 findings + 3 Explore agent file:line 勘查
+- 兩次 deep-research 合計:~83 agent · ~1,000 萬+ token · 71 來源(去重後 ~50 真實 URL)

--- a/claudedocs/5-status/ai-agent-harness-market-research-panorama-20260622.md
+++ b/claudedocs/5-status/ai-agent-harness-market-research-panorama-20260622.md
@@ -1,0 +1,187 @@
+# AI Agent 系統設計與可靠性 — 2026 市場/研究全景報告(中立)
+
+**Purpose**: 截至 2026 年,AI agent 系統(含 harness 控制/保護框架)在實際設計與開發實作時,如何改善「使用體驗」與「工程可靠性」的最新方向與實證。**中立全景,不對照本項目**(落地對照見姊妹文件)。涵蓋 agent loop 架構、記憶、context compaction、orchestration/multi-agent、retry/self-correction、long-running/durable execution、權限/護欄、可觀測性,以及 end-user UX 層。
+**Category / Scope**: Status / External market & academic research panorama (cross-cutting)
+**Created**: 2026-06-22
+**Last Modified**: 2026-06-22
+**Status**: Active (snapshot;基於 deep-research workflow 2026-06-22 跑出的 30 來源 / 148 主張 / 28 對抗驗證)
+**Method**: deep-research harness(節流版:6 搜尋角度批次 fan-out + 單票對抗驗證,避 WebSearch 速率限制)→ 26/28 主張通過、2 否決 → 綜合 14 findings。**單票驗證強度弱於預設 3 票**:殺掉的 2 主張可信,通過的 medium 信度主張引用前建議覆核原始來源。
+**權威聲明**:本文是外部市場/學術研究筆記,**非 V2 設計權威**。
+
+> **Modification History**
+> - 2026-06-22: Add cross-ref to sibling ux-research deep-research run (1-planning)
+> - 2026-06-22: Initial creation — deep-research workflow 全景報告(節流版 workflow,WebSearch 速率限制後重跑)
+
+> **姊妹文件**:[`ai-agent-harness-research-vs-v2-mapping-20260622.md`](ai-agent-harness-research-vs-v2-mapping-20260622.md) —— 把本文 14 findings 逐一對照本項目 11+1 範疇 + server-side governance + `max_turns=8` 有界爆發設計(✅/⚠️/❌/💡)。
+>
+> **🔗 同日第二次 deep-research run（增量補充）**:[agent-harness-ux-research-20260622.md](../1-planning/agent-harness-ux-research-20260622.md)(8 角度版,與本文 ~70% 重疊)。其 net-new(本文未涵蓋):Cat 12 標準化於 OTel GenAI semantic conventions / ACON 量化壓縮目標帶(arXiv 2510.00615) / ICLR2024×EMNLP2024 self-correction 分界線 / MAST + tool-description lint。**矛盾提醒**:該文 §2.2 把「CoT thinking 消除 self-conditioning」誤標 [強],與本文 §被否決 #2(claim 級對抗已否決該 overclaim,vote 0-1)相左——**以本文為準**。
+
+---
+
+## 0. 怎麼讀(證據強度分級)
+
+| 標記 | 意義 |
+|------|------|
+| 🟢 **實證** | 有 arXiv 受控實驗 / 大規模數據(可重現性較高) |
+| 🟡 **共識** | 廠商 blog / 框架設計觀點(primary 但第一方、含立場) |
+| 🔴 **開放/爭議** | 被廣泛討論但缺對照實驗,或在驗證中被否決 |
+
+**一句話**:2026 年主戰場已從「agent **能不能做**」轉向「agent **能不能可靠地長時間做**」。**工程可靠性層有最強實證;End-user UX 層幾乎無獨立硬實證**(關鍵負面發現)。
+
+---
+
+## Part A — 工程架構與可靠性層(證據最強)
+
+### A1. Agent 本質定義 🟢🟡
+Anthropic「Building Effective Agents」二分(2026 仍最廣引用):
+- **Workflow** = LLM/工具透過**預定義 code path** 編排;**Agent** = LLM **動態自主**導引流程與工具,自掌如何完成
+- 關鍵:執行每一步都要從環境取得 **"ground truth"**(工具結果/程式執行)評估進度 → ReAct/TAO loop 核心
+- 來源:Anthropic – Building Effective Agents(primary,vote 3-0)
+
+### A2. 編排模式 🟡
+| 模式 | 適用 | 證據 |
+|------|------|------|
+| 先用最簡方案、慎用框架 | 多數 | 🟡 直接用 LLM API;框架增抽象層、遮蔽 prompt、增除錯難度、誘使過度複雜。**觀點性建議非實證** |
+| Evaluator-Optimizer | 有清楚評估標準、迭代有可衡量價值 | 🟡 一 LLM 產生、另一 LLM 評估回饋迴圈 |
+| Orchestrator-Worker | 可並行子任務 | 🟡🟢 見 A2.1 |
+| Handoff(委派) | agent 各有領域專長 | 🟢 OpenAI Agents SDK:**handoff 機制上就是 tool call**(委派 Refund Agent = 呼叫 `transfer_to_refund_agent`),agent 間委派重用一般 tool-use 機制 |
+
+**A2.1 Multi-agent 實證與代價 🟡**
+- ✅ Anthropic orchestrator-worker(Opus 4 lead + Sonnet 4 subagent)內部研究 eval **比單一 Opus 4 高 90.2%**
+- ⚠️ 三大保留:(1) **~15× token 代價**(single-agent ~4×,vs chat);(2) 90.2% 為**內部不可重現** eval,且 ~80% 變異由 token 用量解釋(compute confound);(3) **實時 agent 間協調仍是開放問題**,需共享 context / 高互依領域(如多數 coding)不適用
+- 🔴 業界辯論:Cognition「Don't Build Multi-Agents」(2025-06)vs Anthropic「Do — Carefully」→ 2026 趨同共識 = **orchestrator + ephemeral subagent**(主 agent 持完整 context,派短命子 agent 在各自乾淨 window 做隔離子任務)
+
+### A3. ⭐ 長程可靠性瓶頸 — 本報告最強實證群 🟢🟢🟢
+**(1) Reliability ≠ Capability,隨任務時長系統性發散**
+- 即使**單步準確率近乎完美、知識非限制因素**,執行步數仍會在某點崩潰
+- 23,392 episodes、10 模型:mean pass@1 從短任務 **76.3% → 很長任務 52.1%**(掉 24.3pp),且**衰退快於 i.i.d. geometric baseline**(正向 error correlation)
+- GPT-4o 在 τ-bench retail:**61% pass@1,但僅 25% pass@8**(連跑 8 次至少失敗一次機率近 75%)
+- 💡 含義:**capability benchmark(單次成功率)結構性地對長程可靠性盲目**
+
+**(2) Self-conditioning:"confused agent stays confused"**
+- context 含自身**先前錯誤**時,後續準確率**進一步惡化**;**放大模型參數救不了**(Kimi-K2 1026B / DeepSeek-V3 670B / Qwen3-235B 皆易受)
+- 💡 含義:**retry 不能只是「重跑」**,錯誤會自我放大
+
+**(3) 任務長度成長趨勢**
+- METR:前沿 AI「50% 任務完成時間視野」自 2019 約**每 7 個月翻倍**(2024 後可能加速約 4 個月)
+- ⚠️ 透明度:原研究「Claude 3.7 Sonnet ≈ 50 分鐘」具體數字**在對抗驗證中被否決**,只保留翻倍趨勢
+
+- 來源:arXiv:2509.09677(Illusion of Diminishing Returns)、arXiv:2603.29231(Beyond pass@1)、arXiv:2503.14499(METR)
+
+### A4. 可靠性介入手段(哪些有效、哪些有害)
+| 手段 | 效果 | 證據 |
+|------|------|------|
+| **任務拆解 + 邊界重啟 agent** | 該研究稱「最高槓桿」;投影增益 13.1pp(DeepSeek V3)~ 41.5pp(Qwen3 30B) | 🟡 **「假設子任務獨立」的分析投影,非實測**,未計拆解/交接 overhead,屬理想上限 |
+| **結構化反思 / self-correction** | 用前步證據診斷工具失敗→提修正後續呼叫。BFCL v3 提升(Qwen3-4B 16.25%→20.75%);Repair@5 6.8%→26.4% | 🟢 有數字、方法嚴謹。**但增益來自 RL 訓練的反思能力,非純 inference-time prompt** |
+| **Naive episodic memory(每輪注入的 scratchpad)** | ❌ **從不改善長程,還傷害 10 模型中 6 個**(overhead 吃步數預算 + context 空間) | 🟢 強實證**反對** naive 記憶。⚠️ 限「naive episodic」+「長程」,**不否定**階層摘要/scoped/有 expiration 的重設計記憶 |
+
+> 💡 記憶系統設計警示:**記憶必須精算 per-step overhead 對任務長度的影響**,不能無腦累積。
+- 來源:arXiv:2603.29231、arXiv:2509.18847(Failure Makes the Agent Stronger)
+
+### A5. Context Engineering + Compaction 🟢🟡
+- **定義**:策展與維護 LLM 推論時「最佳 token 集合」的策略,跨 agent loop 迭代管理 context state
+- **動機 context rot**:token 數增加 → 模型從 context 準確召回能力**下降**(根源之一 transformer O(n²) 成對 attention);應把 context 當有限資源 + 有「attention budget」。🟢 有獨立實證(Chroma 2025、Lost-in-the-Middle 2023)
+- **Compaction**:摘要接近 window 上限的對話、重啟新 window,**保留架構決策與未解 bug、捨棄冗餘工具輸出** → 使長程執行成為可能
+- 來源:Anthropic – Effective Context Engineering
+
+### A6. Durable Execution / 長運行 🟢🟡
+- **LangGraph checkpointer**:把 thread graph state 持久化為 checkpoints → 中斷後恢復、失敗復原、跨互動記憶,支援對話連續性、**HITL、time travel、容錯**
+- ⚠️ 保留:(1) resume 需配 checkpointer、跨 thread 記憶要另設 store(非自動);(2) resume 時 checkpoint 後 node 會**重跑**(LLM/API 重發)→ 需**冪等**;(3) 🔴 有異議來源(Diagrid)主張弱於 Temporal 等真正 durable-execution 引擎
+- 🔴 新興:DBOS、Temporal 等「crashproof agent」durable execution 引擎被熱烈討論
+- 來源:LangGraph – Durable Execution、Diagrid(異議)
+
+### A7. 安全護欄 / Harness Control 🟢
+核心原則:**「限制(restrict)而非僅偵測(detect)」** —— 一旦 agent 攝入**不可信輸入**,必須在**結構上使該輸入不可能觸發任何有副作用的動作**(偵測/對抗訓練「inherently brittle」)。
+**6 種抗 prompt-injection 設計模式**(各以「agent 通用性」換「安全保證」):
+1. **Action-Selector**(對 injection 免疫,但失去 LLM 模糊搜尋能力)
+2. **Plan-Then-Execute**(control-flow integrity 保護)
+3. **LLM Map-Reduce**
+4. **Dual LLM**(privileged + quarantined 分離,結果符號化儲存)
+5. **Code-Then-Execute**
+6. **Context-Minimization**
+- 💡 含義:**安全是架構問題,不是過濾器問題**
+- 來源:arXiv:2506.08837(Design Patterns for Securing LLM Agents against Prompt Injections;作者群 AgentDojo / Microsoft);輔 OWASP Agentic AI、Claude Code Sandboxing
+
+---
+
+## Part B — End-user UX 層 ⚠️🔴(證據最弱)
+
+**關鍵負面發現**:UX 層**幾乎無獨立硬實證**。透明度、信任建立、進度可視化、錯誤處理 UX、agent 協作介面,只能**間接從框架設計層的能力**推得「被廣泛採用」,**非**有對照實驗證明改善 end-user 體驗。
+
+被廣泛採用的可控性/透明度機制(🟡 共識非實證):
+- HITL 介入點設計(LangGraph、Microsoft Magentic-UI)
+- Durable resume、Time travel(回溯重新分支)、Handoff 可視化、思考過程/工具呼叫串流呈現
+- 來源:Microsoft – Magentic-UI Report、Anthropic – Measuring Agent Autonomy
+
+> 💡 **這是「藍海」**:UX 領域被熱烈討論卻缺對照研究,適合用 drive-through 方法論產出這類證據。
+
+---
+
+## 🔴 被否決 / 有爭議的主張(透明度)
+
+對抗驗證殺掉 2 個流傳說法:
+1. ❌ **「前沿模型時間視野 ≈ 50 分鐘」**(具體數字證據不足;只保留「每 7 個月翻倍」趨勢)— source: arXiv:2503.14499,vote 0-1
+2. ❌ **「thinking / extended reasoning 完全消除 self-conditioning」**— vote 0-1。結合「self-conditioning 不受模型大小緩解」這個已確認發現,意味 **「延伸推理能否救長程可靠性」仍是有爭議、未確立的開放問題**
+
+---
+
+## 🔭 五大開放問題
+
+1. **UX 硬實證缺口**:幾乎無對照實驗證明特定透明度/HITL/可視化設計如何量化改善 end-user 信任與介入效率
+2. **Reasoning/thinking 模型能否真正解決長程可靠性與 self-conditioning?**(有爭議)
+3. **任務拆解的「實測」增益?**(13-42pp 為理論投影,未計 overhead)
+4. **記憶系統正確設計**:naive scratchpad 在長程有害,但階層摘要/scoped/有 expiration 的重設計能否帶來淨增益?(論文明列為未來工作)
+5. **異步 multi-agent 編排**(AutoGen v0.4、Google ADK A2A)能否突破「實時協調是開放問題」並克服 ~15× token 代價?
+
+---
+
+## 14 Findings 一覽(供姊妹文件對照引用)
+
+| # | 發現(摘) | 信度 | 主要來源 |
+|---|----------|------|---------|
+| 1 | Agent = while-loop + ground truth 回注;workflow/agent 二分 | high | Anthropic BEA |
+| 2 | 先用最簡方案、慎用框架 | medium | Anthropic BEA |
+| 3 | Evaluator-optimizer 模式 | medium | Anthropic BEA |
+| 4 | Orchestrator-worker multi-agent 90.2% / 15× token | medium | Anthropic multi-agent |
+| 5 | Context engineering + context rot + compaction | high | Anthropic context-eng |
+| 6 | Handoff = tool call 機制 | high | OpenAI Agents SDK |
+| 7 | Durable execution(checkpointer)| high | LangGraph docs |
+| 8 | 任務長度每 7 個月翻倍 | high | arXiv:2503.14499 |
+| 9 | ⭐ reliability≠capability、pass@1 vs pass@8 發散 | high | arXiv:2509.09677 + 2603.29231 |
+| 10 | ⭐ self-conditioning(放大模型救不了)| high | arXiv:2509.09677 |
+| 11 | ⭐ 任務拆解 + 邊界重啟 = 最高槓桿 | medium | arXiv:2603.29231 |
+| 12 | Naive episodic memory scratchpad 有害 | medium | arXiv:2603.29231 |
+| 13 | 結構化反思提升可靠性(RL-trained)| high | arXiv:2509.18847 |
+| 14 | ⭐ 安全「限制非偵測」+ 6 模式 | high | arXiv:2506.08837 |
+
+---
+
+## 來源清單(30 fetched;依角度 + 品質)
+
+**Primary(高品質)**
+- Anthropic: [Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents) · [Multi-Agent Research System](https://www.anthropic.com/engineering/multi-agent-research-system) · [Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) · [Measuring Agent Autonomy](https://www.anthropic.com/research/measuring-agent-autonomy) · [Claude Code Sandboxing](https://anthropic.com/engineering/claude-code-sandboxing) · [Claude Code Security](https://code.claude.com/docs/en/security)
+- OpenAI: [Agents SDK – Handoffs](https://openai.github.io/openai-agents-python/handoffs/)
+- LangChain: [LangGraph – Durable Execution](https://docs.langchain.com/oss/python/langgraph/durable-execution)
+- arXiv: [2503.14499 METR](https://arxiv.org/abs/2503.14499) · [2509.09677 Illusion of Diminishing Returns](https://arxiv.org/html/2509.09677v3) · [2603.29231 Beyond pass@1](https://arxiv.org/pdf/2603.29231) · [2509.18847 Failure Makes the Agent Stronger](https://arxiv.org/pdf/2509.18847) · [2506.08837 Securing LLM Agents](https://arxiv.org/abs/2506.08837) · [2406.12045](https://arxiv.org/pdf/2406.12045) · [2503.13657](https://arxiv.org/abs/2503.13657)
+- Microsoft: [Magentic-UI Report](https://www.microsoft.com/en-us/research/wp-content/uploads/2025/07/magentic-ui-report.pdf)
+- Sierra: [tau-bench](https://sierra.ai/blog/tau-bench-shaping-development-evaluation-agents)
+
+**Secondary / Blog(佐證或觀點)**
+- [Cognition – Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents)、[LangChain – Planning Agents](https://www.langchain.com/blog/planning-agents)、[Palo Alto – OWASP Agentic AI](https://www.paloaltonetworks.com/blog/cloud-security/owasp-agentic-ai-security/)、[Diagrid – Checkpoints ≠ Durable Execution](https://www.diagrid.io/blog/checkpoints-are-not-durable-execution-why-langgraph-crewai-google-adk-and-others-fall-short-for-production-agent-workflows)、[DBOS – Crashproof AI Agents](https://www.dbos.dev/blog/durable-execution-crashproof-ai-agents)、Kili / DigitalApplied / agentmarketcap / machinelearningmastery / datasciencedojo(benchmark/memory/loop 綜述,blog 品質)
+
+---
+
+## 方法限制(誠實標註)
+
+1. **證據不對稱**:工程可靠性層(A)有最強實證(3 篇近期 arXiv);**UX 層(B)幾乎無獨立硬實證**——只能從框架能力間接推得。
+2. **單票對抗驗證**(本次因 WebSearch 速率限制把預設 3 票降為 1 票):殺掉的 2 主張可信,通過的 medium 信度主張引用前建議覆核。
+3. **廠商 blog 為第一方**(Anthropic/OpenAI/LangChain),部分含觀點性建議,非中立 benchmark。
+4. **時效性**:multi-agent 實時協調為開放問題的論斷基於 2025-06 文章;異步編排(AutoGen v0.4、Google ADK A2A)快速演進中。
+5. **數字限定**:任務拆解 13-42pp 為「假設子任務獨立」的分析投影非實測;結構化反思增益來自 RL 訓練(非純 prompt);memory scaffold 負面結果限「naive episodic」+「長程」。
+6. **benchmark 覆蓋**:已驗證 claim 中僅 τ-bench / BFCL v3 有具體數據;SWE-bench / AgentBench / GAIA 雖被點名但本批未取得數據。
+
+---
+
+## 統計
+- 搜尋角度 6 · 抓取來源 30(primary ~16)· 萃取主張 148 · 對抗驗證 28(確認 26 / 否決 2)· 綜合 14 findings
+- 投入:66 agent · ~1,030 萬 token · ~34 分鐘(節流版 workflow)

--- a/claudedocs/5-status/ai-agent-harness-research-vs-v2-mapping-20260622.md
+++ b/claudedocs/5-status/ai-agent-harness-research-vs-v2-mapping-20260622.md
@@ -1,0 +1,167 @@
+# 2026 Agent 研究 14 Findings × V2 落地對照(✅/⚠️/❌/💡)
+
+**Purpose**: 把 [`ai-agent-harness-market-research-panorama-20260622.md`](ai-agent-harness-market-research-panorama-20260622.md) 的 14 項研究發現,逐一對照本項目 V2 的 11+1 範疇 + server-side governance + `max_turns=8` 有界爆發設計,標出已具備 / 部分 / 缺口 / 機會。
+**Category / Scope**: Status / Research-to-implementation mapping (cross-cutting)
+**Created**: 2026-06-22
+**Last Modified**: 2026-06-22
+**Status**: Active (snapshot;基於 git HEAD Sprint 57.135 程式碼 grounding)
+**Grounding**: 3 個 read-only Explore agent 對 `backend/src/agent_harness/` 的 file:line 勘查(2026-06-22)+ 本項目 3 份權威文件(`task-primitive-thin-spike-eval-20260618.md` / `cc-long-running-loop-source-analysis-20260619.md` / `agent-harness-cc-parity-20260607.md`)
+**驗證層級**:**程式碼 grounding(file:line)**,非 drive-through。標 ✅ 者若要宣稱「使用者真的能用」,以既有 drive-through 紀錄(`chat-v2-agent-loop-capability-drivethrough-20260618.md`)為準。
+
+> **Modification History**
+> - 2026-06-22: Add cross-ref to 3rd same-day deep-research (ux-research, 1-planning)
+> - 2026-06-22: Initial creation — 14 findings × V2 對照;校正 2 處 Explore agent 偏差(Cat 10 in-loop verify gate 確存於 loop.py:1770/2617-2687;max_turns loop 預設 50 但 chat 主流量 handler.py:710 寫死 8)
+
+> **標記**:✅ 已具備 · ⚠️ 部分 · ❌ 缺口 · 💡 機會
+>
+> **🔗 第三份同日研究**:[agent-harness-ux-research-20260622.md](../1-planning/agent-harness-ux-research-20260622.md)(8 角度 deep-research)。對本對照表的增量:**Cat 12** 可加「標準化於 OTel GenAI semantic conventions(invoke_agent→chat→execute_tool span、`captureContent` 預設 off 對齊 PII)」;**Cat 4** compaction 可引 ACON 量化目標(削 26–54% peak token 不損準確率,arXiv 2510.00615);**Cat 10** verification 可引 ICLR2024×EMNLP2024 self-correction 分界線。該文盲點:未涵蓋本對照 finding 14 的安全「限制非偵測」6 模式。
+
+---
+
+## 總覽計分卡
+
+| # | 研究發現 | 範疇 | 判定 |
+|---|---------|------|------|
+| 1 | Agent = while-loop + ground truth 回注 | Cat 1/6 | ✅ |
+| 2 | 先用最簡方案、慎用框架 | 架構哲學 | ✅ |
+| 3 | Evaluator-optimizer | Cat 10 | ✅ |
+| 4 | Orchestrator-worker multi-agent(增益 + 15× token) | Cat 11 | ✅(增益未實測) |
+| 5 | Context engineering + context rot + compaction | Cat 4 | ⚠️ 單層 |
+| 6 | Handoff = tool call 機制 | Cat 11 | ⚠️ 不同實作 |
+| 7 | Durable execution | Cat 7 | ✅(比範例更重) |
+| 8 | 任務長度每 7 個月翻倍 | 趨勢 | n/a(外部趨勢) |
+| 9 | ⭐ reliability≠capability、pass@1 vs pass@8 | Cat 1 + 哲學 | ⚠️💡 設計對齊但無實測 |
+| 10 | ⭐ self-conditioning | Cat 8 retry | ✅⚠️ 教練式重試但有殘留風險 |
+| 11 | ⭐ 任務拆解 + 邊界重啟 = 最高槓桿 | Cat 1/3/7 | ⚠️💡 有機械底座、缺顯式任務原語 |
+| 12 | Naive episodic memory scratchpad 有害 | Cat 3 | ✅⚠️ 已避開最差形式 |
+| 13 | 結構化反思 / self-correction(實證) | Cat 10/8 | ⚠️ 有結構、非 RL-trained |
+| 14 | ⭐ 安全「限制非偵測」+ 6 模式 | Cat 9 | ⚠️💡 混合層防線,含偵測成分 |
+
+**一句話**:V2 在**可靠性「機械底座」與「企業治理」上普遍領先研究的範例**(durable pause、多租戶 guardrail、5-scope memory),但在**長程可靠性的「實測驗證」與「結構化任務脊椎」上有明確空缺**——恰好是 2026 研究指出的最高槓桿區。
+
+---
+
+## A. Loop 架構基礎(發現 1, 2, 3)— ✅ 全綠
+
+### 發現 1:while-loop + ground truth 回注 → ✅
+- 主迴圈 `while True:` 由 stop_reason 驅動(`loop.py:2074`),非固定步 pipeline → 正面避開「AP-1 Pipeline 偽裝 Loop」
+- 工具結果以 `Message(role="tool")` 回注、`turn_count++` 後 `continue`(`loop.py:2791-3110`)= 研究「每步取 ground truth」
+- workflow/agent 二分:V2 是 agent 端,用 server-side guardrail 框住 = 有意 hybrid,不衝突
+
+### 發現 2:先用最簡方案、慎用框架 → ✅
+- V2 自建 harness 在 provider-neutral `ChatClient` ABC 上,非套 LangGraph/CrewAI = 研究「直接用 LLM API、不被框架抽象遮蔽」。LLM Provider Neutrality(約束 3)比研究更進一步
+
+### 發現 3:Evaluator-optimizer → ✅
+- Cat 10 in-loop verify gate(`loop.py:1770` `_cat10_verify_gate()`)+ RulesBasedVerifier(`rules_based.py:37-77`)+ LLMJudgeVerifier(`llm_judge.py:57-121`)= 研究「一 LLM 產生、另一 LLM 評估回饋」,且做成 in-loop 非 post-hoc
+
+---
+
+## B. 編排 / Multi-agent(發現 4, 6)
+
+### 發現 4:Orchestrator-worker → ✅(增益未實測)
+- Cat 11 有 **FORK / TEAMMATE / AS_TOOL 真實子 loop**(`fork.py:101-224`、`teammate.py`、`as_tool.py:46-114`),深度結構性限制 1(`fork.py:21`,recursion-safe)= 2026 共識「orchestrator + ephemeral subagent」
+- SSE relay 轉發子 agent 事件到前端(`fork.py:90-98`,57.96)
+- ⚠️ 研究 90.2% 是 Anthropic 內部不可重現 eval;**V2 也沒對自己 multi-agent 做增益實測** = 共識採用非實證
+- 💡 ~15× token 代價提醒:multi-agent 應只用高價值可並行任務 + 成本歸因(已有 cost_ledger 基礎)
+
+### 發現 6:Handoff = tool call → ⚠️ V2 實作不同
+- OpenAI SDK 把 handoff 做成 tool call(`transfer_to_xxx`);**V2 的 HANDOFF 是 loop output classifier 攔截 → `stop_reason="handoff"` → 平台層啟動 child session**(非 tool call;cc-parity §3 #7「半」)
+- 💡 可評估是否收斂到 tool-call 形狀以統一心智模型(風格選擇,非缺陷)
+
+---
+
+## C. ⭐ 長程可靠性瓶頸(發現 8, 9, 10)— 最值得關注
+
+### 發現 8:任務長度每 7 個月翻倍 → n/a(外部趨勢)
+- 戰略含義:`max_turns=8` 有界爆發會隨模型能力面對越來越長的任務;趨勢站在「需要更好長程支撐」這邊
+
+### 發現 9:⭐ reliability ≠ capability → ⚠️💡
+- ✅ **哲學高度對齊**:研究「capability benchmark 對長程可靠性盲目」= V2 的 **drive-through > paper metrics 鐵律**(`feedback_drive_through_over_paper_metrics.md`)的工程化
+- ⚠️ **但無「可靠性實測」**:V2 驗證「單次 drive-through 跑通」(類 pass@1),**無 pass@k 式重複可靠性測量**。研究示 pass@1=61% 的東西 pass@8 可能剩 25%
+- 💡 **機會**:對關鍵主流量(chat-v2 工具執行 / verification / HITL resume)做「重複 N 次可靠性測量」→ 把「能驅動驗證」升級成「可靠地驅動驗證」
+
+### 發現 10:⭐ self-conditioning → ✅⚠️ 有殘留風險
+- ✅ **retry 非 naive 重跑**:工具失敗合成帶診斷 ToolResult(`loop.py:2976-2983`:`"Error: ... Please adjust your approach"`),verification 失敗加 coach feedback(`_build_correction_block` `loop.py:295-309`)= 研究「retry 要帶診斷」
+- ✅ 完整 error_policy 矩陣(`retry.py:71-82`)+ circuit_breaker + error_budget + terminator;FATAL/HITL_RECOVERABLE 不重試
+- ⚠️💡 **殘留風險**:verification 修正迴圈把**失敗答案 + 修正提示一起 append 進 context** 再 continue(`loop.py:2617-2626`)。研究示「context 留著自己的錯誤 → 後續準確率惡化,放大模型救不了」→ 可能反觸發 self-conditioning
+- 💡 **機會**:評估 verification 重試是否該**清掉失敗答案**(只留「目標 + 為何上次不對」精煉版),而非整個失敗 trace 留 context(呼應發現 11「邊界重啟」)
+
+---
+
+## D. ⭐ 可靠性介入(發現 11, 12, 13)
+
+### 發現 11:⭐ 任務拆解 + 邊界重啟 = 最高槓桿 → ⚠️💡 有機械底座、缺顯式脊椎(最關鍵一項)
+- ✅ **機械底座已存在**:「`max_turns=8` 有界爆發(`handler.py:710`)+ 跨輪 rehydration(`DBMessageStore.load()` `message_store.py:93-113`、`loop.py:1937-1947`)」**本質上就是研究的「在邊界重啟 agent」**——每 send 是有界 burst,跨 send 透過 message ledger 重新水合
+- ❌ **缺「decompose 的顯式結構」**:**無 TodoWrite 式顯式任務原語**(`task-primitive-thin-spike-eval` §1.2 確認:無 `LoopState.plan`、無 `tasks:[{id,status}]`、無跨 turn 任務完成度)。plan 是 emergent 自由文字,跨 send rehydrate 只被當對話,**無結構化、durable、可更新的任務狀態**
+- 💡 **正是已評估的 thin spike**:該評估判斷「值得做 thin spike」,推薦 DB-backed `session_tasks` store + run-start rehydrate(鏡像 57.127)。**研究發現 11 提供學術背書**——任務拆解是「最高槓桿可靠性介入」非裝飾
+- ⚠️ 校準:研究 13-42pp 為「假設子任務獨立」的分析投影非實測 → 做完增益要自己量
+
+### 發現 12:Naive episodic memory 有害 → ✅⚠️ 已避開最差形式
+- ✅ **V2 memory 不是有害的 naive scratchpad**:研究批「每輪注入、無限成長的 add_to_memory」。V2 Cat 3 有 **5 scope × 3 time scale(`memory/_abc.py:46-66`)**、summary 上限 200 字元、per-turn 2000-token budget cap(`builder.py:246-257`、`453-520`,低 confidence 先砍)= 研究結尾建議的「重設計記憶(scoped、有 expiration、預算化)」
+- ⚠️ **仍付每輪檢索+注入成本**:每 turn 用「最後一條 user message」重新檢索注入(query-time 固定檢索);budget cap 緩解但未消除
+- ⚠️ **semantic time scale 是 STUB**:Qdrant 向量索引回空(51.2 stub)→ 「3 time scale」實際只有 2 個(short-term Redis + long-term PG)在運作
+- 💡 **機會**:研究「重設計記憶能否在長程帶來淨增益仍是開放問題」。V2 有完整 scoped memory,**適合產出業界還缺的實證**(測開/關 memory 對長程任務完成度淨影響)
+
+### 發現 13:結構化反思 / self-correction → ⚠️ 有結構、非 RL-trained
+- ✅ 有 in-loop self-correction:verification 失敗 → coach feedback → 重試(預設 2 次 `loop.py:2617-2687`),到頂可 verification-ESCALATE 給人(57.99)
+- ⚠️ **關鍵差異**:研究實證增益(BFCL v3、Repair@5 6.8%→26.4%)來自 **RL 訓練的反思能力**,非純 inference-time prompt 反思。V2 是 prompt-based coach feedback → **可能拿不到論文增益幅度**
+- 💡 **機會**:(a) 用更強 model 跑 verification/correction(對應多模型 profile);(b) 優化 coach feedback 結構(診斷 + 可執行下一步,如論文 reflection 形狀)
+
+---
+
+## E. Context 管理(發現 5, 7)
+
+### 發現 5:context engineering + compaction → ⚠️ 單層
+- ✅ 有真 compaction:StructuralCompactor(`structural.py:104-207`)+ observation masking(舊工具結果墓碑化 `observation_masker.py`)+ prompt caching(`cache_manager.py:49-127`,tenant-first hash,多租戶安全)
+- ⚠️ **單層**:觸發 token>75% **或** turn>30(`compactor/_abc.py:60-74`),chat 還要 ≥3 user turns 才實際壓。研究 + cc-long-running 都指出 CC 是 **5 層階梯**(snip→microcompact→collapse→autocompact,便宜先做、貴最後做)
+- 💡 **條件性機會**(cc-long-running 已點明):「若放寬 max_turns,先補的不是數字是壓縮階梯,否則放寬即爆 context」。對短對話單層「可能已夠」;5 層對短 chat 是過度工程 → **只在走「長 autonomous task」時才需要**
+
+### 發現 7:Durable execution → ✅(比範例更重)
+- ✅ **比研究 LangGraph 範例更重**:durable checkpoint(`checkpointer.py:94-281`,transient/durable 分離)+ 獨立 `/resume` 端點重建 = **跨行程可治理暫停**。研究 LangGraph + CC「行程內 await Promise、不持久化」都比 V2 輕
+- ✅ 冪等性 caveat 用 message ledger rehydration + SAVEPOINT(`message_store.py:115-140`)處理
+- = V2 **強過業界範例**的地方,多租戶 SaaS durable HITL pause 是 CC 零藍本純自研區
+
+---
+
+## F. ⭐ 安全護欄(發現 14)→ ⚠️💡 混合層防線,含「偵測」成分
+研究核心:**「限制非偵測」**(偵測啟發式「inherently brittle」)。對照:
+- ✅ **「限制」部分有**:capability matrix(8 能力 role/scope 檢查 `capability_matrix.py`)、per-tenant HITLPolicy(`hitl.py:82-189`)、高風險工具 → HITL escalate、Docker sandbox 硬化(`--network=none`/`--cap-drop=ALL`/`read-only` `sandbox.py:219-392`)、destructive=True 強制升 HIGH(57.124)= 結構性限制
+- ⚠️ **也重度依賴「偵測」**:RiskyActionDetector 是 **13 條 regex pattern match**(`risky_action_detector.py:84-157`)= 研究說「inherently brittle」的偵測式防線
+- ⚠️ **架構模式**:V2 ≈ **context-minimization + guardrail gatekeeping + HITL escalation 混合層防線**,**非** 6 模式中任何單一純結構模式(非 plan-then-execute、非 dual-LLM、非 action-selector);無 plan 層(LLM 直接輸出 tool call),無 dual-LLM(privileged + quarantined)分離
+- 💡 **最有價值機會**:6 模式 = 結構性升級菜單。對「agent 攝入不可信輸入(RAG/外部資料)後觸發副作用」威脅,V2 目前靠 regex 偵測 + HITL;研究建議改**結構限制**(如 Dual LLM:quarantined LLM 處理不可信資料、結果符號化、privileged LLM 不直接看原文;或 Plan-Then-Execute:執行期 plan 不可被 injection 改)。對應 cc-parity §4 C 類「Dangerous command detection」缺口,但研究指出**方向應從「加更多 detector」轉向「結構性限制」**
+
+---
+
+## G. End-user UX 層 → ⚠️ 領先框架,但同缺實證
+- ✅ **可控性/透明度機制比框架豐富**:4 個 HITL escalate 點(input/between-turns/tool/output ESCALATE,`loop.py:634-1620`)、durable resume、chat-v2 Inspector(Turn Block / 思考過程 / 工具串流 / subagent Tree)、SSE 即時事件;verification-ESCALATE / output-ESCALATE(投遞前暫停)比多數框架細緻
+- ⚠️ **但同研究一樣無 UX 對照實證**:無數據證明這些介入點/可視化「量化改善了 end-user 信任或介入效率」
+- 💡 **藍海 + 方法論契合**:drive-through 文化能產出業界缺的 agent-UX 實證(A/B 測「有/無 Inspector 思考過程」對信任與介入正確率影響)
+
+---
+
+## 🎯 綜合:最值得關注的 5 個機會(按研究背書強度)
+
+| 優先 | 機會 | 研究背書 | 現況 | 已識別? |
+|------|------|---------|------|---------|
+| **1** | **顯式任務原語(TodoWrite 式 durable 任務脊椎)** | 發現 11 最高槓桿 | 有 restart 底座、缺 decompose 結構 | ✅ 已有 thin-spike eval,待決定 |
+| **2** | **長程「可靠性實測」(pass@k 式重複驗證)** | 發現 9 reliability≠capability | drive-through 是 pass@1 式單次 | ❌ 未識別(研究新增視角) |
+| **3** | **安全從「偵測」轉「結構限制」(評估 6 模式)** | 發現 14 restrict not detect | RiskyActionDetector 是 regex 偵測 | ⚠️ 列了 detection 但方向是加 detector |
+| **4** | **verification 重試清掉失敗 context(防 self-conditioning)** | 發現 10 錯誤留 context 自我放大 | 目前 append 失敗答案再改 | ❌ 未識別(研究新增視角) |
+| **5** | **壓縮階梯化(僅走長 autonomous task 時)** | 發現 5 + CC 5 層 | 單層 75%/turn>30 | ✅ cc-long-running 已點明條件性 |
+
+**兩個 V2 強過研究範例、應守住的地方**:
+- **durable 可治理 HITL pause**(發現 7)——比 LangGraph/CC 都重,多租戶 SaaS 正確選擇,別為「學 CC 輕量化」而弱化
+- **5-scope 記憶隔離**(發現 12)——比 CC 單一 MEMORY.md 嚴謹,別為學 ACE scoring 而弱化隔離
+
+---
+
+## 後設觀察
+V2 內部文件(task-primitive eval、cc-long-running、cc-parity)**已獨立得出與外部研究高度重疊的結論**(任務原語缺口、壓縮階梯、self-continuation、multi-model profile)。這份 deep research 的**增量價值**主要在兩個內部文件還沒涵蓋的學術視角:
+1. **發現 9/10「reliability≠capability + self-conditioning」實證** → 給「為何要做可靠性實測、為何 verification 重試別把錯誤留 context」的硬數據依據
+2. **發現 14「6 種抗注入結構模式」** → 把「dangerous command detection」方向從「加 detector」修正為「結構限制」
+
+---
+
+## 校正紀錄(Explore agent 偏差)
+- Agent 3 報「Cat 10 verification loop 內未啟用」**錯誤** → 實際 in-loop verify gate 存於 `loop.py:1770` `_cat10_verify_gate()` + 修正迴圈 `2617-2687`(預設 2 次)+ verification-ESCALATE;CLAUDE.md 57.98/57.99 drive-through 佐證。Agent 3 grep 用錯關鍵字漏掉
+- `max_turns`:loop ctor 預設 **50**(`loop.py:323`),但 chat 主流量 handler 寫死 **8**(`handler.py:710`)→ 主流量邊界是 8

--- a/claudedocs/5-status/cc-long-running-loop-source-analysis-20260619.md
+++ b/claudedocs/5-status/cc-long-running-loop-source-analysis-20260619.md
@@ -1,0 +1,209 @@
+# CC v2.1.88 源碼剖析 — agent loop 為何能「長時間運行數十小時」
+
+**Purpose**: 用 Claude Code `@anthropic-ai/claude-code` v2.1.88 提取源碼,逐行回答一個具體問題:「用戶發一次 input 後,CC 的 agent loop 憑什麼能自己一直跑(號稱數十小時),又在什麼條件下停下來把控制權交回用戶?」核心結論:**CC 沒有「長時間執行」的特殊機制 —— 它只有一個無轉數上限的 `while(true)` ReAct loop,唯一退出信號是「模型這一輪不再呼叫工具」;所謂「數十小時」= 模型自己持續發 tool_use + 多層壓縮讓 context 永不溢出 + 多層 `continue` 讓錯誤永不致命。**
+**Category / Scope**: Status / External-benchmark source study(參考,**非 V2 設計權威**)
+**Created**: 2026-06-19
+**Last Modified**: 2026-06-19
+**Status**: Active(snapshot;基於 CC `@anthropic-ai/claude-code` v2.1.88 提取源碼,2026-03-31 擷取)
+**Analysis env / Method**: 親讀 `query.ts` 主迴圈骨架(L219-1729)逐段核實 + 3 個 Explore agent 平行深挖周邊子系統(compaction / 停止條件 / 長運行 enabler)後,**關鍵主張(退出邏輯 / token-budget continuation / retry 常數 / autocompact 門檻)由助手親自讀源碼逐一核對**,非僅採信 agent 回報。所有 `file:line` 與常數均已對源碼驗證。
+**權威聲明**:本文是「研究外部 benchmark CC」的筆記,**不是 V2 設計文件**。V2 的長運行設計(`max_turns=8` 有界爆發 + 跨輪 rehydration)以 sprint 57.127 + `chat-v2-agent-loop-capability-drivethrough-20260618.md` §3 為準。
+
+> **源碼位置**:本次分析用的是**已複製進 repo 的工作副本** `reference/claude-code-source-cdoe/src/`(git **untracked**,未 vendored 入版本控制 —— 維持「CC 是外部唯讀標竿」立場,與既有鏈一致)。等同前兩份文件引用的 `C:\Users\Chris\Downloads\CC-Source\`,版本同鎖 v2.1.88。所有行號以此副本為準。
+
+> **既有 CC 分析鏈**:本文承接 [`agent-harness-cc-parity-20260607.md`](agent-harness-cc-parity-20260607.md)(部件級對照)+ [`cc-source-blueprint-pause-resume-phases-20260608.md`](cc-source-blueprint-pause-resume-phases-20260608.md)(phase / pause-resume 證偽)。前兩份回答「CC 有哪些齒輪 / CC 是不是 phase 狀態機 / CC 有沒有 durable resume」;**本文回答它們未深挖的力學:「同一個 `while(true)` loop 憑什麼能跑很久」**。三份互補,行號互相交叉驗證(皆據 `query.ts`,L241-307 主迴圈一致)。
+
+---
+
+## 0. 一句話 + executive
+
+> **核心真相**:CC 的「數十小時」不是一個 feature,是三件事的乘積 ——
+> **(1) 結構**:互動式 REPL 的 loop **無轉數上限**,唯一自然停止點是模型 end_turn(本輪無 tool_use);
+> **(2) context 不爆**:每次呼叫模型前跑 **5 層由輕到重的壓縮管線**,讓上萬輪對話的 token 永遠落在 window 內;
+> **(3) 錯誤不致命**:迴圈內 **7 個 `continue` 自癒站點** + fallback model + 持久重試(6hr cap + 30s 心跳)讓 413 / 過載 / token 撞頂全部變成「恢復後重跑」而非 throw 退出。
+> 模型只要持續決定「再呼叫一個工具」,這三件事就讓它能無限跑下去。「停」反而是少數明確事件(end_turn / maxTurns / 中斷 / 不可恢復錯誤)。
+
+主迴圈一覽(`query.ts`,行號已核實):
+
+```
+query()  L219  → queryLoop()  L241  → while(true)  L307 … L1728
+  每圈:
+    L365-467  context 管理管線(5 層,§3)           ← 為何 context 不爆
+    L659      callModel() 串流呼叫 LLM
+    L557      toolUseBlocks ← 串流中收集 tool_use   ← 唯一退出信號
+    L1062     if (!needsFollowUp):  本輪無工具
+                …413/media/max-token 恢復(§4)…
+                L1267 stop hooks  ·  L1308 token budget continuation(§6)
+                L1357 return {reason:'completed'}    ← 唯一「正常結束」
+    L1485     工具執行後若被中斷 → return aborted_tools
+    L1570     queued commands 注入下一輪(§6)
+    L1705     if (maxTurns && nextTurnCount>maxTurns) return max_turns  ← 互動模式不設 maxTurns
+    L1714     next.messages=[...舊,...assistant,...toolResults]
+    L1727     state=next → 迴圈續跑                  ← ReAct 續跑本體
+```
+
+---
+
+## 1. 迴圈骨架:退出由「有沒有 tool_use」單一決定
+
+`queryLoop` 是 async generator,`while(true)` 無條件迴圈(`query.ts:307`)。退出信號**只有一個**,源碼註解(`query.ts:554-556`)寫得很直白:
+
+> `// Set during streaming whenever a tool_use block arrives — the sole loop-exit signal. If false after streaming, we're done (modulo stop-hook retry).`
+
+- `toolUseBlocks: ToolUseBlock[]`(`L557`)在串流中每遇一個 tool_use 就 push。
+- `needsFollowUp`(`L558` 初始 false)在 `toolUseBlocks.length > 0` 時轉 true。
+- `L1062 if (!needsFollowUp)`:本輪沒有工具 → 進「收尾」分支 → 最終 `L1357 return {reason:'completed'}`。
+- 否則(有工具結果)→ `L1714-1727` 把 `[...messagesForQuery, ...assistantMessages, ...toolResults]` 組成下一輪 state → 迴圈。
+
+**意義**:這是純 ReAct。迴圈對「該跑多久」沒有任何意見 —— 是**模型靠持續發 tool_use 來驅動自己**。工具結果回注成下一輪輸入,模型再推理,如此循環。
+
+---
+
+## 2. 為何能「長」:互動模式下沒有轉數上限(結構性根因)
+
+```
+L1705:  if (maxTurns && nextTurnCount > maxTurns)   return {reason:'max_turns', turnCount}
+L1508:  (中斷路徑同樣檢查)  if (maxTurns && nextTurnCountOnAbort > maxTurns) …
+```
+
+`maxTurns` 是**可選參數**(`QueryParams.maxTurns?: number`)。判斷式 `if (maxTurns && ...)` —— **互動式 REPL 根本不傳 `maxTurns`**;它只在 SDK / headless / subagent 場景被設定(cc-parity §3 #1 記 SDK default 200)。
+
+⇒ **互動 session 的 loop 無轉數天花板,唯一自然停止 = 模型選擇 end_turn**。這就是「數十小時」最根本的結構原因:不是它「被設計成能跑久」,是「沒有任何計數器叫它停」。
+
+> **對照 V2**:`handler.py:710` 寫死 `max_turns=8`。這正是你 task-primitive-eval 標示的「有界爆發」邊界。CC 互動模式把這個上限**整個拿掉** —— 差異不是技術能力,是**互動 CLI 信任模型自停 vs 多租戶 server 要可治理上限**的形態選擇。
+
+---
+
+## 3. 長運行的真正 enabler:context 永不溢出(每輪呼叫前 5 層壓縮)
+
+模型能跑上萬輪而不爆 context,靠 `query.ts:365-467` 在**每次 callModel 之前**依序跑的壓縮管線(由輕到重;多數 feature-gated,代表是逐步推出的優化):
+
+| 層 | 實作 / gate | 做什麼 | 觸發 | 行號 |
+|---|---|---|---|---|
+| 1. tool-result budget | `utils/toolResultStorage.ts` `applyToolResultBudget` | 超大工具結果落盤,訊息裡只留 reference + 預覽 | 工具宣告 `maxResultSizeChars` 超標 | `query.ts:379` |
+| 2. snip(`HISTORY_SNIP`) | `snipModule.snipCompactIfNeeded` | 移除舊訊息,**不呼叫 LLM**;回報 `tokensFreed` 去校正 autocompact 門檻 | feature-gated | `query.ts:401-409` |
+| 3. microcompact(`CACHED_MICROCOMPACT`) | `services/compact/microCompact.ts` | **純按 `tool_use_id`** 清空最舊工具結果內容(從不看內容,所以與層 1 的內容替換正交) | 時間 / cache-edit | `query.ts:414` |
+| 4. context collapse(`CONTEXT_COLLAPSE`) | collapse store + `projectView()` 每輪重放 commit log | 分層折疊,保粒度;若折疊後已低於門檻,則 autocompact 變 no-op(保留 granular context 而非單一摘要) | 跑在 autocompact **之前** | `query.ts:440-447` |
+| 5. **autocompact** | `services/compact/autoCompact.ts` | 呼叫 LLM 產生摘要 + 保留最近 K 條,`buildPostCompactMessages` 重建並標 compact boundary | **context 用到 ~93.5%** | `query.ts:454` |
+
+核實過的關鍵常數(`services/compact/autoCompact.ts`):
+
+| 常數 | 值 | 行號 | 意義 |
+|---|---|---|---|
+| `AUTOCOMPACT_BUFFER_TOKENS` | `13_000` | L62 | 觸發門檻 = `effectiveContextWindow − 13k` |
+| `getAutoCompactThreshold(model)` | `window − 13k` | L72-76 | 200k window ⇒ **~187k / 93.5% 觸發** |
+| `MAX_OUTPUT_TOKENS_FOR_SUMMARY` | `20_000` | L30 | effective window 還會預扣摘要輸出空間 |
+| `MANUAL_COMPACT_BUFFER_TOKENS` | `3_000` | L65 | `/compact` 手動門檻更貼近上限 |
+| `MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES` | `3` | L70 | circuit breaker:連 3 次壓縮失敗才放棄,防無限重試燒 API |
+
+> **對照 V2**:你只有**單層** compaction(`CHAT_COMPACTION_TOKEN_BUDGET`,且 ≥3 user turn 才實際壓)。CC 是 **5 層階梯**:輕量層(snip / microcompact,毫秒級、零 LLM)先扛日常,重量層(autocompact,秒級、要 LLM call)最後才上。**這個「便宜的先做、貴的最後做」的階梯,才是 CC 能撐超長對話的工程核心** —— 比「無 maxTurns」更值得學(cc-parity §7.4 已警告:5-stage 對短對話是過度工程,但對 autonomous long task 是剛需)。
+
+---
+
+## 4. 為何不會中途死:錯誤非致命 = 7 個 `continue` 自癒站點 + retry 韌性
+
+迴圈裡每個失敗都不是 `throw` 出迴圈,而是觸發一條特定恢復路徑後 `continue` 回 `while(true)`。`query.ts` 7 個 continue 站點:
+
+| # | 站點 | 觸發 | 恢復動作 |
+|---|---|---|---|
+| 1 | `L894-951` | 主模型連 3 次 529 過載 → `FallbackTriggeredError` | 切 `fallbackModel`、清過期 assistant、重建 streamingToolExecutor、重試 |
+| 2 | `L1089-1116` | prompt too long(413) | 先 drain 已 stage 的 context-collapse |
+| 3 | `L1119-1166` | 413 仍在 | reactive compact(完整摘要)後重試 |
+| 4 | `L1199-1221` | max_output_tokens 撞頂 | 從 8k escalate 到 64k(`ESCALATED_MAX_TOKENS`)同題重試 |
+| 5 | `L1223-1252` | 仍撞頂 | 注入「Resume directly — no apology, no recap」續寫(最多 `MAX_OUTPUT_TOKENS_RECOVERY_LIMIT` 次) |
+| 6 | `L1282-1306` | stop hook 回 blockingErrors | 注入錯誤後重跑(`stopHookActive=true`) |
+| 7 | `L1316-1340` | token budget 判定續跑 | 注入 nudge 合成訊息(§6) |
+
+⚠️ 多條路徑都有**防死亡螺旋**的明確守衛(源碼註解親述教訓):413 壓不動時**不 fall through 到 stop hooks**(`L1168-1172`:否則 error→hook blocking→retry→error 無限燒 call);stop-hook 重跑時**保留** `hasAttemptedReactiveCompact`(`L1292-1296`:重置會造成 compact→still too long→error→hook→compact 無限迴圈,曾燒掉數千 call)。
+
+底層 API 韌性在 `services/api/withRetry.ts`(常數已核實):
+
+| 常數 | 值 | 行號 |
+|---|---|---|
+| `DEFAULT_MAX_RETRIES` | `10` | L52 |
+| `MAX_529_RETRIES` | `3`(連 3 次 529 → 觸發 fallback) | L54 |
+| `PERSISTENT_MAX_BACKOFF_MS` | `5 * 60 * 1000`(5 分鐘) | L96 |
+| `PERSISTENT_RESET_CAP_MS` | `6 * 60 * 60 * 1000`(**6 小時**) | L97 |
+| `HEARTBEAT_INTERVAL_MS` | `30_000`(30 秒) | L98 |
+
+**Ant-only 無人值守模式**(`CLAUDE_CODE_UNATTENDED_RETRY`,`L101`;非外部 build 預設):rate-limit 持續重試達 **6 小時 reset cap**,每 **30 秒**吐一個 keep-alive 防 orchestrator 判定 session 掉線(`L500`)。**這條就是「掛機跑一整晚不死」的字面實作** —— 但要誠實標明:它是 ant-internal flag,不是公開預設行為。
+
+---
+
+## 5. 何時停下來把控制權交回用戶(4 類 + 1 個特例)
+
+| 停止類型 | 機制 | 行號 | 控制權回到用戶的方式 |
+|---|---|---|---|
+| **任務完成** | 模型 end_turn(無 tool_use)+ 所有 recovery / stop-hook 都放行 | `L1357` `return {reason:'completed'}` | 正常 return Terminal |
+| **轉數上限** | 僅當有設 `maxTurns`(SDK / subagent;互動模式無) | `L1705` `return {reason:'max_turns'}` | return + `max_turns_reached` 附件 |
+| **用戶中斷** | Esc → `abortController.signal.aborted` | `L1015`(串流中)/ `L1485`(工具中) | `return {reason:'aborted_streaming'/'aborted_tools'}` |
+| **不可恢復錯誤** | 413 壓不動 / 圖太大 / 最後訊息是 API error | `L1175 / L1182 / L1264` | yield 錯誤訊息 + return |
+| **危險操作 / 需許可**(特例) | `canUseTool` 在**工具執行層** `await` 一個 Promise | `services/tools/toolExecution.ts:921`、`hooks/useCanUseTool.tsx` | **不是迴圈停**:該工具 `await` 卡住,UI 收集用戶決定後 resolve;迴圈因為在 await 工具批次而被動暫停 |
+
+> **設計洞察(對 V2 最重要,延伸 cc-source-blueprint §2)**:CC **沒有獨立的 pause/resume 狀態機**。「危險操作暫停」只是工具 handler 內 `await` 一個由 UI resolve 的 Promise —— 暫停狀態活在 in-process 的 Promise / AbortController,**不持久化**(這正是 cc-source-blueprint 證偽「CC 無 durable pause-resume」的執行層細節)。`canUseTool` 三種結果:`allow` 直接跑 / `deny` 回 tool_result 錯誤後迴圈續下一輪 / `ask` 彈互動對話阻塞該工具。**注意:permission 不退出迴圈,只阻塞單一工具** —— 迴圈是被動等待。
+>
+> V2 反而做了更重的東西:HITL ESCALATE → durable checkpoint 暫停 → 獨立 `/resume` 端點重建。CC 是「行程內輕量暫停」,V2 是「跨行程可治理暫停」。差異純粹來自**互動 CLI vs 多租戶 SaaS** 的本質需求,不是誰對誰錯(cc-source-blueprint §2.5 已列「loop phase / 執行中間狀態 CC 根本不存 → V2 自研」)。
+
+---
+
+## 6. 兩個「自主續跑」附加引擎(超越單純 end_turn)
+
+CC 還有兩個機制能在模型「想收手」時把它推回去繼續,**不需用戶再輸入** —— 這是最接近「自動續跑調度器」的真實實作:
+
+### 6.1 Token budget continuation(`query/tokenBudget.ts` 全讀 + `query.ts:1308-1340`)
+- **僅在 `feature('TOKEN_BUDGET')` 開且設了 budget 時生效**(`tokenBudget.ts:51-53`:`agentId || budget===null || budget<=0` 直接回 stop)。**預設不啟用** —— 這是 opt-in,不是日常行為。
+- 邏輯:本輪用量 `< budget × 0.9`(`COMPLETION_THRESHOLD`)且非報酬遞減 → 注入 `createUserMessage({content: nudgeMessage, isMeta:true})` 再 `continue`(`query.ts:1321-1340`)。
+- **報酬遞減守衛**(`tokenBudget.ts:59-62`):`continuationCount≥3 && deltaSinceLastCheck<500 && lastDelta<500`(`DIMINISHING_THRESHOLD=500`)→ 才判定停,避免空轉。
+- 本質 = **用合成 `isMeta` user message 自我延續**:模型以為用戶說「繼續」,於是繼續做。`isMeta:true` 讓這訊息在 UI / SDK 層不顯示。
+
+### 6.2 Queued commands 注入(`query.ts:1570-1643`)
+- 每輪工具跑完後,把佇列(`utils/messageQueueManager.ts` 的 process-global singleton)裡的 `task-notification`(背景 subagent 完成通知)+ 排隊 `prompt` 轉成 attachment,併入下一輪輸入。
+- agent 各自只 drain 屬於自己的(main thread drain `agentId===undefined`,subagent drain 自己的 id;`L1570-1578`)。
+- slash command **排除**(`L1573`,要走 turn 結束後的 `processSlashCommand`,不能當文字塞給模型)。
+- ⇒ 背景任務完成、排隊指令靠這條**無聲驅動續跑**:不中斷串流、不等用戶回應。`scheduler/cron` 式無人值守自動化即由此鋪路。
+
+> **對照 V2**:你目前**無**自主續跑引擎(每爆發需新 send)。CC 的 6.1 給了一個極輕量範本:**不需要 task primitive,只需「判定該繼續 → 注入一條 nudge synthetic message」**。這直接回應你 task-primitive-eval 的「自動續跑調度器」缺口 —— CC 證明它可以做得很薄(一個 budget 判定 + 一條 isMeta 訊息),不必先建 durable 任務脊椎。
+
+---
+
+## 7. 跨 session 持久化(關掉再開繼續)
+
+`assistant/sessionHistory.ts` + `QueryEngine.ts`(`recordTranscript` / `flushSessionStorage`):每輪訊息 fire-and-forget 落盤 `{projectDir}/{sessionId}.jsonl`(一行一 entry;subagent 用 `agent-{id}.jsonl`)。`/resume` 從 session 檔重載**整個 Message[]** 再進 `query()`。compact 邊界訊息帶 `tailUuid` 指向未壓縮段尾,壓縮後 resume 也不丟接點。
+
+⚠️ 但(承 cc-source-blueprint §2.2):這是「**重載整段對話從頭跑**」,**不是**「從中斷點 mid-loop 恢復」—— tool 執行中間狀態 / active stream / loop phase 全部遺失。CC 的「持久化」對長運行的意義是「斷線後對話不丟」,不是「執行狀態可續」。
+
+---
+
+## 8. 對照 V2 + 三個值得研究的 CC 設計
+
+| 維度 | Claude Code(互動) | V2(chat real_llm) |
+|---|---|---|
+| 迴圈 | `while(true)` ReAct,**無轉數上限** | `while-true` TAO,**`max_turns=8` 硬上限** |
+| 長運行模型 | 單次無界 run,模型自決何時停 | 多次有界爆發 + 跨輪 rehydration(57.127) |
+| Context 管理 | **5 層階梯**(budget / snip / microcompact / collapse / autocompact) | 單層 compaction(≥3 turn 觸發) |
+| 自主續跑 | token-budget continuation(opt-in)+ queued-command 注入 | 無(每爆發需新 send) |
+| 暫停 / HITL | 行程內 `await` Promise,**不持久化** | durable checkpoint + `/resume` 端點(可治理) |
+| 韌性 | fallback model + 6hr 持久重試 + 30s 心跳(ant flag) | adapter 層重試 |
+| 任務脊椎 | 隱式(全靠 messages + tool_use 鏈) | task-primitive-eval 標示的缺口 |
+
+**最值得研究的三個 CC 設計**(都直接對應 task-primitive-eval 的三缺口分析):
+
+1. **「無界 + 多層壓縮」取代「有界 + rehydration」** —— CC 證明只要壓縮夠強,單次無界 run 在技術上可行;V2 的 `max_turns=8` 是伺服器治理選擇,不是技術必需。若要放寬,**先補的不是 max_turns 數字,是壓縮階梯**(否則放寬即爆 context)。
+2. **合成 `isMeta` user message 自我延續(§6.1)** —— 這是「自動續跑調度器」的最小實作:不需 task primitive,只需「判定該繼續 → 注入一條 nudge」。比你評估的 DB-backed task store 輕得多,可作為續跑缺口的 thin-spike 起點。
+3. **暫停 = await Promise 而非狀態機(§5)** —— CC 用最輕的方式做 HITL;V2 的 durable pause 更重但能跨行程。差異來自 SaaS 多租戶需求,**不是 V2 過度設計** —— 反而印證 cc-source-blueprint「durable resume 是 CC 零藍本的純自研區」。
+
+---
+
+## 9. 與既有 CC 分析鏈的關係(三份互補,非重複)
+
+| 文件 | 回答的問題 | 與本文的關係 |
+|---|---|---|
+| `agent-harness-cc-parity-20260607` | V2 有沒有 CC 的 18 個進階齒輪? | 部件**靜態盤點**;本文補「核心 loop 齒輪轉起來的動態力學」 |
+| `cc-source-blueprint-pause-resume-phases-20260608` | CC 是 phase 狀態機嗎?有 durable resume 嗎?(答:都沒有) | **證偽** CC 的兩個假設;本文承接「CC 是 turn loop」這個事實,往下挖「這個 turn loop 為何能跑長」 |
+| **本文(cc-long-running-loop-source-analysis)** | 同一個 `while(true)` loop 憑什麼跑數十小時 + 何時停? | 補前兩份未深挖的**長運行力學**:退出信號 / 無 maxTurns / 5 層壓縮 / 7 自癒站點 / retry 常數 / 自主續跑引擎 |
+
+三份行號互相交叉驗證(皆據 `query.ts`,主迴圈 L241-307 一致),可合視為「CC v2.1.88 核心 loop 完整逆向」的三個切面:**有哪些齒輪(parity)· 是什麼形狀(blueprint)· 怎麼轉得久(本文)**。
+
+---
+
+## Modification History (newest-first)
+- 2026-06-19: Initial creation — CC v2.1.88 `query.ts` 主迴圈逐段親讀 + 3 Explore agent 周邊深挖 + 助手親自核實關鍵主張/常數。答「為何能長運行」:無 maxTurns 上限(互動模式)+ 5 層壓縮管線(snip/microcompact/collapse/autocompact,~93.5% 觸發)+ 7 個 continue 自癒站點 + 6hr 持久重試/30s 心跳(ant flag)+ 2 自主續跑引擎(token-budget continuation opt-in / queued-command 注入)。答「何時停」:end_turn(唯一退出信號 toolUseBlocks=0)/ maxTurns(SDK only)/ 中斷 / 不可恢復錯誤 + permission 特例(工具層 await 非迴圈停)。接上 cc-parity + cc-source-blueprint 成三份互補鏈;接 task-primitive-eval 三缺口。源碼用 repo 內 untracked 工作副本 `reference/claude-code-source-cdoe/`。


### PR DESCRIPTION
## Summary

兩次同日 deep-research(claim 級對抗驗證版 + 8 角度輕驗證版)針對「AI agent 系統(含 harness)如何改善使用體驗與工程可靠性(2024–2026)」,加上一份對 V2 11+1 範疇的 **file:line grounding** 落地對照,整合成單一綜合主文件。

中立全景結論:主戰場已從「能不能做」轉向「能不能可靠地長時間做」;工程可靠性層有最強實證,End-user UX 層幾乎無獨立硬實證。

## 新增文件

**`claudedocs/5-status/`**
- `ai-agent-harness-consolidated-analysis-20260622.md` — ⭐ **入口**(讀這份 = 讀完三份):執行摘要 9 條 + 8 維度全景 + 11+1 落地對照(✅/⚠️/❌/💡 + file:line)+ 6 跨維度主題 + 8 優先機會 + 證據品質 + thinking×self-conditioning 矛盾調和
- `ai-agent-harness-market-research-panorama-20260622.md` — 中立全景,14 條 claim 級對抗驗證 findings
- `ai-agent-harness-research-vs-v2-mapping-20260622.md` — 14 findings × V2,`loop.py` 行級 grounding

**`claudedocs/1-planning/`**
- `agent-harness-ux-research-20260622.md` — 8 角度 / 41 來源,per-Cat 可操作 pattern + 證據品質審查

**其他**
- `cc-long-running-loop-source-analysis-20260619.md`(新索引行引用,一併納入避免 dangling reference)
- `5-status/README.md` 群組 2 索引更新

## 8 優先機會(綜合排序)

1. 顯式任務原語(DAG-based)· 2. pass^k 可靠性實測 · 3. 安全從「偵測」轉「結構限制」(6 模式)· 4. 分層 compaction(tool-result clearing 先行)+ ACON 目標帶 · 5. Cat 12 標準化在 OTel GenAI conventions · 6. verification 重試清掉失敗 context(防 self-conditioning)· 7. tool-description lint + structured-error reflection · 8. key-condition verifier

## 注意

- **驗證層級:程式碼 grounding(file:line),非 drive-through**。標 ✅ 者若要宣稱「使用者真的能用」,以既有 drive-through 紀錄為準。
- 多數可靠性數字為 vendor self-report / 單篇 preprint(directional,非可重現 benchmark)—— 各文件 §證據品質 有逐項標註已核實 / 未核實 / mis-attributed。
- Docs-only;無程式碼變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)