### PR TITLE
chore(docs): stale-open backlog audit — 4 ADs were shipped weeks ago but never un-listed

### DIFF
--- a/claudedocs/1-planning/next-phase-candidates.md
+++ b/claudedocs/1-planning/next-phase-candidates.md
@@ -213,6 +213,8 @@ This list follows the canonical research §5 ranked order (#6 → #3 → #8 → 
 ## 🌱 Open Carryover ADs (raw per-sprint seeds)
 
 > Un-curated AD seeds lifted verbatim from each sprint's closeout `NEW carryover` / `Still-open` lists. **Some may since have been closed** (any `✅ CLOSED` / strike-through markers are preserved verbatim — trust the marker). Full context per AD → the archive block + the sprint's memory subfile. For the curated, prioritized candidate list see §Top Candidates (#1–#46) below.
+>
+> ⚠️ **Stale-open is real — verify before selecting** (2026-07-22 grep audit). A spot-check of 4 "open" ADs found **all 4 already shipped**, un-flipped for weeks: #23 register (57.87 `api/v1/tenants.py`) · #24 invite (57.85 `invites.py:189`) · #25 MFA (57.112 `mfa.py:155`) · `AD-Subagent-RealList` (57.78 `subagents.py:72`). Root cause: an AD is echoed into 2-4 places (this section + §Top Candidates + §6 bundle + the dashboard) but only ONE gets flipped at closeout. **Before drafting a plan from any entry here, grep the claimed gap in `backend/src` first** — that is Day-0 Prong 2 applied to the backlog itself. Knock-on: `5-status/v2-reality-audit-engine-vs-grounding-20260715.md` §7's "8 YES real-pull" includes these 4 → the real YES count is ≈ 5 (knowledge-connector 4 + `AD-Loop-CancelEvent-Poll`), and its 78% over-engineering index is a **conservative lower bound**.
 
 #### 🆕 Drive-Through 2026-07-15 — production persona + memory presentation gap
 **NEW `AD-Chat-Default-Persona-Demo-Leak`** (✅ FIXED 2026-07-15 — drive-through PASS 4/4, **method A**, branch `feature/chat-production-default-persona`, PR-pending): the real-chat 主流量 default system prompt IS `DEMO_SYSTEM_PROMPT` ("Sprint 50.2 demonstration agent"; `handler.py:154/301/915`, `resolve_session_persona:1017-1050` all fail-open to it) → unless a tenant sets an `agent_role` persona, **every ordinary user gets the demo persona**: self-identifies as a demonstration agent + is instructed to put "confidential" in any answer sharing something confidential (the 57.93 output-ESCALATE demo trigger) + echo/note triggers. AND it **never teaches the agent to USE injected memory** (57.148 `profile()` identity + 57.151 `recent_sessions()` session recall) to answer identity/history questions → the agent DENIES having memory + confuses timeline (prior session read as current). **Drive-through evidence** (jamie dev-login asked "what have we discussed before" → every fact tagged (confidential) + "I don't have access to complete chat history" + INC-99999 (a 07-09/10 PRIOR session) mislabeled "in this session"); **DB disproves the denial**: recall IS wired (`memory_session_summary` 24 rows + `memory_user` facts always-on inject via `builder.py:301`; the agent could name INC-99999 which exists ONLY in the session summary, not user facts). **Characterization**: a Potemkin variant (function is real, the PERSONA is a demo placeholder); audit pillar-3 ~40% verdict UNCHANGED (recall mechanism works), this is a persona/presentation gap the 4 audit facets all missed. **Method A** (user-selected 2026-07-15): new `DEFAULT_SYSTEM_PROMPT` (keep write_todos/knowledge_search guidance + ADD memory-usage guidance "use the identity/prior-session summary in your context to answer; do NOT deny having memory; do NOT tag things confidential without cause"; drop demonstration-agent identity + confidential mandate + echo/note) + `CHAT_DEMO_MODE` env flag (default False = clean production; demo triggers move behind the flag so 57.91/92/93 drive-through tests stay green) + session-summary hint gets a time marker (`retrieval.py:236`, fixes the timeline confusion). File change (actual): `handler.py` (`DEFAULT_SYSTEM_PROMPT` + `_default_persona()` + 5 `resolve_session_persona` fallbacks repointed) + `core/config` (`chat_demo_mode`) + `retrieval.py` (dated `[Prior session, YYYY-MM-DD]` marker) + **only 2** test files' compat (build_*handler defaults kept `= DEMO_SYSTEM_PROMPT` so the demo-test entry points stay untouched — 主流量 fixed via router-passed `resolve_session_persona`) + 3 new tests + drive-through PASS 4/4. CHANGE-133. Gates: mypy 400 · V2 lints 12/12 · pytest 16 unit + 28 demo-path integration green. Detail: CHANGE-133 + `5-status/v2-reality-audit-engine-vs-grounding-20260715.md` (§tracking to append).
@@ -257,15 +259,15 @@ This list follows the canonical research §5 ranked order (#6 → #3 → #8 → 
 - **`AD-Register-OIDC-User-Linkage-Phase58`** (NEW) — register creates the user by `email` (no `external_id`); the OIDC callback upserts by `(tenant_id, external_id)` → a later login creates a SECOND user row. Fix: callback link-by-email OR register OIDC-initiated.
 - **`AD-Tenant-Plan-Tiers-Phase58`** (NEW) — `TenantPlan` only has ENTERPRISE; the wizard's trial/pro/enterprise choice is stored in `meta_data` only. Real BASIC/STANDARD/trial tiers + quota enforcement are Phase 56+ Stage 2.
 - **Process (single occurrence — fold into `sprint-workflow.md` only if recurs)**: a concurrent Claude session sharing the repo working directory switched the branch mid-sprint (to `chore/drive-through-acceptance-principle`), stranding uncommitted Day-3 edits + hiding `registration.py` → a phantom mypy `import-untyped` first mis-chased as editable-install staleness. Diagnostic lesson: when a first-party import reads "installed missing py.typed" + the mypy source-file count doesn't increment → check `git branch` FIRST. Root cause = two-sessions-one-worktree (recommend separate git worktrees/clones per session); not a workflow gap.
-- **`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn; `/auth/mfa` still stub 501.
+- ~~**`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn; `/auth/mfa` still stub 501.~~ ✅ **CLOSED** **Sprint 57.112** (stale corrected 2026-07-22 — `api/v1/mfa.py:155` is real; TOTP only, **WebAuthn still open**).
 - **`AD-Auth-Recovery-Page-Phase58`** — password reset/recovery; needs an email adapter (none exists); `/auth/recovery` does not exist.
 - **`AD-Auth-PasswordLogin-Lockout-Phase58`** — brute-force throttle on `/auth/password-login` (+ register-spam throttle); reuse the Redis rate-limit infra.
 - **Calibration — `iam-backend-spike` 0.65 1st validation**: ratio ≈1.0 core (≈1.1-1.2 incl. the branch-collision anomaly) → KEEP single data point; flag the next IAM backend spike (MFA/recovery) for the 2nd validation per the 3-sprint window.
 ---
 
 #### 57.86
-- **`AD-Auth-Register-Backend-IAM-Block-B-Phase58`** — self-service tenant registration (POST /tenants/register: create tenant + first admin user + password; reuses `passwords.py` + `CredentialsService.set_password`). The register page is still fixture/501.
-- **`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn (password-login lands the user via `consumePostLoginRedirect()`; `/auth/mfa` still stub 501).
+- ~~**`AD-Auth-Register-Backend-IAM-Block-B-Phase58`** — self-service tenant registration … The register page is still fixture/501.~~ ✅ **CLOSED** **Sprint 57.87** (stale corrected 2026-07-22 — `api/v1/tenants.py` is real).
+- ~~**`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn (…; `/auth/mfa` still stub 501).~~ ✅ **CLOSED** **Sprint 57.112** (stale corrected 2026-07-22; WebAuthn still open).
 - **`AD-Auth-PasswordLogin-Lockout-Phase58`** (NEW) — brute-force / lockout throttle on `/auth/password-login` (no per-tenant login-attempt counter this spike; bcrypt cost=12 + generic-401 raise per-guess cost but no rate limit). Candidate substrate: the Redis rate-limit-counter infra (57.48/57.58).
 - **Password-strength policy** — invite-accept keeps `min_length=1`; password fields gain only `max_length=72` (bcrypt safety). Min length / complexity / breach-check is a follow-up.
 - **`AD-Auth-Recovery-Page-Phase58`** — password reset / recovery; `/auth/recovery` does not exist.
@@ -275,8 +277,8 @@ This list follows the canonical research §5 ranked order (#6 → #3 → #8 → 
 
 #### 57.85
 - **`AD-Auth-Credentials-PasswordLogin-Phase58`** (NEW, next obvious = 57.86) — local-password credentials table + bcrypt + a tenant-scoped password-login endpoint. The accept's `password` is accepted-not-stored until then; the created user authenticates via OIDC/dev-login. (Login-page UI wiring further gated by mockup-fidelity — mockup login has no password field.)
-- **`AD-Auth-Register-Backend-IAM-Block-B-Phase58`** — self-service tenant registration (POST /tenants/register: create tenant + first admin user).
-- **`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn (accept navigates to `/auth/mfa`, still stub 501).
+- ~~**`AD-Auth-Register-Backend-IAM-Block-B-Phase58`** — self-service tenant registration (POST /tenants/register: create tenant + first admin user).~~ ✅ **CLOSED** **Sprint 57.87** (stale corrected 2026-07-22).
+- ~~**`AD-Auth-MFA-Backend-IAM-Block-C-Phase58`** — Block C MFA TOTP + WebAuthn (accept navigates to `/auth/mfa`, still stub 501).~~ ✅ **CLOSED** **Sprint 57.112** (stale corrected 2026-07-22; WebAuthn still open).
 - **Invite email delivery** — no email facility exists; create returns the raw token in-response. Phase-58 follow-up (e.g. SMTP/SES adapter).
 - **Admin invites-list / resend UI** — `revoke` service method exists (US-4 revocable); a full management surface (list pending / resend / revoke UI) is a follow-up.
 - **Calibration**: `medium-backend` 0.80 greenfield-IAM data point ran ratio ~1.25 (over-band, as the plan flagged). Single outlier (ignored for the multiplier); if 57.86 (also greenfield IAM) confirms > 1.0 → propose a new `iam-backend-spike` class (~0.55-0.65). Track in `sprint-workflow.md §Scope-class matrix` if it recurs.
@@ -324,7 +326,7 @@ This list follows the canonical research §5 ranked order (#6 → #3 → #8 → 
 #### 57.77
 - ✅ #1+#2 Inspector Trace + Memory (57.75) · #3 admin-tenants stats (57.74)
 - ✅ `AD-Memory-OpsHistory-Backend` **fully closed** (backend 57.76 + frontend 57.77)
-- ⏳ **FE `/subagents` real list (`AD-Subagent-RealList-Phase58`) — THE LAST Area-A remaining item** (agent_catalog specs exist; needs tenant-facing GET + FE re-mount, like 57.73)
+- ✅ ~~FE `/subagents` real list (`AD-Subagent-RealList-Phase58`) — THE LAST Area-A remaining item~~ **CLOSED Sprint 57.78** (stale `⏳` corrected 2026-07-22 by grep audit: `backend/src/api/v1/subagents.py:72` router is re-pointed STUB → `agent_catalog` registry per its own header `Sprint 57.78 (re-point STUB → agent_catalog registry)`; `README-integration-gap-abc.md:41` already recorded it as the closing item of **Area-A COMPLETE**). The row survived here + in the §6 Backend-Wire bundle + the misc dashboard track purely as un-flipped copies.
 - (A-4 Tier 2 real Jaeger export = EXCLUDED per user program → Area-C/DevOps)
 - **READ-path ops** — write/evict only (57.76 backend); sampled reads a future option (row-volume tradeoff).
 - **role/session/system layer ops** — those layers raise / in-memory (57.76); not recorded → never appear in RecentOps/marks.
@@ -600,7 +602,7 @@ Sprint 57.19 carryover. Pages:
 ### 6. AD-Backend-Wire Bundle
 
 Sprint 57.19 4 NEW ADs:
-- Subagent-RealList-Phase58
+- ~~Subagent-RealList-Phase58~~ ✅ **CLOSED Sprint 57.78** (stale copy corrected 2026-07-22 — see #⏳ 57.77 block above)
 - Loop-Session-Enrich-Phase58
 - Overview-Backend-Wire
 - Orchestrator-Backend-Wire
@@ -681,14 +683,14 @@ Sprint 57.16 carryover. `/chat-v2` 的 `heading-order` + duplicate `<main>` land
 
 7 ADs from Sprint 57.23 AD-Auth-Page-Full-Rebuild-Round-2 closeout. Frontend rebuild shipped 8/8 USs with stub-501 demo banners; backend wiring deferred to Phase 58+ IAM Block B/C per Q2 frontend-only decision.
 
-### 23. AD-Auth-Register-Backend-IAM-Block-B-Phase58
-`POST /api/v1/tenants/register` real implementation. Currently 501 stub. Frontend `/auth/register` 4-step wizard fully shipped + i18n + Vitest 5 cases. Phase 58+ IAM Block B scope.
+### 23. ✅ CLOSED — AD-Auth-Register-Backend-IAM-Block-B (shipped Sprint 57.87)
+~~`POST /api/v1/tenants/register` real implementation. Currently 501 stub.~~ **Stale-open corrected 2026-07-22** (grep audit): the endpoint is REAL — `backend/src/api/v1/tenants.py` (header `Scope: Sprint 57.87 / US-1 + US-3 + US-4`, guest-exempt path, tenant + first admin user + password). The 2026-06-07 drive-through already recorded it green (register wizard → **201 + DB write + slug-unique 409**, later hardened by FIX-030's `IntegrityError → 409`). Frontend `/auth/register` 4-step wizard + i18n + Vitest 5 cases were already shipped 57.23. This entry (and the 57.85/57.86/57.87 carryover echoes of it) was never flipped at the time.
 
-### 24. AD-Auth-Invite-Backend-IAM-Block-B-Phase58
-`GET /api/v1/invites/:token` (metadata) + `POST /api/v1/invites/:token/accept`. Currently 501 stubs; frontend falls back to fixture metadata silently for GET, surfaces explicit error for POST. Frontend `/auth/invite/:token` shipped + Vitest 4 cases. Phase 58+ IAM Block B scope.
+### 24. ✅ CLOSED — AD-Auth-Invite-Backend-IAM-Block-B (shipped Sprint 57.85)
+~~`GET /api/v1/invites/:token` (metadata) + `POST /api/v1/invites/:token/accept`. Currently 501 stubs.~~ **Stale-open corrected 2026-07-22** (grep audit): `backend/src/api/v1/invites.py` (header `Scope: Sprint 57.85 / US-1 + US-2 + US-3`, admin create + guest view/accept; `accept_invite` at :189) is REAL. Frontend `/auth/invite/:token` + Vitest 4 cases shipped 57.23. **Still genuinely open** (separate ADs, NOT this one): invite **email delivery** (no email adapter exists — create returns the raw token in-response) + the admin invites-list / resend UI.
 
-### 25. AD-Auth-MFA-Backend-IAM-Block-C-Phase58
-`POST /api/v1/mfa/verify` + TOTP secret enrollment + WebAuthn credential registration backend. Currently 501 stub. Frontend `/auth/mfa` Roll-own UI shipped (TOTP 6-digit grid + WebAuthn conic ring + Simulate button) + Vitest 7 cases. Phase 58+ IAM Block C scope.
+### 25. ✅ CLOSED — AD-Auth-MFA-Backend-IAM-Block-C (shipped Sprint 57.112)
+~~`POST /api/v1/mfa/verify` + TOTP secret enrollment + WebAuthn credential registration backend. Currently 501 stub.~~ **Stale-open corrected 2026-07-22** (grep audit): `backend/src/api/v1/mfa.py` (header `Scope: Sprint 57.112 / US-2` — enroll / confirm / verify; `verify` at :155) is REAL, with the `v2_mfa_challenge` short-lived JWT cookie swapped for the real session on a valid TOTP (`auth.py:117-122`, `issue_session()` shared). Frontend `/auth/mfa` + Vitest 7 cases shipped 57.23. **Still genuinely open** (narrower than this AD's original scope): **WebAuthn** credential registration (TOTP only today) → tracked by #26 recovery + the misc IAM rows.
 
 ### 26. AD-Auth-MFA-Recovery-Page-Phase58
 `/auth/mfa/recovery` page wire — currently displayed as `<span pointer-events-none>` with tooltip "Recovery flow pending Phase 58+ IAM Block C". Backend recovery-code generation + verification. Phase 58+ IAM Block C scope.
@@ -867,6 +869,7 @@ NEW Sprint 57.28. `check-mockup-fidelity.mjs` grep guard baselines `HEX_OKLCH_BA
 
 ## Modification History
 
+- 2026-07-22: **Stale-open audit** — 4 ADs flipped to CLOSED after grepping `backend/src` (they were shipped weeks earlier but never un-listed): #23 register → 57.87 · #24 invite → 57.85 · #25 MFA → 57.112 (WebAuthn still genuinely open) · `AD-Subagent-RealList` → 57.78 (also struck in §6 bundle + the 57.77 block + 5 echoed lines in the 57.85/86/87 carryover blocks). Added a §Open Carryover ADs warning banner (grep before selecting). Also Sprint 57.166 closeout: `AD-Scheduler-Burst-Stats-Aggregate` CLOSED + 3 new Task-range carryovers. Same corrections applied to `5-status/v2-pending-backlog-dashboard-20260714.html`. **Not applied** (dated point-in-time report, left intact): `5-status/v2-reality-audit-...-20260715.md` §7 — its "8 YES" over-counts by these 4.
 - 2026-07-07: REFACTOR-010 tier ① — 103 per-sprint SHIPPED carryover blocks (57.29→57.161) moved **verbatim** to `next-phase-candidates-shipped-archive.md`; replaced by §Shipped Sprints Pointer Index + §Open Carryover ADs; file 445 KB → ~155 KB (−66%). Zero deletion (moved, not deleted; also single-sourced in memory subfiles + retrospectives). Closeout append contract added (§Maintenance Notes) + sprint-workflow.md §Sprint Closeout self-check. See `claudedocs/4-changes/refactoring/REFACTOR-010-*.md`.
 - 2026-05-22: Sprint 57.28 Day 4 closeout — verbatim-CSS foundation switch SHIPPED (22-route sweep 0 catastrophic / 0 structural regression); +2 ADs (#45 `AD-RouteSweep-Object-Mock-Gap` + #46 `AD-Mockup-Fidelity-HexBaseline-Migration`); the Phase-2 per-page re-point epic now runs on a correct verbatim foundation
 - 2026-05-21: Sprint 57.27 Day 3 closeout — `/overview` rebuild SHIPPED (DRIFT verdict PARITY); +2 ADs (#43 `AD-Overview-Backend-Extensions-Phase58` + #44 `AD-CardShell-Title-Crossverify-cost-sla`); RESOLVED #41 (rich-dashboard sub-class DROPPED — 57.27 `/overview` 4th `frontend-mockup-strict-rebuild` data point ratio ≈0.95 in-band; rich-subset 3-pt mean ~1.01 → no split, KEEP single 0.60 baseline)

--- a/claudedocs/5-status/v2-pending-backlog-dashboard-20260714.html
+++ b/claudedocs/5-status/v2-pending-backlog-dashboard-20260714.html
@@ -11,6 +11,16 @@
   Regenerate: 重新從上述來源推導 TRACKS[] 資料陣列。本檔為 Artifact source file
     (發布於 claude.ai/code/artifact)；重新發布同一路徑即更新同一 URL。
   Note: checkbox「已處理」狀態僅存於瀏覽器 localStorage（視覺追蹤，不寫回 repo）。
+
+  Modification History (newest-first):
+    - 2026-07-22: Sprint 57.166 closeout + grep 稽核 — (a) Task range `AD-Scheduler-Burst-Stats-Aggregate`
+      → done (57.166); +3 新 carryover（CacheRate / AwaitingApproval-TurnCount / DriveThrough-Lever-Plan-At-Day0）;
+      (b) **4 項 stale-open 更正為 done**（清單失真，非新完成）：#23 register (57.87, api/v1/tenants.py) ·
+      #24 invite (57.85, invites.py:189) · #25 MFA (57.112, mfa.py:155) · AD-Subagent-RealList (57.78,
+      subagents.py:72)。三者原記「現 501 stub」與程式碼不符。**連帶影響**：
+      v2-reality-audit-...-20260715.md §7 的「8 個 YES 真實拉力」含此 4 項 → 實際 YES ≈ 5
+      （knowledge connector 4 + AD-Loop-CancelEvent-Poll）；過度開發指數 78% 為保守下界。
+    - 2026-07-14: Initial creation (105 open AD baseline)
 -->
 <title>V2 Pending Backlog 操作台</title>
 <style>
@@ -329,7 +339,7 @@ const TRACKS = [
   {
     id: "engine", label: "引擎債 7 Range", tag: "Phase 1 · 進行中主線",
     title: "Engine-Debt 7-Range Program（引擎內部債）",
-    desc: "2026-07-06 使用者拍板：先清 7 個引擎內部 range，再做 grounding。已推進 11 個 sprint（57.155–165）。Tool range 已 4/4；Task primitive 近收官；Loop-interrupt 與 Observability 兩個 range 尚未動工。",
+    desc: "2026-07-06 使用者拍板：先清 7 個引擎內部 range，再做 grounding。已推進 12 個 sprint（57.155–166）。Tool range 已 4/4；Task primitive 近收官（57.166 關掉 burst-stats，但同時新增 3 個 carryover）；Loop-interrupt 與 Observability 兩個 range 尚未動工。⚠️ reality-audit 7-15：本線 39 open 中僅 1 個（Loop CancelEvent-Poll）有真實 user-facing 拉力，~87% 是完備性驅動。",
     sections: [
       { name: "① Tool  ✅ 核心 4/4 完成", items: [
         { id:"reflection rare-path verify + weaker-model A/B", d:"③1 + ④；reflection tier-dependent（弱模型 +12.5%）", s:"57.163", st:"done" },
@@ -346,8 +356,11 @@ const TRACKS = [
         { id:"DAG task primitive (depends_on)", d:"Todo.depends_on DAG + ready/blocked", s:"57.156", st:"done" },
         { id:"cross-burst auto-continue scheduler", d:"kickoff；突破 max_turns=8 短命上限（default OFF）", s:"57.157", st:"done" },
         { id:"DAG enforce(soft) + cycle report + Inspector Viz", d:"closes 57.156 的 3 個 DAG carryover", s:"57.162", st:"done" },
+        { id:"cross-burst turn/token aggregate in final loop_end", d:"4 個 accumulator 加總每個 burst → 終端 loop_end + audit 帶全run 總計（billing 刻意維持 per-burst，避免雙扣）", s:"57.166", st:"done" },
         { id:"AD-TaskPrimitive-Saturation-DriveThrough-Phase58", d:"5+ send 飽和 drive-through 測試", r:"Task", p:"Phase 58" },
-        { id:"AD-Scheduler-Burst-Stats-Aggregate-Phase58", d:"loop_end 只反映最後一 burst 的 counter，非跨-burst 總計", r:"Task", p:"Phase 58" },
+        { id:"AD-Scheduler-Burst-CacheRate-Aggregate", d:"cached_input_tokens 可加總、但 cache_hit_rate 是比率需加權重算；兩者仍只反映最後一 burst", r:"Task", p:"Phase 58" },
+        { id:"AD-Scheduler-AwaitingApproval-Burst-Turn-Count", d:"停在 HITL 閘的 burst 回報 total_turns=0 → 總計靜默漏掉該部分 turn；確認是否為預期語意", r:"Task", p:"Phase 58" },
+        { id:"AD-DriveThrough-Determinism-Lever-Plan-At-Day0", d:"驗收需要 RARE runtime 路徑時，Day 0 就在 plan §Risks 寫明 lever + 還原證明（57.166 Day 3 才臨時想 → 燒了 6 legs）", r:"Task", p:"Phase 58" },
         { id:"AD-Scheduler-Burst-Boundary-Wire-Phase58", d:"無 wire event 標記 burst 邊界（FE burst counter 需要）", r:"Task", p:"Phase 58" },
         { id:"AD-Scheduler-PerTenant-Phase58", d:"global env → per-tenant policy（刻意避 AP-6）", r:"Task", p:"Phase 58" },
         { id:"AD-Scheduler-TokenBudget-Continue-Phase58", d:"只有 max_turns 續跑；token_budget 保守停止", r:"Task", p:"Phase 58" },
@@ -433,7 +446,7 @@ const TRACKS = [
   {
     id: "frontend", label: "Frontend / SaaS 2", tag: "獨立線 · 多數 Phase 58+",
     title: "Frontend / SaaS Stage 2（Top Candidates #1–#46）",
-    desc: "Phase 57.19–28 累積的前端 mockup-fidelity + 後端接線 + IAM/SaaS Stage 2 carryover。selection-gated：使用者明確選取才起 sprint。僅 #32 已 shipped、#41 已 drop，其餘 44 項待處理。",
+    desc: "Phase 57.19–28 累積的前端 mockup-fidelity + 後端接線 + IAM/SaaS Stage 2 carryover。selection-gated：使用者明確選取才起 sprint。#32 已 shipped、#41 已 drop；2026-07-22 grep 稽核再更正 #23/#24/#25（register / invite / MFA 後端早已實作，非 501 stub）→ 其餘 41 項待處理。",
     sections: [
       { name: "Chat-v2 Mockup-Fidelity Phase-2 (#1)", items: [
         { id:"#1 AD-ChatV2-Full-Mockup-Fidelity Phase-2", d:"Memory block / HITL 4-action / Composer richness+wire / Inspector Trace·Memory·SubagentTree / SessionList backend / Cat12 SSE trace-id（8 子 AD）", r:"#1", p:"Phase 58" },
@@ -468,9 +481,9 @@ const TRACKS = [
         { id:"#22 SOC 2 + SBOM", d:"SOC 2 合規 + SBOM（~12-15 hr）", r:"#22", p:"Stage 2" },
       ]},
       { name: "Auth 後端 IAM Block B/C (#23–#30)", items: [
-        { id:"#23 AD-Auth-Register-Backend-IAM-Block-B", d:"POST /tenants/register 真實作（現 501 stub）", r:"#23", p:"Phase 58" },
-        { id:"#24 AD-Auth-Invite-Backend-IAM-Block-B", d:"invite metadata + accept（現 501 stub）", r:"#24", p:"Phase 58" },
-        { id:"#25 AD-Auth-MFA-Backend-IAM-Block-C", d:"MFA verify + TOTP + WebAuthn 後端（現 501 stub）", r:"#25", p:"Phase 58" },
+        { id:"#23 AD-Auth-Register-Backend-IAM-Block-B", d:"POST /tenants/register 真實作（2026-07-22 grep 更正：api/v1/tenants.py 已實作，非 501 stub）", s:"57.87", st:"done" },
+        { id:"#24 AD-Auth-Invite-Backend-IAM-Block-B", d:"invite metadata + accept（2026-07-22 grep 更正：api/v1/invites.py:189 accept_invite 已實作）", s:"57.85", st:"done" },
+        { id:"#25 AD-Auth-MFA-Backend-IAM-Block-C", d:"MFA verify + TOTP（2026-07-22 grep 更正：api/v1/mfa.py:155 verify + challenge cookie 已實作；WebAuthn 仍缺 → 見 #26/misc）", s:"57.112", st:"done" },
         { id:"#26 AD-Auth-MFA-Recovery-Page", d:"/auth/mfa/recovery 頁 + recovery-code 後端", r:"#26", p:"Phase 58" },
         { id:"#27 AD-Auth-Callback-Loading-UX", d:"static setTimeout → 真 SSE per-step 事件", r:"#27", p:"Phase 58" },
         { id:"#28 AD-WorkOS-Multi-IdP", d:"SAML / Microsoft / Google SSO via WorkOS", r:"#28", p:"Phase 58" },
@@ -519,7 +532,7 @@ const TRACKS = [
         { id:"Password-strength policy", d:"invite-accept 仍 min_length=1；min-length/複雜度/breach-check", r:"IAM", p:"Phase 58" },
       ]},
       { name: "Subagent / Observability 真資料", items: [
-        { id:"AD-Subagent-RealList-Phase58", d:"THE LAST Area-A item：/subagents 真列表（agent_catalog spec 已存在，需 tenant-facing GET + FE re-mount）", r:"Subagent", p:"Phase 58" },
+        { id:"AD-Subagent-RealList-Phase58", d:"/subagents 真列表（2026-07-22 grep 更正：api/v1/subagents.py:72 router 已 re-point 到 agent_catalog registry；README-integration-gap-abc 亦記為 57.78 CLOSED = Area-A COMPLETE 的最後一項）", s:"57.78", st:"done" },
         { id:"AD-Subagent-Invocations-Persistence-Phase58", d:"per-spawn 執行 timeline（新 ORM + dispatcher persist hook + 讀側投影）", r:"Subagent", p:"Phase 58" },
         { id:"Subagent budget/tools loop enforcement", d:"stored 但未 enforce（57.70 §9）", r:"Subagent", p:"Phase 58" },
       ]},


### PR DESCRIPTION
A grep spot-check of 4 "open" ADs found **all 4 already implemented** in `backend/src`. They stayed on the candidate list because an AD gets echoed into 2-4 places (§Open Carryover ADs + §Top Candidates + the #6 bundle + the dashboard) and only **one** copy is flipped at closeout.

## Corrected — with the file:line that disproves each "still 501 stub" claim

| AD | Actually shipped | Evidence |
|---|---|---|
| #23 register | Sprint **57.87** | `api/v1/tenants.py` (its own header: `Scope: Sprint 57.87 / US-1 + US-3 + US-4`) |
| #24 invite | Sprint **57.85** | `api/v1/invites.py:189 accept_invite` |
| #25 MFA | Sprint **57.112** | `api/v1/mfa.py:155 verify` + the `v2_mfa_challenge` cookie swap |
| `AD-Subagent-RealList` | Sprint **57.78** | `api/v1/subagents.py:72` (STUB → `agent_catalog` re-point); `README-integration-gap-abc.md:41` already recorded it as the item that made **Area-A COMPLETE** |

## Narrower scopes deliberately NOT swept up in the flip

- **WebAuthn** credential registration — MFA ships **TOTP only**
- **invite email delivery** (no email adapter exists; create returns the raw token in-response) + the admin invites-list / resend UI

## Also folded in

Sprint 57.166's closeout, which the dashboard had not yet seen: `AD-Scheduler-Burst-Stats-Aggregate` → done, +3 new Task-range carryovers (`CacheRate` / `AwaitingApproval-TurnCount` / `DriveThrough-Lever-Plan-At-Day0`).

## Open-AD count: 105 → 103

| Track | before | after |
|---|:---:|:---:|
| engine-debt | 39 | **41** (+3 new −1 closed) |
| grounding | 6 | 6 |
| frontend / SaaS 2 | 44 | **41** |
| misc | 16 | **15** |

## Guardrail added

A warning banner at the top of §Open Carryover ADs: **grep the claimed gap in `backend/src` before drafting a plan from any entry** — Day-0 Prong 2 applied to the backlog itself. Four-for-four on a spot-check means this is systemic, not a one-off.

## Knock-on left deliberately unedited

`5-status/v2-reality-audit-engine-vs-grounding-20260715.md` §7's "8 YES real-pull" counts these 4 → the real YES is **≈5** (knowledge-connector 4 + `AD-Loop-CancelEvent-Poll`), and its **78% over-engineering index is a conservative lower bound**. That file is a dated point-in-time report, not a live registry, so the correction is recorded in `next-phase-candidates.md` MHist rather than rewriting the snapshot.

Docs-only; `run_all.py` **12/12** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
