### PR TITLE
fix(chat): New session no longer wipes the sidebar session list

### DIFF
--- a/claudedocs/4-changes/bug-fixes/FIX-034-chat-new-session-wipes-sidebar.md
+++ b/claudedocs/4-changes/bug-fixes/FIX-034-chat-new-session-wipes-sidebar.md
@@ -1,0 +1,50 @@
+# FIX-034: "New session" button wipes the chat sidebar session list
+
+**Date**: 2026-07-15
+**Sprint**: drive-through-driven immediate fix (`AD-Chat-New-Session-Wipes-Sidebar`)
+**Scope**: Frontend / chat_v2 (Zustand store + SessionList component)
+
+## Problem
+
+On the chat-v2 page, clicking the **[New session]** button made the **entire sidebar session list disappear**. Refreshing the page brought the list back. Reported via a user drive-through 2026-07-15.
+
+## Root Cause
+
+The "New session" button was wired to the store's `reset()`:
+
+- `SessionList.tsx:151` — `onClick={() => reset()}`
+- `chatStore.ts` `reset()` does `set({ ..._initial() })`
+- `_initial()` includes `sessions: []`
+
+So `reset()` zeroed the `sessions` sidebar list along with the conversation state. On refresh, `SessionList`'s mount effect calls `loadSessions()` (GET /sessions), which re-fetched and repopulated the list — hence "gone on click, back on refresh".
+
+The codebase already knew this sharp edge: `loadSessionHistory`'s comment reads *"preserve `sessions` + `mode` — … NOT reset() which nukes the sidebar list"*. Both `loadSessionHistory` and `applyPivot` (HANDOFF pivot) do conversation-only resets that preserve `sessions`; only the "New session" button used the full-wipe `reset()`.
+
+## Solution
+
+Add a dedicated **`newSession()`** store action — a conversation-only reset that clears the live conversation + inspector slices (turns / sessionId / activeSessionId / rawEvents / approvals / verifications / subagents / spans / memoryOps / todos) but **preserves the `sessions` sidebar list** (and `mode`, which is preserved automatically since it is not part of `_initial()`'s `Pick`). Wire the button to `newSession()`.
+
+`reset()` is left unchanged as the full wipe used by test teardown (`beforeEach`/`afterEach`) — separating the two avoids changing test-isolation semantics.
+
+- `chatStore.ts` — add `newSession: () => void` to the store type + `newSession()` implementation (`set((s) => ({ ..._initial(), sessions: s.sessions }))`).
+- `SessionList.tsx` — subscribe to `newSession` (was `reset`); button `onClick={() => newSession()}`.
+
+## Verification
+
+**Gate layer**:
+- Vitest (4 affected files): 86 passed — new `chatStore.newSession.test.ts` (4 tests: preserves sidebar / clears conversation / preserves mode / reset() still full-wipes) + updated `SessionList.test.tsx` regression (button click → `activeSessionId` null **and** sidebar list preserved) + `chatStore.mergeEvent.test.ts` + `chatStore.historyReplay.test.ts` (no regression).
+- ESLint (`npm run lint`, no `--silent`): exit 0.
+- Build (tsc typecheck + vite): built, exit 0.
+
+**Drive-through layer** (real dev server + real backend, 2026-07-15): user confirmed — after the fix, clicking [New session] starts a fresh conversation and the sidebar session list **no longer disappears**.
+
+## Impact
+
+- Frontend-only. No backend / API / migration change.
+- `reset()` now has no production caller (only test teardown); intentional — it is the store's full-wipe primitive.
+
+## Related
+
+- `AD-Chat-New-Session-Wipes-Sidebar` — discovered + fixed in one session via drive-through; this FIX doc is the record (not pre-registered in next-phase-candidates.md).
+- `chatStore.ts` `loadSessionHistory` / `applyPivot` — the pre-existing conversation-only-reset siblings this fix mirrors
+- CLAUDE.md §Drive-Through Acceptance Hard Constraint (bug found + fix confirmed by drive-through)

--- a/frontend/src/features/chat_v2/components/SessionList.tsx
+++ b/frontend/src/features/chat_v2/components/SessionList.tsx
@@ -34,6 +34,7 @@
  * Last Modified: 2026-06-12
  *
  * Modification History:
+ *   - 2026-07-15: "New session" → newSession() (was reset()) — keep sidebar list (AD-Chat-New-Session-Wipes-Sidebar)
  *   - 2026-06-16: Sprint 57.126 — session click → loadSessionHistory (replay) replaces setActiveSessionId
  *   - 2026-06-12: Sprint 57.107 B3 — real GET /sessions via loadSessions; drop fixture + DEMO banner; +handoff-chain badge + empty state
  *   - 2026-06-06: chat-v2 honest surface — wire "New session" → store.reset() (was a no-op button) + DEMO badge on section header (fixture list honesty) (CHANGE-054)
@@ -121,9 +122,11 @@ function SessionItem({ session }: { session: Session }): JSX.Element {
 export function SessionList(): JSX.Element {
   const { t } = useTranslation("common");
   // Honest-surface: "New session" was a visual-only button (no onClick). Wire it
-  // to reset the store so it actually starts a fresh conversation (clears turns /
-  // session id / inspector slices).
-  const reset = useChatStore((s) => s.reset);
+  // to newSession() — a conversation-only reset that starts a fresh conversation
+  // (clears turns / session id / inspector slices) while PRESERVING the sidebar
+  // session list (AD-Chat-New-Session-Wipes-Sidebar: reset() blanked the list until
+  // a page refresh re-fetched GET /sessions).
+  const newSession = useChatStore((s) => s.newSession);
   const sessions = useChatStore((s) => s.sessions);
   const loadSessions = useChatStore((s) => s.loadSessions);
 
@@ -148,7 +151,7 @@ export function SessionList(): JSX.Element {
           type="button"
           className="btn primary"
           data-size="sm"
-          onClick={() => reset()}
+          onClick={() => newSession()}
         >
           <Plus size={12} aria-hidden="true" />
           {t("chat.session.newSession")}

--- a/frontend/src/features/chat_v2/store/chatStore.ts
+++ b/frontend/src/features/chat_v2/store/chatStore.ts
@@ -37,6 +37,7 @@
  * Last Modified: 2026-06-16
  *
  * Modification History:
+ *   - 2026-07-15: +newSession() conversation-only reset — preserve sidebar list (AD-Chat-New-Session-Wipes-Sidebar; "New session" no longer blanks the session list)
  *   - 2026-07-07: Sprint 57.159 — context_compacted pushes a CompactionMarkerTurn (was rawEvents-only; Cat 4 L2→L3)
  *   - 2026-06-16: Sprint 57.131 — llm_request stamps per-turn model on the AgentTurn (Inspector model row)
  *   - 2026-06-16: Sprint 57.130 — +loop_terminated case (flip pending tool→error + terminated badge)
@@ -200,6 +201,9 @@ type ChatStoreState = {
   appendVerification: (event: VerificationEvent) => void;
   clearVerifications: () => void;
   clearSubagents: () => void;
+  // "New session" — conversation-only reset that PRESERVES the `sessions` sidebar
+  // list (reset() below is the full wipe used by tests).
+  newSession: () => void;
   reset: () => void;
 };
 
@@ -1168,6 +1172,19 @@ export const useChatStore = create<ChatStoreState>((set, get) => ({
   clearVerifications: () => set({ verifications: [] }),
 
   clearSubagents: () => set({ subagents: [] }),
+
+  // AD-Chat-New-Session-Wipes-Sidebar: the "New session" button is a
+  // CONVERSATION-ONLY reset — it starts a fresh chat (clears turns / sessionId /
+  // activeSessionId / inspector slices) but PRESERVES the `sessions` sidebar list
+  // that loadSessions() fetched. reset() spreads _initial() (which zeroes
+  // `sessions`), so wiring "New session" to reset() blanked the whole sidebar until
+  // a page refresh re-fetched GET /sessions. Mirrors loadSessionHistory / applyPivot
+  // (both keep sessions). `mode` is preserved automatically (not in _initial()'s
+  // Pick, so the partial set() merge leaves it untouched).
+  newSession: () => {
+    _turnCounter = 0;
+    set((s) => ({ ..._initial(), sessions: s.sessions }));
+  },
 
   reset: () => {
     // Zero the module-global turn counter so a fresh session's turns restart at

--- a/frontend/tests/unit/chat_v2/chatStore.newSession.test.ts
+++ b/frontend/tests/unit/chat_v2/chatStore.newSession.test.ts
@@ -1,0 +1,103 @@
+/**
+ * File: frontend/tests/unit/chat_v2/chatStore.newSession.test.ts
+ * Purpose: Vitest coverage for chatStore.newSession — conversation-only reset that
+ *   preserves the sidebar session list (AD-Chat-New-Session-Wipes-Sidebar).
+ * Category: Frontend / tests / unit / chat_v2
+ * Scope: Phase 57 / AD-Chat-New-Session-Wipes-Sidebar
+ *
+ * Description:
+ *   The "New session" button used to call reset(), which spreads _initial()
+ *   (sessions: []) and blanked the whole sidebar until a page refresh re-fetched
+ *   GET /sessions. newSession() is the fix: a conversation-only reset that clears
+ *   the live conversation slices but PRESERVES `sessions` (and `mode`). These tests
+ *   assert both halves — the conversation is wiped, the sidebar survives.
+ *
+ * Modification History:
+ *   - 2026-07-15: Initial creation (AD-Chat-New-Session-Wipes-Sidebar)
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/features/chat_v2/services/chatService", () => ({
+  fetchSessionEvents: vi.fn(),
+  listSessions: vi.fn(),
+}));
+
+import { useChatStore } from "@/features/chat_v2/store/chatStore";
+import type { Session } from "@/features/chat_v2/types";
+
+const SESSIONS: Session[] = [
+  {
+    id: "a",
+    title: "session A",
+    agent: "agent",
+    turns: 3,
+    status: "done",
+    time: "t",
+    handoffParentId: null,
+    agentRole: "agent",
+  },
+  {
+    id: "b",
+    title: "session B",
+    agent: "agent",
+    turns: 1,
+    status: "running",
+    time: "t",
+    handoffParentId: null,
+    agentRole: "agent",
+  },
+];
+
+describe("chatStore.newSession (AD-Chat-New-Session-Wipes-Sidebar)", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+  afterEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  test("preserves the sessions sidebar list (the regression)", () => {
+    useChatStore.setState({ sessions: SESSIONS });
+    useChatStore.getState().newSession();
+    expect(useChatStore.getState().sessions.map((s) => s.id)).toEqual(["a", "b"]);
+  });
+
+  test("clears the live conversation slices", () => {
+    // Seed a populated conversation + inspector state (as if a chat had run).
+    useChatStore.setState({
+      sessions: SESSIONS,
+      sessionId: "a",
+      activeSessionId: "a",
+      status: "running",
+      totalTurns: 4,
+      turns: [{ role: "user", id: "t_1", at: "now", text: "hi" }],
+      rawEvents: [{ type: "loop_start" } as never],
+    });
+
+    useChatStore.getState().newSession();
+
+    const s = useChatStore.getState();
+    expect(s.turns).toEqual([]);
+    expect(s.sessionId).toBeNull();
+    expect(s.activeSessionId).toBeNull();
+    expect(s.status).toBe("idle");
+    expect(s.totalTurns).toBe(0);
+    expect(s.rawEvents).toEqual([]);
+    // Sidebar untouched.
+    expect(s.sessions.map((x) => x.id)).toEqual(["a", "b"]);
+  });
+
+  test("preserves the chat mode (not part of _initial())", () => {
+    useChatStore.setState({ sessions: SESSIONS, mode: "echo_demo" });
+    useChatStore.getState().newSession();
+    expect(useChatStore.getState().mode).toBe("echo_demo");
+    expect(useChatStore.getState().sessions).toHaveLength(2);
+  });
+
+  test("reset() still fully wipes (including sessions) — teardown contract intact", () => {
+    useChatStore.setState({ sessions: SESSIONS });
+    useChatStore.getState().reset();
+    expect(useChatStore.getState().sessions).toEqual([]);
+  });
+});

--- a/frontend/tests/unit/chat_v2/components/SessionList.test.tsx
+++ b/frontend/tests/unit/chat_v2/components/SessionList.test.tsx
@@ -197,13 +197,20 @@ describe("SessionList (Sprint 57.107 B3 — real backend data)", () => {
     expect(counts.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("'New session' resets the store (clears active session) — honest-surface wiring", async () => {
+  test("'New session' starts a fresh chat but PRESERVES the sidebar list (AD-Chat-New-Session-Wipes-Sidebar)", async () => {
     const user = userEvent.setup();
     seedSessions(SESSIONS);
     useChatStore.setState({ activeSessionId: "sess_root" });
     expect(useChatStore.getState().activeSessionId).toBe("sess_root");
+    const idsBefore = useChatStore.getState().sessions.map((s) => s.id);
+    expect(idsBefore.length).toBeGreaterThan(0);
     render(<SessionList />);
     await user.click(screen.getByRole("button", { name: /New session/i }));
+    // Conversation reset: the active session is cleared...
     expect(useChatStore.getState().activeSessionId).toBeNull();
+    // ...but the sidebar session list SURVIVES. The bug: "New session" was wired to
+    // reset(), which spreads _initial() (sessions: []) → the whole list vanished
+    // until a page refresh re-fetched GET /sessions.
+    expect(useChatStore.getState().sessions.map((s) => s.id)).toEqual(idsBefore);
   });
 });


### PR DESCRIPTION
## Problem

On chat-v2, clicking **[New session]** made the **entire sidebar session list disappear**; a page refresh brought it back. Reported via a user drive-through 2026-07-15.

## Root Cause

The "New session" button was wired to the store's `reset()`:

- `SessionList.tsx` — `onClick={() => reset()}`
- `chatStore.ts` `reset()` → `set({ ..._initial() })`, and `_initial()` includes `sessions: []`

So `reset()` zeroed the `sessions` sidebar list along with the conversation state. On refresh, `SessionList`'s mount effect calls `loadSessions()` (GET /sessions) → the list re-fetched and reappeared — hence "gone on click, back on refresh".

The codebase already knew this sharp edge — `loadSessionHistory`'s comment reads *"preserve `sessions` … NOT reset() which nukes the sidebar list"*. Both `loadSessionHistory` and `applyPivot` do conversation-only resets that preserve `sessions`; only "New session" used the full-wipe `reset()`.

## Fix

Add a dedicated **`newSession()`** store action — a conversation-only reset that clears the live conversation + inspector slices but **preserves the `sessions` sidebar list** (and `mode`, preserved automatically as it is not in `_initial()`'s `Pick`). Wire the button to `newSession()`. Leave `reset()` unchanged as the full wipe used by test teardown — separating the two avoids touching test-isolation semantics.

- `chatStore.ts` — `+newSession: () => void` + `set((s) => ({ ..._initial(), sessions: s.sessions }))`
- `SessionList.tsx` — subscribe to `newSession` (was `reset`); button `onClick={() => newSession()}`

## Verification

- **Vitest** (4 affected files): 86 pass — new `chatStore.newSession.test.ts` (preserves sidebar / clears conversation / preserves mode / reset() still full-wipes) + updated `SessionList.test.tsx` regression (click → `activeSessionId` null **and** sidebar preserved) + `chatStore.mergeEvent` + `chatStore.historyReplay` (no regression).
- **ESLint** (`npm run lint`, no `--silent`): exit 0.
- **Build** (tsc typecheck + vite): exit 0.
- **Drive-through** (real dev server + real backend, 2026-07-15): user confirmed — [New session] starts a fresh chat and the sidebar list no longer disappears.

## Scope

Frontend-only. No backend / API / migration change. `reset()` now has no production caller (test-teardown only) — intentional; it is the store's full-wipe primitive.

`AD-Chat-New-Session-Wipes-Sidebar` · FIX-034

🤖 Generated with [Claude Code](https://claude.com/claude-code)